### PR TITLE
synapse: mark the dfk leg dead, the chain stopped producing blocks and it kills every other leg

### DIFF
--- a/fees/synapse/index.ts
+++ b/fees/synapse/index.ts
@@ -29,7 +29,7 @@ const bridgeConfig: Record<string, { bridge: string; start: string; deadFrom?: s
   [CHAIN.KLAYTN]: { bridge: "0xAf41a65F786339e7911F4acDAD6BD49426F2Dc6b", start: "2022-06-18" },
   [CHAIN.ARBITRUM]: { bridge: "0x6F4e8eBa4D337f874Ab57478AcC2Cb5BACdc19c9", start: "2021-09-12" },
   [CHAIN.AVAX]: { bridge: "0xC05e61d0E7a63D27546389B7aD62FdFf5A91aACE", start: "2021-08-25" },
-  [CHAIN.DFK]: { bridge: "0xE05c976d3f045D0E6E7A6f61083d98A15603cF6A", start: "2022-03-25" },
+  [CHAIN.DFK]: { bridge: "0xE05c976d3f045D0E6E7A6f61083d98A15603cF6A", start: "2022-03-25", deadFrom: "2026-08-29" },
   [CHAIN.AURORA]: { bridge: "0xaeD5b25BE1c3163c907a471082640450F928DDFE", start: "2021-12-27" },
   [CHAIN.HARMONY]: { bridge: "0xAf41a65F786339e7911F4acDAD6BD49426F2Dc6b", start: "2021-10-25" },
   //[CHAIN.CANTO]: { bridge: "0xDde5BEC4815E1CeCf336fb973Ca578e8D83606E0", start: "2022-10-05", deadFrom: "2026-08-11" },


### PR DESCRIPTION
`fees/synapse` has published nothing since **2026-08-28**, on any chain. This is the same failure #8979 fixed for Canto in August, on a different leg.

**DFK Chain has not produced a block since 2026-08-29 04:25:39 UTC.** Its head is stuck at 62472734 — the same number on repeated reads, and block 62472735 does not exist:

```
$ subnets.avax.network/defi-kingdoms/dfk-chain/rpc   eth_blockNumber
62472734   ts 2026-08-29T04:25:39Z      (unchanged 28s later)
$ eth_getBlockByNumber(62472735)  ->  null
```

The second RPC in the SDK's `providers.json` for this chain (`avax-dfk.api.pocket.network`) returns 404, so that endpoint is the only one left.

The SDK's staleness check throws on the block lookup, `fromBlock` is never set, and `getChainResult` rethrows inside `runAdapter`'s `Promise.all`, so the whole run is rejected and every chain loses its record:

```
$ npx ts-node --transpile-only cli/testAdapter.ts fees synapse 2026-09-04
error fetching block Error: Last block for dfk is 10452 minutes behind (Sat Aug 29 2026 04:25:39 UTC).
error fetching block dfk Error getting block: dfk 1788479999 Request failed with status code 500
------ ERROR ------
Error: fromBlock or fromTimestamp is required
```

The last day Synapse published is 2026-08-28 — the run that started at 2026-08-29 00:00 UTC, four hours before the chain stopped. Every run since has died on this.

With the leg dated off, the adapter gets past the block lookup and the other seventeen chains run:

```
Skipping moonbeam because the adapter ended at Tue, 11 Aug 2026 00:00:00 GMT
Skipping moonriver because the adapter ended at Tue, 11 Aug 2026 00:00:00 GMT
Skipping dfk because the adapter ended at Sat, 29 Aug 2026 00:00:00 GMT
```

DFK is an Avalanche subnet, so "no new blocks" means no transactions rather than a validator failure — either way there is nothing for a fees adapter to read while it stays that way, and the date is one line to move if the chain wakes up. `deadFrom` rather than deletion, and dated the day of the last block, matching how Moonbeam, Moonriver and Canto are already handled in this file.
