### PR TITLE
aera v3: the newer fee calculators return a wider struct, so a timestamp is being read as the unit price

### DIFF
--- a/fees/aera-v3.ts
+++ b/fees/aera-v3.ts
@@ -36,7 +36,18 @@ const abis = {
   numeraire: 'function NUMERAIRE() view returns (address)',
   getVaultState:
     'function getVaultState(address vault) external view returns ((bool paused, uint8 maxPriceAge, uint16 minUpdateIntervalMinutes, uint16 maxPriceToleranceRatio, uint16 minPriceToleranceRatio, uint8 maxUpdateDelayDays, uint32 timestamp, uint24 accrualLag, uint128 unitPrice, uint128 highestPrice, uint128 lastTotalSupply))',
+  // The newer fee calculators (the ones whose version() answers "2.0") return an 18-word state
+  // with a different field order: word 8 is a timestamp there and the unit price is word 10.
+  // The 11-field struct above decodes such a return without complaining, which is how a unix
+  // timestamp ends up being used as a price. Only paused and unitPrice are read here, so this
+  // one is decoded positionally, and a calculator is treated as new only when this wider decode
+  // succeeds - the old ones return 15 words and fail it.
+  getVaultStateWide:
+    'function getVaultState(address vault) external view returns (uint256[18] state)',
 };
+
+const UNIT_PRICE_INDEX = 8;
+const WIDE_UNIT_PRICE_INDEX = 10;
 
 const PROTOCOL_FEE_RATIO = 0.2;
 
@@ -97,31 +108,32 @@ const fetch = async (options: FetchOptions) => {
     }),
   ]);
 
