### PR TITLE
lighter spot: add the robinhood deployment, its fees have never been counted

### DIFF
--- a/fees/lighterv2-spot/index.ts
+++ b/fees/lighterv2-spot/index.ts
@@ -4,7 +4,14 @@ import { METRIC } from '../../helpers/metrics'
 import fetchURL from '../../utils/fetchURL'
 import PromisePool from '@supercharge/promise-pool'
 
-const API_BASE = 'https://mainnet.zklighter.elliot.ai/api/v1'
+// Lighter runs the same spot exchange on two deployments and dexs/lighter-spot already
+// reports both; the fees side only ever read the zkLighter one. Robinhood's account-level
+// transfer/withdraw fees are counted by fees/lighter-rh, so only the per-market trading
+// fees are taken here.
+const chainConfig: Record<string, { API: string; start: string; globalFees: boolean }> = {
+  [CHAIN.ZK_LIGHTER]: { API: 'https://mainnet.zklighter.elliot.ai/api/v1', start: '2025-10-22', globalFees: true },
+  [CHAIN.ROBINHOOD]: { API: 'https://api.rh.lighter.xyz/api/v1', start: '2026-06-26', globalFees: false },
+}
 const RATE_LIMIT_PER_MINUTE = 200
 
 interface ExchangeMetricResponse {
@@ -27,9 +34,9 @@ interface OrderBookDetailsResponse {
   spot_order_book_details: OrderBookDetail[]
 }
 
-async function fetchExchangeMetricByMarket(kind: string, symbol: string, startOfDay: number): Promise<number> {
+async function fetchExchangeMetricByMarket(API_BASE: string, kind: string, symbol: string, startOfDay: number): Promise<number> {
   const response: ExchangeMetricResponse = await fetchURL(
-    `${API_BASE}/exchangeMetrics?period=all&kind=${kind}&filter=byMarket&value=${symbol}`
+    `${API_BASE}/exchangeMetrics?period=all&kind=${kind}&filter=byMarket&value=${encodeURIComponent(symbol)}`
   )
   
   if (!response?.metrics || !Array.isArray(response.metrics)) {
@@ -41,7 +48,7 @@ async function fetchExchangeMetricByMarket(kind: string, symbol: string, startOf
   return metric?.data || 0
 }
 
-async function fetchExchangeMetricGlobal(kind: string, startOfDay: number): Promise<number> {
+async function fetchExchangeMetricGlobal(API_BASE: string, kind: string, startOfDay: number): Promise<number> {
   const response: ExchangeMetricResponse = await fetchURL(
     `${API_BASE}/exchangeMetrics?period=all&kind=${kind}`
   )
@@ -55,7 +62,7 @@ async function fetchExchangeMetricGlobal(kind: string, startOfDay: number): Prom
   return metric?.data || 0
 }
 
-async function getActiveSpotMarkets(api: any): Promise<OrderBookDetail[]> {
+async function getActiveSpotMarkets(API_BASE: string, api: any): Promise<OrderBookDetail[]> {
   const response: OrderBookDetailsResponse = await fetchURL(`${API_BASE}/orderBookDetails`)
   
   if (!response?.spot_order_book_details || !Array.isArray(response.spot_order_book_details)) {
@@ -73,8 +80,10 @@ async function getActiveSpotMarkets(api: any): Promise<OrderBookDetail[]> {
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const { API: API_BASE, globalFees } = chainConfig[options.chain]
+
   // Get all active spot markets
-  const markets = await getActiveSpotMarkets(options.api)
+  const markets = await getActiveSpotMarkets(API_BASE, options.api)
   
   // Calculate concurrency based on rate limit
   // 2 fee types per market, 200 requests per minute limit
@@ -90,8 +99,8 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
     .for(markets)
     .process(async (market: OrderBookDetail) => {
       const [makerFee, takerFee] = await Promise.all([
-        fetchExchangeMetricByMarket('maker_fee', market.symbol, options.startOfDay),
-        fetchExchangeMetricByMarket('taker_fee', market.symbol, options.startOfDay),
+        fetchExchangeMetricByMarket(API_BASE, 'maker_fee', market.symbol, options.startOfDay),
+        fetchExchangeMetricByMarket(API_BASE, 'taker_fee', market.symbol, options.startOfDay),
       ])
 
       totalMakerFee += makerFee
@@ -105,11 +114,14 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
       }
     })
 
-  // Fetch global fees once
-  const [totalTransferFee, totalWithdrawFee] = await Promise.all([
-    fetchExchangeMetricGlobal('transfer_fee', options.startOfDay),
-    fetchExchangeMetricGlobal('withdraw_fee', options.startOfDay),
-  ])
+  // Fetch global fees once. They are exchange-wide rather than spot-only, so on Robinhood
+  // they belong to fees/lighter-rh and taking them here as well would double count.
+  const [totalTransferFee, totalWithdrawFee] = globalFees
+    ? await Promise.all([
+      fetchExchangeMetricGlobal(API_BASE, 'transfer_fee', options.startOfDay),
+      fetchExchangeMetricGlobal(API_BASE, 'withdraw_fee', options.startOfDay),
+    ])
+    : [0, 0]
 
   const tradingFees = totalMakerFee + totalTakerFee
 
@@ -142,9 +154,9 @@ const breakdownMethodology = {
 
 const adapter: SimpleAdapter = {
   version: 1,
-  fetch,
-  chains: [CHAIN.ZK_LIGHTER],
-  start: '2025-10-22',
+  adapter: Object.fromEntries(
+    Object.entries(chainConfig).map(([chain, { start }]) => [chain, { fetch, start }])
+  ),
   methodology,
   breakdownMethodology,
 }


### PR DESCRIPTION
`dexs/lighter-spot` reports Lighter's spot exchange on **two** deployments — zkLighter and Robinhood Chain — but `fees/lighterv2-spot` hardcodes the zkLighter host, so the Robinhood side has never contributed a cent of fees.

Robinhood is not a rounding error there. Published spot volume:

| day | zkLighter | Robinhood Chain |
|---|---|---|
| 2026-09-01 | 9,360,072 | 6,464,469 |
| 2026-09-02 | 9,682,857 | 11,444,530 |
| 2026-09-03 | 28,555,474 | 19,546,131 |
| 2026-09-04 | 30,751,200 | 22,157,667 |

$83.5M over the last 45 days, non-zero on 44 of them — about 40% of the protocol's spot volume — against a fees series whose only chain is zkLighter.

The Robinhood host serves the same two endpoints the adapter already uses. `orderBookDetails` returns 27 active spot markets (`AAPL/USDG`, `QQQ/USDG`, `ETH/USDG`, …), and `exchangeMetrics` answers per market:

```
GET api.rh.lighter.xyz/api/v1/exchangeMetrics?period=all&kind=taker_fee&filter=byMarket&value=AAPL%2FUSDG
  2026-09-01  3.74      maker_fee  1.05
  2026-09-02  7.38      maker_fee  2.11
```

So the change is to give the file the same per-chain shape its volume sibling already has, with the host and start date taken from `dexs/lighter-spot`.

One thing deliberately not carried over: `transfer_fee` and `withdraw_fee` are account-level and exchange-wide rather than spot-only, and on Robinhood `fees/lighter-rh` already books them (its own comment says the unfiltered value is the perp+spot total). Taking them here as well would double count, so on Robinhood only the per-market maker and taker fees are read.

Verified locally for 2026-09-03:

```
chain     | Daily fees | Daily revenue | Daily protocol revenue
zklighter | 6.31 k     | 6.31 k        | 6.31 k
robinhood | 1.99 k     | 1.99 k        | 1.99 k
Aggregate | 8.30 k     | 8.30 k        | 8.30 k
```

zkLighter's 6,310 is exactly what the protocol published for that day, so the existing chain is untouched — the whole difference is the leg that was missing. The market symbols now go through `encodeURIComponent` because the Robinhood ones contain a slash; zkLighter's `ETH/USDC` returns the same `code: 200` series encoded or not.
