### PR TITLE
dodo fees: add base, avalanche and optimism, the volume adapter has always read them

### DIFF
--- a/fees/dodo-fees.ts
+++ b/fees/dodo-fees.ts
@@ -102,6 +102,11 @@ const adapter: Adapter = {
     [CHAIN.ARBITRUM]: { fetch },
     [CHAIN.AURORA]: { fetch },
     [CHAIN.BOBA]: { fetch },
+    // the volume adapter reads these three from the same api and they have traded every week;
+    // the fee query answers for them under the same chain key
+    [CHAIN.BASE]: { fetch },
+    [CHAIN.AVAX]: { fetch },
+    [CHAIN.OPTIMISM]: { fetch },
   },
   runAtCurrTime: true,
   methodology,


### PR DESCRIPTION
`dexs/dodo` reads nine chains from DODO's dashboard API; `fees/dodo-fees` reads six of them, and the three it leaves out have been trading the whole time.

Volume DefiLlama already publishes for DODO over the last 45 days:

| chain | volume 45d | in the fees adapter? |
|---|---|---|
| Polygon | 142,726,129 | yes |
| Ethereum | 99,721,828 | yes |
| Arbitrum | 23,955,435 | yes |
| **Avalanche** | **10,745,442** | **no** |
| BSC | 5,825,364 | yes |
| **Base** | **4,044,269** | **no** |
| **OP Mainnet** | **210,651** | **no** |
| Scroll / Linea | 0 | no |

The fee side needs nothing new to reach them — `fetch` already passes `options.chain` straight through as the `chain` filter, and the same query answers for all three under DefiLlama's own chain keys:

```
POST gateway.dodoex.io/graphql?opname=FetchDashboardPairs   order_by: fee, limit 10, tvl > 1000
ethereum   pages=3461   fee24h  912.72
base       pages= 530   fee24h   71.54
avax       pages= 202   fee24h   82.31
optimism   pages=  85   fee24h    1.99
```

Local run, before and after:

```
chain     | Daily fees            chain     | Daily fees
ethereum  | 913.00                ethereum  | 913.00
bsc       | 3.08 k                bsc       | 3.08 k
polygon   | 90.00                 polygon   | 90.00
arbitrum  | 6.10                  arbitrum  | 6.10
aurora    | 0.16                  aurora    | 0.16
boba      | 0.00                  boba      | 0.00
                                  base      | 72.00
                                  avax      | 82.00
                                  optimism  | 1.99
Aggregate | 4.09 k                Aggregate | 4.24 k
```

Every existing chain is unchanged; the whole difference is the three legs that were never asked for. About +3.8% on the day, and Avalanche alone is more than Polygon's leg.

Scroll and Linea are deliberately left out: the API answers for them too, but at \$0.30 and \$0.02 a day against zero published volume, so there is nothing there to add. Aurora and Boba stay as they are — they are not in the volume adapter, but they are already in this one and removing them is a separate question from filling the gap.
