### PR TITLE
sushiswap-agg: stop querying thundercore, the halted chain takes all 40 other chains down with it

### DIFF
--- a/aggregators/sushiswap-agg.ts
+++ b/aggregators/sushiswap-agg.ts
@@ -700,10 +700,12 @@ const adapters = {
   //   fetch,
   //   start: '2024-04-22'
   // },
-  [CHAIN.THUNDERCORE]: {
-    fetch,
-    start: '2024-02-25'
-  },
+  // thundercore halted on 2026-09-01 at block 236120709; the stale-head guard throws on the
+  // block lookup and takes every other chain's record down with it
+  // [CHAIN.THUNDERCORE]: {
+  //   fetch,
+  //   start: '2024-02-25'
+  // },
   [CHAIN.ZETA]: {
     fetch,
     start: '2024-02-25'


### PR DESCRIPTION
`aggregators/sushiswap-agg` has published **nothing since 2026-09-01**, on any of its 40+ chains. It was doing $1.3M–$4.6M a day up to that point.

The cause is one chain. ThunderCore stopped producing blocks on **2026-09-01 06:18:02 UTC** at block **236120709** and has not moved since — every endpoint in the SDK's `providers.json`, plus drpc, returns the identical head, re-read twenty seconds apart and again four days later:

```
mainnet-rpc.thundercore.com    236120709   2026-09-01T06:18:02Z
mainnet-rpc.thundertoken.net   236120709   2026-09-01T06:18:02Z
mainnet-rpc.thundercore.io     236120709   2026-09-01T06:18:02Z
thundercore.drpc.org           236120709   2026-09-01T06:18:02Z
```

The SDK's staleness check throws on the block lookup, `fromBlock` is never set, and `getChainResult` rethrows inside the `Promise.all` in `runAdapter` — so the whole run is rejected and no chain gets a record:

```
$ npx ts-node --transpile-only cli/testAdapter.ts aggregators sushiswap-agg 2026-09-04
error fetching block Error: Last block for thundercore is 5968 minutes behind (2026-09-01 06:18:02).
------ ERROR ------
Error: fromBlock or fromTimestamp is required
```

With the leg commented out the same command completes and returns the day:

```
====== TOTAL DAILY AGGREGATED (sum of slots per chain) ======
ethereum   3.28 M     base      839.55 k    arbitrum  432.09 k
xdai     160.05 k     katana    103.12 k    polygon   100.45 k
...
Aggregate  5.76 M
```

$5.76M for 2026-09-03, a day that currently reports nothing at all.

ThunderCore's own contribution was immaterial before the halt, so nothing real is lost by dropping it — and while the chain is stopped there is nothing to read either. Commented rather than deleted, in the same style as the `SKALE_EUROPA` and `XLAYER` entries just above it, so it is one line to restore if the chain comes back.

`dexs/ttswap` is the other adapter configuring ThunderCore and it also stopped on 2026-09-01, but it is ThunderCore-only — there is no other chain to rescue there, and whether it should be marked dead is a separate call about the protocol rather than about this bug. Filed the chain-level side as #9220; this PR is just the leg that is costing an otherwise healthy 40-chain adapter its data.
