### PR TITLE
lunarbase: add the fourth base pool, it emits the same swap event and shares the owner

### DIFF
--- a/dexs/lunarbase/index.ts
+++ b/dexs/lunarbase/index.ts
@@ -25,6 +25,11 @@ const POOLS_BY_CHAIN: Record<string, readonly PoolConfig[]> = {
             address: "0x0000eFC4ec03a7c47D3a38A9Be7Ff1d52dD01b99",
             feeModel: "dark_pools_v2",
         },
+        {
+            // USDC/cbBTC, same owner() as the three above
+            address: "0xcb1c06554772bc855d81a6be648cc599710e1b99",
+            feeModel: "dark_pools_v2",
+        },
     ],
     [CHAIN.MONAD]: [
         {


### PR DESCRIPTION
`dexs/lunarbase` lists three Base pools. A fourth one has been emitting the adapter's own `SwapExecuted` event the whole time and is not in the config, so its swaps have never been counted.

Scanning Base chain-wide for the event's topic — `keccak("SwapExecuted(address,bool,uint256,uint256,uint256)")` = `0x1b43ddf90e971181a7faf41549e512675072e84befadbba7873086509dec1fdc`, no address filter — over 24h returns **exactly two** emitters:

```
BASE chain-wide SwapExecuted 24h: logs=2625 chunksOK=5 failed=0
   0x0000efc4ec03a7c47d3a38a9be7ff1d52dd01b99  2427   <- configured
   0xcb1c06554772bc855d81a6be648cc599710e1b99   198   <- not configured
```

It is LunarBase's. All four pools return the **same `owner()`** and the same `BPS()`:

```
pool                                        codeLen  owner                                       X                  Y
0x6ccc8223532fff07f47ef4311beb3647326894ab   20333   0xcD301D52eb89FF130F758006Df77E0A9323502ed  0x0 (ETH)          USDC
0x00003bf45ce34bf1bea78669f9a40ee630e11b99   23963   0xcD301D52eb89FF130F758006Df77E0A9323502ed  0x0 (ETH)          USDC
0x0000efc4ec03a7c47d3a38a9be7ff1d52dd01b99     176   0xcD301D52eb89FF130F758006Df77E0A9323502ed  0x0 (ETH)          USDC
0xcb1c06554772bc855d81a6be648cc599710e1b99     141   0xcD301D52eb89FF130F758006Df77E0A9323502ed  USDC               cbBTC
```

`X()`/`Y()` resolve to USDC and cbBTC, both priced by DefiLlama, so no `tokenXOverride` is needed. Its address also carries the same `…b99` vanity suffix as the two other Base dark pools and both BSC ones.

**It is small, and that is worth saying up front.** 198 of 2,625 swaps by count, but only about 1% by value — the pool trades in dust relative to the ETH/USDC one. Running the Base leg for 2026-09-03 before and after:

```
before   Daily volume: 441.59 k   Daily fees: 127.00
after    Daily volume: 445.79 k   Daily fees: 129.00
```

So +$4.2k of volume and +$2 of fees on the day, against a leg that publishes ~$430k. `dark_pools_v2` is the right fee model — like the other two dark pools it has no readable `treasuryShareBps`, and the whole fee is supply-side, which is what the after-run shows.

There is a second unconfigured pool on Monad, `0xb1c8ead40da9b6afcb6f34b15e10123505c38888`, which also shares that `owner()`. It is deliberately **not** in this PR: Monad emits no `SwapExecuted` at all right now (0 logs over the last 6 hours, 711/711 clean chunks), so adding it would change nothing today. Worth adding whenever that leg wakes up.
