### PR TITLE
fix(vaulta-rex): revenue and supply side are the same balance, so the pair is 2x fees

### DIFF
--- a/fees/vaulta-rex/index.ts
+++ b/fees/vaulta-rex/index.ts
@@ -11,6 +11,10 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
     const unixTodayInMs = options.startOfDay * 1000;
 
     const { chartSeries } = await httpGet(STATS_URL, { headers: HEADERS });
+    // Outside the endpoint's rolling window a day has no entry, not a zero
+    if (!chartSeries.some((chart: any) => chart.data.some((entry: any) => entry[0] === unixTodayInMs))) {
+        throw new Error(`eosauthority has no ${options.dateString}, serving ${chartSeries[0]?.data?.length ?? 0} days`);
+    }
     chartSeries.forEach((chart: any) => {
         const feeType = chart.name;
         const feeToday = chart.data.find((entry: any) => entry[0] === unixTodayInMs);

--- a/fees/vaulta-rex/index.ts
+++ b/fees/vaulta-rex/index.ts
@@ -21,15 +21,15 @@ async function fetch(options: FetchOptions): Promise<FetchResult> {
 
     return {
         dailyFees,
-        dailyRevenue: dailyFees,
+        dailyRevenue: 0,
         dailySupplySideRevenue: dailyFees,
     }
 }
 
 const methodology = {
     Fees: "Includes income from bidnames,ramfee,cpuloan , netloan and powerup",
-    Revenue: "All the fees are revenue",
-    SupplySideRevenue: "All the fees goes to supplyside"
+    Revenue: "No revenue, every stream is channeled to the REX pool",
+    SupplySideRevenue: "All the fees are channeled to the REX pool, where they accrue to REX lenders"
 };
 
 const breakdownMethodology = {


### PR DESCRIPTION
Two fixes in `fees/vaulta-rex/index.ts`.

First, revenue and supply side are the same object:

```ts
dailyRevenue: dailyFees,
dailySupplySideRevenue: dailyFees,
```

so `revenue + supplySide = 2 x fees`, against `Revenue = Fees - SupplySideRevenue`. The methodology asserts both, "All the fees are revenue" and "All the fees goes to supplyside".

Production says the same. `api.llama.fi/summary/fees/vaulta-rex`: 265 days, all three series totalling $4,884.49, revenue equal to fees on each of the 240 days carrying one, ratio 2.0000.

`eosio.system` channels name bids, the RAM fee, CPU and NET loan fees and PowerUp into `eosio.rex`, raising `total_lendable` for REX lenders. The protocol keeps no percentage, so revenue is 0 and the whole amount is supply side, which is the Lending row of AGENTS.md.

Second, a day outside the endpoint's window read as a day of no fees. eosauthority serves a rolling 31-day chart, and anything older matches no entry in any of the five series, so the adapter returned 0. `start` is `2025-12-13` and there is no `runAtCurrTime`, so a refill would write that over the whole history.

`npm run test fees vaulta-rex`: `2026-09-03` gives 16.00 / 0.00 / 16.00 where master gives 16.00 / 16.00 / 16.00, and `2026-08-06` now errors instead of returning 0. Both `ts-check` projects are clean and `package-lock.json` is untouched.

One thing the diff cannot fix: the branch reproduces the stored figure on 23 of the 30 days the endpoint still serves, and seven from 2026-08-28 are stored low, the worst 2026-08-30 at $0.83 against $143.00. They start the day the browser user-agent went in, and they leave the window as it rolls, so a refill would have to be soon.

Website: https://eosauthority.com/rex/statistics?network=eos · Twitter: https://twitter.com/Vaulta_
