### PR TITLE
tria-card, trust-wallet: drop the repeated fee source, the helper counts each entry separately

### DIFF
--- a/fees/tria-card.ts
+++ b/fees/tria-card.ts
@@ -8,7 +8,6 @@ const FEE_RECIPIENT = '0xea8cd5684f2a44a593975cf42f5a88f27f21c513';
 const SOURCE_ADDRESSES = [
   '0xa66b23D9a8a46C284fa5b3f2E2b59Eb5cc3817F4', //crossmint treasury
   '0x9C8B5b82FD99c6e46c9DA84d9A1bf176AAbdc16D', //daimo pay executor
-  '0x9C8B5b82FD99c6e46c9DA84d9A1bf176AAbdc16D', //daimo pay executor - old
   '0xa7F0804632966D94292fe0deb8F2a93f202e2527', //tria core sale
   '0x123ae52505570Ba1300aA4519722f5963aeDE10e', //tria card booking
 ];

--- a/fees/trust-wallet.ts
+++ b/fees/trust-wallet.ts
@@ -41,7 +41,6 @@ const targets: any = {
   ],
   [CHAIN.BASE]: [
     "0xaD01C20d5886137e056775af56915de824c8fCe5",
-    "0xaD01C20d5886137e056775af56915de824c8fCe5",
     "0x19cd4F3820E7BBed45762a30BFA37dFC6c9C145b"
   ],
   [CHAIN.POLYGON]: [


### PR DESCRIPTION
Two adapters list the same address twice in an array that `addTokensReceived` fans out over, and the helper does not de-duplicate, so a repeated entry has its transfers added to the same balances twice.

**Neither one changes a published number today**, and that is worth saying before anything else — this is a latent-correctness fix, not a recovered-value one. The measurements are below.

### Why a repeat double counts

`helpers/token.ts` fans out both list forms into one shared `balances` and never dedupes:

```ts
// targets  (:169)
await Promise.all(targets.map(target => addTokensReceived({ ...clonedOptions, target })))

// fromAdddesses  (:156)
const clonedOptions = { ...params, balances, skipIndexer: true }
await Promise.all(fromAdddesses.map(fromAddressFilter => addTokensReceived({ ...clonedOptions, fromAddressFilter })))
```

The two cases differ in when they bite. `targets` is only reached after the indexer path fails (`:134`), so `fees/trust-wallet`'s repeat inflates the Base leg on fallback runs. The `fromAdddesses` branch sets `skipIndexer: true` itself, so `fees/tria-card`'s repeat would count on **every** run.

### fees/tria-card

`SOURCE_ADDRESSES` carries `0x9C8B5b82FD99c6e46c9DA84d9A1bf176AAbdc16D` twice, labelled "daimo pay executor" and "daimo pay executor - old" — the same address, so the second line adds nothing but the double count.

It is inert right now because that source has stopped. USDC transfers into the fee recipient `0xea8cd568…` on Optimism over the last 30 days, by source:

```
crossmint treasury   0xa66b23D9…   75 transfers   12,486 USDC
daimo pay executor   0x9C8B5b82…    0 transfers        0 USDC
tria core sale       0xa7F08046…    0 transfers        0 USDC
tria card booking    0x123ae525…    0 transfers        0 USDC
   (145/145 chunks clean)
```

Running the adapter for 2026-09-03 gives `Card Service Fees 1629` before and after, as expected while daimo is quiet. If it resumes, its inflow would be booked twice.

### fees/trust-wallet

`targets[CHAIN.BASE]` lists `0xaD01C20d5886137e056775af56915de824c8fCe5` on two consecutive lines. That collector is live and is the first entry on six of the adapter's seven chains, so on any run that falls back off the indexer the Base leg reports its inflow twice.

### Scope

I swept every adapter under `dexs/ fees/ aggregators/ options/ open-interest/ bridge-aggregators/ aggregator-derivatives/ helpers/ factory/` for an address repeated inside a single array literal, ignoring commented lines. Twelve files match, but the other ten are token lists and whitelists (`fees/stargate.ts`, `fees/futureswap.ts`, `fees/index-coop`, `fees/kerberos/routers.ts`, `helpers/aggregators/bungee.ts`, `helpers/lists.ts`, `dexs/alphix.ts`, …) — none of them calls `addTokensReceived`, `getETHReceived` or `addGasTokensReceived`, so a repeat there is harmless. These two are the only ones that feed a duplicate into the helper.
