### PR TITLE
Add GIGA DEX gauges

### DIFF
--- a/dexs/brownfi-v3/index.ts
+++ b/dexs/brownfi-v3/index.ts
@@ -86,10 +86,14 @@ export const getBrownFiV3Fetch = (chainConfig: BrownFiV3ChainConfig) => async (o
     const [token0, token1] = pairObject[pair]
     const feeRate = fee / (1 + fee)
     logs.forEach((log: any) => {
-      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In })
-      addOneToken({ chain, balances: feesRaw, token0, token1, amount0: Number(log.amount0In) * feeRate, amount1: Number(log.amount1In) * feeRate })
-      addOneToken({ chain, balances: revenue, token0, token1, amount0: Number(log.amount0In) * feeRate * protocolFee, amount1: Number(log.amount1In) * feeRate * protocolFee })
-      addOneToken({ chain, balances: supplySideRevenue, token0, token1, amount0: Number(log.amount0In) * feeRate * (1 - protocolFee), amount1: Number(log.amount1In) * feeRate * (1 - protocolFee) })
+      // addOneToken prices a swap through the pair's core asset, so both the input and the
+      // output side have to be offered or swaps whose input is the non-core token are dropped
+      for (const [amount0, amount1] of [[log.amount0In, log.amount1In], [log.amount0Out, log.amount1Out]]) {
+        addOneToken({ chain, balances: dailyVolume, token0, token1, amount0, amount1 })
+        addOneToken({ chain, balances: feesRaw, token0, token1, amount0: Number(amount0) * feeRate, amount1: Number(amount1) * feeRate })
+        addOneToken({ chain, balances: revenue, token0, token1, amount0: Number(amount0) * feeRate * protocolFee, amount1: Number(amount1) * feeRate * protocolFee })
+        addOneToken({ chain, balances: supplySideRevenue, token0, token1, amount0: Number(amount0) * feeRate * (1 - protocolFee), amount1: Number(amount1) * feeRate * (1 - protocolFee) })
+      }
     })
   })
 

