### PR TITLE
palmswap, optionblitz: mark dead, both subgraphs are gone from the network and both protocols are empty

### DIFF
--- a/dexs/palmswap/index.ts
+++ b/dexs/palmswap/index.ts
@@ -77,6 +77,9 @@ const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.BSC],
   start: '2023-07-19',
+  // the only subgraph this reads is gone from the network, palmswap.org publishes no address,
+  // and tvl has been zero since 2024-10-01
+  deadFrom: '2024-10-02',
 };
 
 export default adapter;

--- a/options/optionBlitz/index.ts
+++ b/options/optionBlitz/index.ts
@@ -45,6 +45,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResult> => {
 };
 
 const adapters: SimpleAdapter = {
+  // the only subgraph this reads is gone from the network, optionblitz.co no longer resolves,
+  // and tvl has been zero since 2024-07-11
+  deadFrom: '2026-01-10',
   adapter: {
     [CHAIN.ARBITRUM]: {
       fetch: fetch as any,


### PR DESCRIPTION
Two adapters whose only data source no longer exists, on protocols that hold nothing. Neither produces a number today, so this changes no published value — it stops two daily runs against endpoints that cannot answer.

Both subgraphs are gone from the decentralized network. Same response on two probes forty minutes apart:

```
options/optionBlitz  5m8N5qAkDWTf2hhMFhJJJDsWWF5b9J7bzFbXwPnZHJQQ
dexs/palmswap        DdLtKxzUi6ExMok8dNWh9B2HN5WeTWcQsfSSZMKH1trQ
  -> {"errors":[{"message":"subgraph not found: no allocations"}]}
```

Each file reads exactly one endpoint, so there is no working leg to keep.

The protocols are gone too, not just the feeds:

| | OptionBlitz | Palmswap |
|---|---|---|
| site | `optionblitz.co` **NXDOMAIN** on Cloudflare and Google, apex and www | `palmswap.org` resolves NOERROR with **zero A records** |
| TVL now | $0 | $0 |
| last non-zero TVL | 2024-07-11 ($367) | 2024-10-01 ($33,941) |
| last dimension data | 2026-01-09, and the tail is all zeros | never listed |

`deadFrom` dates are set from what each one last did rather than from today: OptionBlitz kept emitting (zero) points through 2026-01-09, so it is dated the day after; Palmswap has no dimension series at all, so it is dated from its last non-zero TVL.

Both verified to engage rather than silently no-op:

```
🦙 OPTIONBLITZ is dead (deadFrom 2026-01-10); skipping run.
🦙 PALMSWAP is dead (deadFrom 2024-10-02); skipping run.
```

Same shape as #9207, #9208 and #9209. Two other adapters turned up in the same sweep and are deliberately **not** here: `options/opyn`'s subgraph is gone but opyn.co is live, and `fees/avalon_old`'s two subgraphs are gone while Avalon itself is still operating — a live protocol with a dead feed needs its source replaced, not a `deadFrom`.
