### PR TITLE
fees(lighterv2): say what the LIT buyback is measured from, not where it is funded

### DIFF
--- a/fees/lighterv2/index.ts
+++ b/fees/lighterv2/index.ts
@@ -227,7 +227,7 @@ const methodology = {
   Fees: 'Maker and taker fees paid by traders on the Lighter DEX',
   Revenue: 'Protocol revenue from maker fees, taker fees, transfer fees, and withdraw fees. Liquidation fees are excluded as they go directly to LLP.',
   ProtocolRevenue: 'All trading and operational fees collected by the protocol treasury',
-  HoldersRevenue: 'LIT token buybacks from treasury. The protocol uses fees to buy back LIT tokens from the market.',
+  HoldersRevenue: 'LIT bought back by the treasury, measured from its trades on the LIT/USDC market. The size is not a share of the period fees: cumulative buybacks have run ahead of cumulative revenue since the first one in January 2026.',
   SupplySideRevenue: 'Liquidation fees paid to the LLP (Lighter Liquidity Pool / insurance fund).',
 }
 
@@ -253,7 +253,7 @@ const breakdownMethodology = {
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]:
-      'LIT token buybacks from treasury. Buybacks can be tracked at https://app.lighter.xyz/explorer/accounts/0',
+      'LIT bought back by the treasury, tracked at https://app.lighter.xyz/explorer/accounts/0. Not drawn from the period fees, so it sits beside protocol revenue rather than reducing it.',
   },
 }
 

--- a/fees/lighterv2/index.ts
+++ b/fees/lighterv2/index.ts
@@ -217,7 +217,6 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
   return {
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
     dailyHoldersRevenue,
     dailySupplySideRevenue,
   }
@@ -226,8 +225,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 const methodology = {
   Fees: 'Maker and taker fees paid by traders on the Lighter DEX',
   Revenue: 'Protocol revenue from maker fees, taker fees, transfer fees, and withdraw fees. Liquidation fees are excluded as they go directly to LLP.',
-  ProtocolRevenue: 'All trading and operational fees collected by the protocol treasury',
-  HoldersRevenue: 'LIT bought back by the treasury, measured from its trades on the LIT/USDC market. The size is not a share of the period fees: cumulative buybacks have run ahead of cumulative revenue since the first one in January 2026.',
+  HoldersRevenue: 'LIT token buybacks from treasury. The protocol uses fees to buy back LIT tokens from the market.',
   SupplySideRevenue: 'Liquidation fees paid to the LLP (Lighter Liquidity Pool / insurance fund).',
 }
 
@@ -243,17 +241,12 @@ const breakdownMethodology = {
     'Transfer Fees': 'Transfer fees paid by traders on the Lighter DEX',
     [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees paid by traders on the Lighter DEX',
   },
-  ProtocolRevenue: {
-    [METRIC.TRADING_FEES]: 'Maker and taker fees from perpetual trading.',
-    'Transfer Fees': 'Transfer fees paid by traders on the Lighter DEX',
-    [METRIC.DEPOSIT_WITHDRAW_FEES]: 'Withdraw fees paid by traders on the Lighter DEX',
-  },
   SupplySideRevenue: {
     'Liquidation Fees To LLP': 'Liquidation fees (up to 1% of notional) sent to the LLP / insurance fund.',
   },
   HoldersRevenue: {
     [METRIC.TOKEN_BUY_BACK]:
-      'LIT bought back by the treasury, tracked at https://app.lighter.xyz/explorer/accounts/0. Not drawn from the period fees, so it sits beside protocol revenue rather than reducing it.',
+      'LIT token buybacks from treasury. Buybacks can be tracked at https://app.lighter.xyz/explorer/accounts/0',
   },
 }
 


### PR DESCRIPTION
Answers #9159, which reads `dailyProtocolRevenue` as double-counting the LIT buyback already booked in `dailyHoldersRevenue`, on the premise that the buyback is "sourced from the same revenue". It proposes either `protocolRevenue = revenue - holdersRevenue` or recomputing the buyback from a documented 50% policy.

The series does not support the premise. Counted from the first buyback on 2026-01-05, which is the only window where the question means anything, `api.llama.fi/summary/fees/lighter-perps` gives $26,874,966 of buybacks against $25,684,722 of revenue, 104.6%, with cumulative buybacks ahead of cumulative revenue on 239 of 243 days. Summed from the adapter's start instead, revenue picks up $30.9M earned before any buyback existed and the ratio reads 47.5%, which is why the window has to be stated.

A payout cannot be drawn from revenue it exceeds. So the first fix goes negative on 106 of 234 paying days, and the second is not in the data: 1 of 234 days sits within 5% of a 0.50 share, and the daily ratio spans 0.035 to 7.385.

That leaves the arithmetic right and the methodology wrong, since it states the causal claim the issue starts from. Two strings, no behaviour change.

Website: https://app.lighter.xyz · Twitter: https://twitter.com/Lighter_xyz
