### PR TITLE
mynth: mark dead, the novaswap api and app hosts are both de-provisioned

### DIFF
--- a/bridge-aggregators/mynth/index.ts
+++ b/bridge-aggregators/mynth/index.ts
@@ -100,6 +100,9 @@ const adapter: SimpleAdapter = {
   },
   prefetch,
   start: "2025-06-20",
+  // api.novaswap.io serves a *.b-cdn.net certificate now, app.novaswap.io is NXDOMAIN, and the
+  // operator's site no longer mentions the product; last published day was 2026-06-24
+  deadFrom: "2026-06-25",
 };
 
 export default adapter;


### PR DESCRIPTION
`bridge-aggregators/mynth` has thrown on every run since **2026-06-24**, and the product it tracks no longer exists.

Its only source is `api.novaswap.io/liquidity/transfers`. That hostname still resolves, but the CDN pull zone behind it has been de-provisioned, so the TLS handshake fails before any request is made:

```
$ curl -o /dev/null -w '%{http_code}' https://api.novaswap.io/liquidity/transfers?page=1&limit=10
000

$ node -e "require('https').get('https://api.novaswap.io/liquidity/transfers', ...)"
ERR_TLS_CERT_ALTNAME_INVALID  Hostname/IP does not match certificate's altnames:
  Host: api.novaswap.io. is not in the cert's altnames: DNS:*.b-cdn.net, DNS:b-cdn.net
```

The product is gone with it, not just the endpoint:

| host | Cloudflare DoH | Google DoH | HTTP |
|---|---|---|---|
| `app.novaswap.io` | **NXDOMAIN** (3) | **NXDOMAIN** (3) | 000 |
| `novaswap.io` | NOERROR, 2 A | NOERROR, 2 A | 000 |
| `api.novaswap.io` | NOERROR, 2 A | NOERROR, 2 A | 000 |
| `mynth.ai` | NOERROR, 1 A | NOERROR, 1 A | **200** |

The operator's own site is the last row, and it is up — but `mynth.ai` returns zero matches for "novaswap", "bridge", "cross-chain" or "crosschain" anywhere in the page. Mynth has moved on from this product; there is no replacement host to repoint at. There is also no TVL entry for it on DefiLlama.

Published `bridge-aggregators/novaswap-crosschain` ends at 2026-06-24 (73 days ago) after $8,017 that day, having run $8k–$11k a day in its final week. Nothing wrong is being published — the adapter simply errors every run — so this is housekeeping, in the same shape as #9207 / #9208 / #9209.

Dated 2026-06-25, the day after the last value, and verified to engage rather than silently no-op:

```
$ npx ts-node --transpile-only cli/testAdapter.ts bridge-aggregators mynth
🦙 MYNTH is dead (deadFrom 2026-06-25); skipping run.
```