-  const [numeraireTokens, vaultStatesStart, vaultStatesEnd] = await Promise.all(
-    [
-      fromApi.multiCall({
-        abi: abis.numeraire,
-        calls: feeCalculators.map((fc) => ({ target: fc })),
-        permitFailure: true,
-      }),
-      fromApi.multiCall({
-        abi: abis.getVaultState,
-        calls: vaults.map((vault, i) => ({
-          target: feeCalculators[i],
-          params: [vault],
-        })),
-        permitFailure: true,
-      }),
-      toApi.multiCall({
-        abi: abis.getVaultState,
-        calls: vaults.map((vault, i) => ({
-          target: feeCalculators[i],
-          params: [vault],
-        })),
-        permitFailure: true,
-      }),
-    ]
-  );
+  const stateCalls = vaults.map((vault, i) => ({
+    target: feeCalculators[i],
+    params: [vault],
+  }));
+
+  const [
+    numeraireTokens,
+    narrowStatesStart,
+    narrowStatesEnd,
+    wideStatesStart,
+    wideStatesEnd,
+  ] = await Promise.all([
+    fromApi.multiCall({
+      abi: abis.numeraire,
+      calls: feeCalculators.map((fc) => ({ target: fc })),
+      permitFailure: true,
+    }),
+    fromApi.multiCall({ abi: abis.getVaultState, calls: stateCalls, permitFailure: true }),
+    toApi.multiCall({ abi: abis.getVaultState, calls: stateCalls, permitFailure: true }),
+    fromApi.multiCall({ abi: abis.getVaultStateWide, calls: stateCalls, permitFailure: true }),
+    toApi.multiCall({ abi: abis.getVaultStateWide, calls: stateCalls, permitFailure: true }),
+  ]);
+
+  const isWide = vaults.map((_, i) => Boolean(wideStatesStart[i]) && Boolean(wideStatesEnd[i]));
+  const vaultStatesStart = vaults.map((_, i) => (isWide[i] ? wideStatesStart[i] : narrowStatesStart[i]));
+  const vaultStatesEnd = vaults.map((_, i) => (isWide[i] ? wideStatesEnd[i] : narrowStatesEnd[i]));
 
   for (let i = 0; i < vaults.length; i++) {
     const totalSupply = totalSupplies[i];
@@ -141,15 +153,16 @@ const fetch = async (options: FetchOptions) => {
     }
 
     // Skip paused vaults — pricing can be frozen or invalid
-    const isPausedStart = vaultStateStart[0];
-    const isPausedEnd = vaultStateEnd[0];
+    const isPausedStart = Boolean(Number(vaultStateStart[0]));
+    const isPausedEnd = Boolean(Number(vaultStateEnd[0]));
 
     if (isPausedStart || isPausedEnd) {
       continue;
     }
 
-    const unitPriceStart = BigInt(vaultStateStart[8]);
-    const unitPriceEnd = BigInt(vaultStateEnd[8]);
+    const priceIndex = isWide[i] ? WIDE_UNIT_PRICE_INDEX : UNIT_PRICE_INDEX;
+    const unitPriceStart = BigInt(vaultStateStart[priceIndex]);
+    const unitPriceEnd = BigInt(vaultStateEnd[priceIndex]);
 
     const unitPriceDelta = unitPriceEnd - unitPriceStart;
 


### PR DESCRIPTION
`fees/aera-v3` reads `getVaultState`'s word 8 as the vault's unit price. On the newer fee calculators that word is a **unix timestamp**, so the adapter treats one day of wall-clock seconds as one day of price appreciation. Ethereum currently reports roughly **90x** the real number.

### The two struct layouts

Aera has nine distinct fee calculators behind the 33 Ethereum vaults. Four of them answer `version()` with `"2.0"` and return **18 words**; the other five have no `version()` and return **15**. The 11-field struct in the file decodes both without error, because every field is a value type and the extra words are simply ignored — which is exactly why this has been silent.

```
calc 0x8F3FfA11… version="(none)"  words=15  [6]=1788618563  [8]=1115394             [9]=1107866
calc 0x811C6f0e… version="(none)"  words=15  [6]=1788617131  [8]=100955928           [9]=100958542
calc 0x183eE5FF… version="2.0"     words=18  [8]=1782339863  [10]=1000000            [12]=1000000
calc 0x7efa2160… version="2.0"     words=18  [8]=1788620519  [10]=1001699            [12]=1002044
calc 0x19C03BdB… version="2.0"     words=18  [8]=1788617171  [10]=1007033897415804618
calc 0x75AdBacE… version="2.0"     words=18  [8]=1784858711  [10]=1000852840334009000
```

Word 8 on the 2.0 calculators is `1.78e9` — a timestamp, not a price. The price is word 10, and that is not a guess: `totalSupply * word[10] / 10**decimals` equals `getVaultValueAtLastUpdate(vault)` **exactly**, on every 2.0 vault with supply:

```
vault 0x874d8e4d…  totalSupply 13033577488667233244866  d=18  valueAtLastUpdate 13055721536
   index whose totalSupply*word/1e18 == valueAtLastUpdate: [10] only        w8=1788620519 w10=1001699
vault 0xfb3d942b…  totalSupply 45232364111884448372028  d=18  valueAtLastUpdate 44882808402
   index: [10] only                                                        w8=1788620195 w10=992272
vault 0x8f2d9852…  totalSupply   115389524581693003619  d=18  valueAtLastUpdate   116820585
   index: [10] and [12] (equal that day)                                   w8=1788620987 w10=1012402
vault 0x694f9d66…  totalSupply     1000000000000000000  d=18  valueAtLastUpdate 1000852840334009
   index: [10] and [12] (equal that day)                                   w8=1784858711 w10=1000852840334009000
```

### What it costs

The daily "yield" for such a vault is `totalSupply x (t_end - t_start) / 10**decimals`, and `t_end - t_start` is 86,400. Ten of the 33 Ethereum vaults sit on 2.0 calculators.

```
$ npx ts-node --transpile-only cli/testAdapter.ts fees aera-v3 2026-09-04 ethereum

upstream            patched
Daily fees        42.16 k        463.00
Daily revenue      8.43 k         93.00
Daily supply side 33.73 k        370.00
```

`api.llama.fi/summary/fees/aera-v3` published **$41,874** on Ethereum for that same day, which matches the upstream run, so this is what is live. The 30-day Ethereum total is $332k, essentially all of it fabricated.

### The change

Ask for the state twice — once with the existing struct, once as a positional `uint256[18]` — and use the wide answer for the calculators that return one. The old calculators return 15 words and fail the wide decode, so the selection is structural rather than a version-string match, which also survives a "2.1". `paused` is word 0 in both layouts.

`ts-check` passes. The Base leg is unchanged in shape but I could not run it locally: its vault factory logs start at block 30.8M and every public Base RPC I have prunes below ~49.5M (`pruned history unavailable: requested 46534202, earliest available 49500000`), so that leg needs a run with the production archive node.

Worth noting separately, because it is the same misreading in another repo: `DefiLlama-Adapters/projects/aera-v3/index.js` computes TVL as `totalSupply * vaultState[8] / 10**decimals` with the same 11-field ABI, so the 2.0 vaults' TVL is derived from a timestamp too. I have not touched that here.
