### PR TITLE
wildcat: use the simple daily rate for interest, not compounded apy/365

### DIFF
--- a/fees/wildcat.ts
+++ b/fees/wildcat.ts
@@ -13,8 +13,8 @@ const fetchFees = async (options: FetchOptions): Promise<FetchResultV2> => {
 
     totalBorrow.forEach((borrow: any) => {
         const _apy = apy.find((item: any) => item.market === borrow.market)
-        const dailyApy = _apy.apy / 100 / 365
-        const fees = Number(borrow.totalBorrow) * dailyApy
+        const dailyRate = (Number(_apy.annualInterestBips) / 10000) / 365
+        const fees = Number(borrow.totalBorrow) * dailyRate
         dailyFees.add(borrow.token, fees)
     })
     const dailyRevenue = dailyFees.clone(0.05)


### PR DESCRIPTION
Fixes #9253. `annualInterestBips` is an APR (Wildcat accrues interest linearly via the market scale factor), so the per-day fee is `debt × APR/365`. The adapter was compounding the APR into an APY and then dividing that by 365, which overstates every day's accrual by `compoundedAPY/APR`, +5% at 10% APR, +30% at 50% (the live kPhoenixUSDC market).

Verified against live on-chain state (44 markets, $171.3M debt, blended 9.5% APR): booked $47,131/day → correct $44,481/day, a +5.96% / ~$967k/year overstatement. The harness baseline before the change is `Daily fees: 49.19k`, matching the booked figure.

The change is one line, swap `compoundedAPY/365` for `(annualInterestBips/10000)/365`; the split (5% revenue / 95% supply-side) is unchanged.