--- a/dexs/giga-dex-cl/index.ts
+++ b/dexs/giga-dex-cl/index.ts
@@ -1,0 +1,28 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { breakdownMethodology, buildResult, clFetch } from "../giga-dex";
+
+// GIGA DEX CL: PancakeSwap-v3 style concentrated liquidity pools on Robinhood Chain,
+// on-chain logic and fee model shared with dexs/giga-dex
+const fetch = async (options: FetchOptions) => buildResult(options, [await clFetch(options)]);
+
+const methodology = {
+  Fees: "Swap fees paid by traders on GIGA DEX CL pools, per the pool's fee tier.",
+  UserFees: "Traders pay the full swap fee on every trade.",
+  Revenue: "Share of swap fees collected by the GIGA fee center for veGIGA stakers, read per pool from slot0.feeProtocol: 100% on gauged pools (pools receiving GIGA emissions), 3% on non-gauged pools.",
+  HoldersRevenue: "Share of swap fees distributed to veGIGA stakers (all of the protocol's share).",
+  ProtocolRevenue: "The protocol treasury keeps no direct share of swap fees, it earns as a veGIGA staker.",
+  SupplySideRevenue: "Share of swap fees kept by liquidity providers: 0% on gauged pools (LPs there earn GIGA emissions instead), 97% on non-gauged pools.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: '2026-07-15',
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/dexs/giga-dex/index.ts
+++ b/dexs/giga-dex/index.ts
@@ -1,15 +1,47 @@
-import { Balances } from "@defillama/sdk";
+import { Balances, cache } from "@defillama/sdk";
+import { ethers } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
-import { getUniV2LogAdapter } from "../../helpers/uniswap";
+import { addOneToken } from "../../helpers/prices";
+import { filterPools } from "../../helpers/uniswap";
 import { getBrownFiV3Fetch } from "../brownfi-v3";
 
-// GIGA DEX Classic (uniswap-v2 style) factory on Robinhood Chain, first pair created 2026-07-15
+// GIGA DEX on Robinhood Chain, contracts: https://docs.gigadex.fi/security/contracts
+//
+// Three pool systems, tracked as two listings that share this module:
+//  - giga-dex: Classic (solidly-style stable + volatile pairs, first pair created 2026-07-15)
+//    and BrownFi (oracle-based AMM pairs deployed as a GIGA white-label, first pair created 2026-07-29)
+//  - giga-dex-cl: CL (PancakeSwap-v3 style concentrated liquidity pools, first pool created 2026-07-15),
+//    see dexs/giga-dex-cl
+//
+// Every pool's protocol share of swap fees is set per pool on-chain and collected by the
+// GIGA fee center (0x35A31D2De2673a021534C0395e06C09154657024), which distributes it to
+// veGIGA stakers:
+//  - gauged pools (pools receiving GIGA emissions, listed on the Classic / CL MasterChefs)
+//    are set to 100%, LPs there are paid in GIGA emissions instead of swap fees
+//  - non-gauged pools send 3% to veGIGA stakers and keep 97% for the LPs (freshly created
+//    pools sit at the factory default, 20% Classic / 10% CL, until the controller sets them)
+// The share is read per pool on-chain so both states are counted as they are. The protocol
+// treasury keeps no direct share, it earns as a veGIGA staker, so the whole protocol share
+// is reported as HoldersRevenue.
+
 // https://robinhoodchain.blockscout.com/address/0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916
 const CLASSIC_FACTORY = "0x6Fdf38f92eAd1adFc04B73aaa947ab254f6c0916";
+// ClassicFactory.FEE_DENOM, shared by pair.fee() and pair.protocolFee()
+const CLASSIC_FEE_DENOM = 1e6;
+const classicSwapEvent = 'event Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)';
 
-// BrownFi oracle-based AMM factory deployed for GIGA DEX, first pair created 2026-07-29
+// https://robinhoodchain.blockscout.com/address/0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B
+const CL_FACTORY = "0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B";
+const clPoolCreatedEvent = 'event PoolCreated(address indexed token0, address indexed token1, uint24 indexed fee, int24 tickSpacing, address pool)';
+// pancake-v3 fork: pools emit Swap with protocolFeesToken0/1, the default uniswap-v3 Swap event matches no logs
+const clSwapEvent = 'event Swap(address indexed sender, address indexed recipient, int256 amount0, int256 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint128 protocolFeesToken0, uint128 protocolFeesToken1)';
+// pancake-v3 slot0: feeProtocol is a uint32, token0 share in the low 16 bits, token1 share in the high 16 bits
+const clSlot0Abi = 'function slot0() view returns (uint160 sqrtPriceX96, int24 tick, uint16 observationIndex, uint16 observationCardinality, uint16 observationCardinalityNext, uint32 feeProtocol, bool unlocked)';
+// CLPool.PROTOCOL_FEE_DENOMINATOR
+const CL_PROTOCOL_FEE_DENOM = 1e4;
+
 // https://robinhoodchain.blockscout.com/address/0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA
 const BROWNFI_FACTORY = "0x831880Bd3b331249DF63bacC6e21495e5e8f1eAA";
 // factory.pairConfig(), holds the per-pair fee and feeSplit
@@ -18,23 +50,136 @@ const BROWNFI_PAIR_CONFIG = "0xD3F729D909a7E84669A35c3F25b37b4AC3487784";
 const BROWNFI_START = '2026-07-29';
 const BROWNFI_START_TIMESTAMP = 1785283200; // 2026-07-29T00:00:00Z
 
-// Classic pairs charge a flat 0.3% swap fee (UniswapV2Pair fork, hardcoded in the pair contract),
-// of which the protocol treasury keeps 20% via feeTo, same values the giga-dex factory entry used
-const CLASSIC_FEES = 0.003;
-const REVENUE_RATIO = 0.2;
+// labels kept identical to the ones the uniswap helpers emit
+export const LABELS = {
+  TradingFees: 'Trading fees',
+  ProtocolFees: 'Protocol fees',
+  LPFees: 'LP fees',
+  TokenholderFees: 'Tokenholder fees',
+};
 
-// GIGA DEX Classic (uniswap-v2 style) pools
-const classicFetch = getUniV2LogAdapter({
-  factory: CLASSIC_FACTORY,
-  fees: CLASSIC_FEES,
-  stableFees: CLASSIC_FEES,
-  userFeesRatio: 1,
-  revenueRatio: REVENUE_RATIO,
-  protocolRevenueRatio: REVENUE_RATIO,
-});
+export type PoolSystemResult = {
+  dailyVolume: Balances,
+  dailyFees: Balances,
+  dailyHoldersRevenue: Balances,
+  dailySupplySideRevenue: Balances,
+};
 
-// BrownFi oracle-based AMM pools deployed for GIGA DEX,
-// fee and protocol share (feeSplit) are read on-chain per pair
+// Classic pairs charge a per-pair swap fee (pair.fee(), 0.3% by default) on the input token.
+// Each pair's protocol share (pair.protocolFee()) is minted as LP tokens to the pair's
+// feeReceiver, the GIGA fee center.
+export const classicFetch = async (options: FetchOptions): Promise<PoolSystemResult> => {
+  const { createBalances, getLogs, chain, api } = options;
+  const cacheKey = `tvl-adapter-cache/cache/uniswap-forks/${CLASSIC_FACTORY.toLowerCase()}-${chain}.json`;
+
+  const { pairs, token0s, token1s } = await cache.readCache(cacheKey, { readFromR2Cache: true });
+  if (!pairs?.length) throw new Error('No pairs found, is there TVL adapter for this already?');
+  const pairObject: Record<string, string[]> = {};
+  pairs.forEach((pair: string, i: number) => {
+    pairObject[pair.toLowerCase()] = [token0s[i], token1s[i]];
+  });
+
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+  const dailyHoldersRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const result = { dailyVolume, dailyFees, dailyHoldersRevenue, dailySupplySideRevenue };
+
+  const filteredPairs = await filterPools({ api, pairs: pairObject, createBalances });
+  const pairIds = Object.keys(filteredPairs);
+  api.log(`giga-dex classic: filtered to ${pairIds.length}/${pairs.length} pairs`);
+  if (!pairIds.length) return result;
+
+  const [swapFees, protocolFees] = await Promise.all([
+    api.multiCall({ abi: 'uint256:fee', calls: pairIds }),
+    api.multiCall({ abi: 'uint256:protocolFee', calls: pairIds }),
+  ]);
+  const allLogs = await getLogs({ targets: pairIds, eventAbi: classicSwapEvent, flatten: false });
+
+  allLogs.forEach((logs: any[], i: number) => {
+    if (!logs.length) return;
+    const pair = pairIds[i];
+    const [token0, token1] = pairObject[pair];
+    const feeRate = Number(swapFees[i]) / CLASSIC_FEE_DENOM;
+    const veGigaShare = Number(protocolFees[i]) / CLASSIC_FEE_DENOM;
+
+    logs.forEach((log: any) => {
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0In, amount1: log.amount1In });
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0Out, amount1: log.amount1Out });
+
+      // the fee is charged on the input token, priced through whichever side of the pair is the core asset
+      const feeIn = addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0In) * feeRate, amount1: Number(log.amount1In) * feeRate });
+      const feeOut = addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0Out) * feeRate, amount1: Number(log.amount1Out) * feeRate });
+      for (const { token, amount } of [feeIn, feeOut]) {
+        if (!amount) continue;
+        dailyHoldersRevenue.add(token, amount * veGigaShare);
+        dailySupplySideRevenue.add(token, amount * (1 - veGigaShare));
+      }
+    });
+  });
+
+  return result;
+};
+
+// CL pools charge their fee tier on every swap, the protocol share is stored in each
+// pool's slot0.feeProtocol and collected by the GIGA fee center through collectProtocol.
+export const clFetch = async (options: FetchOptions): Promise<PoolSystemResult> => {
+  const { createBalances, getLogs, chain, api } = options;
+  const cacheKey = `tvl-adapter-cache/cache/logs/${chain}/${CL_FACTORY.toLowerCase()}.json`;
+  const iface = new ethers.Interface([clPoolCreatedEvent]);
+
+  let { logs: poolLogs } = await cache.readCache(cacheKey, { readFromR2Cache: true });
+  if (!poolLogs?.length) throw new Error('No pools found, is there TVL adapter for this already?');
+  // bad rpcs return bad log with undefined format, filter them out
+  poolLogs = poolLogs.map((log: any) => iface.parseLog(log)?.args).filter((log: any) => !!log);
+
+  const pairObject: Record<string, string[]> = {};
+  const feeTiers: Record<string, number> = {};
+  poolLogs.forEach((log: any) => {
+    const pool = log.pool.toLowerCase();
+    pairObject[pool] = [log.token0, log.token1];
+    feeTiers[pool] = Number(log.fee) / 1e6;
+  });
+
+  const dailyVolume = createBalances();
+  const dailyFees = createBalances();
+  const dailyHoldersRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  const result = { dailyVolume, dailyFees, dailyHoldersRevenue, dailySupplySideRevenue };
+
+  const filteredPairs = await filterPools({ api, pairs: pairObject, createBalances });
+  const pools = Object.keys(filteredPairs);
+  api.log(`giga-dex cl: filtered to ${pools.length}/${poolLogs.length} pools`);
+  if (!pools.length) return result;
+
+  const slot0s = await api.multiCall({ abi: clSlot0Abi, calls: pools, permitFailure: true });
+  const allLogs = await getLogs({ targets: pools, eventAbi: clSwapEvent, flatten: false });
+
+  allLogs.forEach((logs: any[], i: number) => {
+    if (!logs.length) return;
+    const pool = pools[i];
+    const [token0, token1] = pairObject[pool];
+    const feeTier = feeTiers[pool];
+    const feeProtocol = Number(slot0s[i]?.feeProtocol ?? 0);
+    const share0 = (feeProtocol % 65536) / CL_PROTOCOL_FEE_DENOM;
+    const share1 = Math.floor(feeProtocol / 65536) / CL_PROTOCOL_FEE_DENOM;
+    // both sides are always set to the same share on GIGA, average them anyway
+    const veGigaShare = (share0 + share1) / 2;
+
+    logs.forEach((log: any) => {
+      addOneToken({ chain, balances: dailyVolume, token0, token1, amount0: log.amount0, amount1: log.amount1 });
+      const { token, amount } = addOneToken({ chain, balances: dailyFees, token0, token1, amount0: Number(log.amount0) * feeTier, amount1: Number(log.amount1) * feeTier });
+      dailyHoldersRevenue.add(token, amount * veGigaShare);
+      dailySupplySideRevenue.add(token, amount * (1 - veGigaShare));
+    });
+  });
+
+  return result;
+};
+
+// BrownFi pairs: fee and protocol share (feeSplit) are read on-chain per pair by the shared
+// BrownFi fetch. The protocol share is minted to the BrownFi factory's feeTo, which is the
+// GIGA fee center as well, so it goes to veGIGA stakers too.
 const brownfiFetch = getBrownFiV3Fetch({
   [CHAIN.ROBINHOOD]: {
     factory: BROWNFI_FACTORY,
@@ -43,56 +188,71 @@ const brownfiFetch = getBrownFiV3Fetch({
   },
 });
 
-// the Classic fetch already emits these labels, BrownFi balances are
-// merged under them too so the breakdown stays unified
-const dimensionLabels: Record<string, string | undefined> = {
-  dailyVolume: undefined,
-  dailyFees: METRIC.SWAP_FEES,
-  dailyUserFees: 'Trading fees',
-  dailyRevenue: 'Protocol fees',
-  dailyProtocolRevenue: 'Protocol fees',
-  dailySupplySideRevenue: 'LP fees',
+// BrownFi pairs only exist from BROWNFI_START, skip them on earlier runs
+export const brownfiFetchFrom = async (options: FetchOptions): Promise<Partial<PoolSystemResult>> => {
+  if (options.startTimestamp < BROWNFI_START_TIMESTAMP) return {};
+  const brownfi: Record<string, any> = await brownfiFetch(options);
+  // BrownFi's "protocol" share (feeSplit) lands in the GIGA fee center like the others
+  return { dailyVolume: brownfi.dailyVolume, dailyFees: brownfi.dailyFees, dailyHoldersRevenue: brownfi.dailyRevenue, dailySupplySideRevenue: brownfi.dailySupplySideRevenue };
+};
+
+// Sum the pool systems of a listing into one set of dimensions
+export const buildResult = (options: FetchOptions, systems: Partial<PoolSystemResult>[]) => {
+  const merge = (label: string | undefined, key: keyof PoolSystemResult) => {
+    const balances: Balances = options.createBalances();
+    for (const system of systems) {
+      const source: any = system[key];
+      if (source && typeof source !== 'number') balances.addBalances(source, label);
+    }
+    return balances;
+  };
+
+  const dailyVolume = merge(undefined, 'dailyVolume');
+  const dailyFees = merge(METRIC.SWAP_FEES, 'dailyFees');
+  const dailyHoldersRevenue = merge(LABELS.TokenholderFees, 'dailyHoldersRevenue');
+  const dailySupplySideRevenue = merge(LABELS.LPFees, 'dailySupplySideRevenue');
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees.clone(1, LABELS.TradingFees),
+    dailyRevenue: dailyHoldersRevenue.clone(1, LABELS.ProtocolFees),
+    dailyHoldersRevenue,
+    dailyProtocolRevenue: 0,
+    dailySupplySideRevenue,
+  };
 };
 
 const fetch = async (options: FetchOptions) => {
-  // Run both pool systems and merge their balances into a single result.
   const classic = await classicFetch(options);
-  // BrownFi pools only exist from BROWNFI_START, skip them on earlier runs
-  const brownfi = options.startTimestamp >= BROWNFI_START_TIMESTAMP ? await brownfiFetch(options) : {} as Record<string, any>;
-
-  const result: Record<string, Balances> = {};
-  for (const [dimension, label] of Object.entries(dimensionLabels)) {
-    const balances = options.createBalances();
-    if (classic[dimension] && typeof classic[dimension] !== 'number') balances.addBalances(classic[dimension]);
-    if (brownfi[dimension] && typeof brownfi[dimension] !== 'number') balances.addBalances(brownfi[dimension], label);
-    result[dimension] = balances;
-  }
-  return result;
+  const brownfi = await brownfiFetchFrom(options);
+  return buildResult(options, [classic, brownfi]);
 };
 
 const methodology = {
-  Fees: "Swap fees paid by traders across GIGA DEX Classic (v2 stable + volatile) and BrownFi oracle-based pools.",
+  Fees: "Swap fees paid by traders across GIGA DEX Classic (stable + volatile) and BrownFi oracle-based pools, per-pair fee rate read on-chain.",
   UserFees: "Traders pay the full swap fee on every trade.",
-  Revenue: "Share of swap fees kept by the GIGA protocol treasury (20% on Classic pools, per-pair feeSplit read on-chain for BrownFi pools).",
-  ProtocolRevenue: "Share of swap fees routed to the GIGA protocol treasury.",
-  SupplySideRevenue: "Share of swap fees paid to liquidity providers.",
+  Revenue: "Share of swap fees collected by the GIGA fee center for veGIGA stakers, read per pair on-chain (pair.protocolFee() on Classic, feeSplit on BrownFi): 100% on gauged pairs (pairs receiving GIGA emissions), 3% on non-gauged Classic pairs.",
+  HoldersRevenue: "Share of swap fees distributed to veGIGA stakers (all of the protocol's share).",
+  ProtocolRevenue: "The protocol treasury keeps no direct share of swap fees, it earns as a veGIGA staker.",
+  SupplySideRevenue: "Share of swap fees kept by liquidity providers: 0% on gauged pairs (LPs there earn GIGA emissions instead), 97% on non-gauged Classic pairs, the non-feeSplit part on BrownFi pairs.",
 };
 
-const breakdownMethodology = {
+export const breakdownMethodology = {
   Fees: {
-    [METRIC.SWAP_FEES]: "Swap fees paid by traders across Classic and BrownFi pools.",
+    [METRIC.SWAP_FEES]: "Swap fees paid by traders.",
   },
   UserFees: {
-    'Trading fees': "Full swap fee paid by traders on every trade.",
+    [LABELS.TradingFees]: "Full swap fee paid by traders on every trade.",
   },
   Revenue: {
-    'Protocol fees': "Share of swap fees kept by the GIGA protocol treasury.",
+    [LABELS.ProtocolFees]: "Per-pool protocol share of swap fees, read on-chain, collected for veGIGA stakers.",
   },
-  ProtocolRevenue: {
-    'Protocol fees': "Share of swap fees kept by the GIGA protocol treasury.",
+  HoldersRevenue: {
+    [LABELS.TokenholderFees]: "Per-pool protocol share of swap fees distributed to veGIGA stakers.",
   },
   SupplySideRevenue: {
-    'LP fees': "Share of swap fees paid to liquidity providers.",
+    [LABELS.LPFees]: "Swap fees kept by liquidity providers (total fees minus the veGIGA share).",
   },
 };
 

--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -418,9 +418,6 @@ const configs: Record<string, Record<string, any>> = {
   'sheriff-v3': { 
     [CHAIN.ROBINHOOD]: { factory: '0x21Fd9aB06cc927E66013e89b045c26b3eDE7bB20', start: "2026-07-06", isAlgebraV3: true, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2 },
   },
-  'giga-dex-cl': {
-    [CHAIN.ROBINHOOD]: { factory: '0xEce6eCd61177336ea6Fb9b17937AC439D85EE20B', start: "2026-07-15", swapEvent: protocolFeesSwapEvent, userFeesRatio: 1, revenueRatio: 0.2, protocolRevenueRatio: 0.2 }
-  },
   "betterswap-v3": {
     [CHAIN.VECHAIN]: { factory: '0xf9f1722f95d036efbd1352d84e3a3755f8027b39', userFeesRatio: 1, revenueRatio: 0, protocolRevenueRatio: 0, start: "2026-07-20", },
   },


### PR DESCRIPTION
GIGA DEX (Robinhood Chain) launched gauges with GIGA emissions, which changed how swap fees are split. Every pool's protocol share is now set per pool on-chain and collected by the GIGA fee center, which distributes it to veGIGA stakers:

gauged pools (listed on the Classic / CL MasterChefs): 100% of swap fees to veGIGA stakers, LPs are paid in GIGA emissions instead
non-gauged pools: 3% to veGIGA stakers, 97% to LPs (freshly created pools sit at the factory default until the controller sets them, so the share is read per pool rather than hardcoded)

The treasury keeps no direct share of swap fees (it earns as a veGIGA staker), so the protocol share is reported as HoldersRevenue, with Revenue = HoldersRevenue and ProtocolRevenue = 0. This replaces the flat 20% treasury / 80% LP split both listings used before.