### PR TITLE
flamingo: refuse the frozen analytics rollup instead of publishing its zero

### DIFF
--- a/dexs/flamingo-finance/index.ts
+++ b/dexs/flamingo-finance/index.ts
@@ -7,6 +7,14 @@ const fetch = async ({ dateString }: FetchOptions) => {
   const dayData = data.find((day: any) => day.date.slice(0, 10) === dateString)
   if (!dayData) throw new Error(`No data for date ${dateString}`)
 
+  // Since 2026-08-29 the rollup has served a placeholder for every new day: the per-day activity
+  // fields are missing and only the cumulative counters remain, frozen at their 2026-08-28 values.
+  // Its total_order_volume reads "0.0", which is indistinguishable from a quiet day, so refuse the
+  // row instead of storing that zero. A day that genuinely had no swaps still carries
+  // total_transactions, since Neo blocks carry traffic other than Flamingo's.
+  if (dayData.total_data?.total_transactions === undefined)
+    throw new Error(`Flamingo analytics has not written a row for ${dateString} yet`)
+
   return { dailyVolume: dayData.total_data.total_order_volume, dailyFees: dayData.total_data.total_order_fee_usd };
 };
 

--- a/dexs/flamingo-finance/index.ts
+++ b/dexs/flamingo-finance/index.ts
@@ -12,7 +12,9 @@ const fetch = async ({ dateString }: FetchOptions) => {
   // Its total_order_volume reads "0.0", which is indistinguishable from a quiet day, so refuse the
   // row instead of storing that zero. A day that genuinely had no swaps still carries
   // total_transactions, since Neo blocks carry traffic other than Flamingo's.
-  if (dayData.total_data?.total_transactions === undefined)
+  // == null so a written row reporting a real 0 still publishes, while both an absent and an
+  // explicitly null field are refused
+  if (dayData.total_data?.total_transactions == null)
     throw new Error(`Flamingo analytics has not written a row for ${dateString} yet`)
 
   return { dailyVolume: dayData.total_data.total_order_volume, dailyFees: dayData.total_data.total_order_fee_usd };


### PR DESCRIPTION
Flamingo's analytics rollup stopped writing daily rows on **2026-08-29**. It still answers 200 with a 30-day array, but every row since is a placeholder, and the adapter reads `total_order_volume` straight off it — so DefiLlama has published **$0 volume and $0 fees for eight consecutive days** for a protocol that was doing $2k–$430k a day.

The stub is unmistakable once you count the fields. Real days carry 14–28 keys in `total_data`; the new ones carry exactly 11, with every per-day activity field missing and the cumulative counters frozen at their 2026-08-28 values:

```
date         keys  total_order_volume  total_order_fee_usd  total_transactions  total_flocks_minted
2026-09-05    11   0.0                 0.0                  (absent)            12504937917676605
2026-09-03    11   0.0                 0.0                  (absent)            12504937917676605
2026-08-30    11   0.0                 0.0                  (absent)            12504937917676605
2026-08-29    11   0.0                 0.0                  (absent)            12504937917676605
2026-08-28    21   25024.19            37.54                882                 12504937917676605
2026-08-27    25   429922.13           621.10               2063                12504829849858322
2026-08-26    22   12820.83            19.35                1365                12504829849858322
2026-08-22    22   33606.08            51.19                2674                12504519952377555
```

`total_flocks_minted`, `total_flm_burned` and `total_flocks_burned_usd_value` have not moved since 2026-08-28 either, and the sibling `rolling-30-days/pair_data` returns `{"pair_data": {}}` for exactly the same eight dates. So it is the whole rollup that stopped, not Flamingo's volume specifically. The rest of Flamingo's infrastructure is up — `neo-api.b-cdn.net/flamingo/live-data/prices/latest` returns current prices.

Over the 23 real days still in the payload the protocol ran a median of **$9,786** and a mean of **$36,104** a day, so the stored zeros are not a plausible reading of the same series.

### The guard

The obvious counter-argument is that Flamingo might genuinely have gone quiet, and a guard that throws would then error every day forever. That is why the test is not "is the volume zero" but "was this row ever written": a day with no swaps still carries `total_transactions`, because Neo blocks carry traffic that is not Flamingo's, and the payload shows it on all 23 real days (422–2,674) and on none of the eight placeholders. If the rollup resumes and starts writing real zero rows, the adapter publishes zero as normal.

Same remedy as #9222, where `fees/fragment` was refusing a TON day whose table had not been loaded rather than storing it as a zero.

Verified both directions locally:

```
$ npx ts-node --transpile-only cli/testAdapter.ts dexs flamingo-finance 2026-08-29   # a real day
NEO
Daily volume: 25.02 k
Daily fees: 38.00                          <- matches the API's 25024.19 / 37.54

$ npx ts-node --transpile-only cli/testAdapter.ts dexs flamingo-finance 2026-09-04   # a placeholder day
------ ERROR ------
Error: Flamingo analytics has not written a row for 2026-09-03 yet
```
