### PR TITLE
[fix] moneyx-pro - stop swallowing a dead subgraph behind a confusing crash

### DIFF
--- a/dexs/moneyx-pro/index.ts
+++ b/dexs/moneyx-pro/index.ts
@@ -27,10 +27,11 @@ const fetch = async (options: FetchOptions) => {
   const dayTimestamp = Math.floor(options.startOfDay / 86400) * 86400;
   const variables = { id: `${dayTimestamp}:daily` };
 
-  const stats = await request(endpoint, statsQuery, variables).catch(() => ({}));
+  const stats = await request(endpoint, statsQuery, variables);
 
-  const volume = stats.volumeStat;
-  const fees = stats.feeStat;
+  // volumeStat/feeStat are genuinely absent (not an error) on a day with no trades at all
+  const volume = stats.volumeStat ?? {};
+  const fees = stats.feeStat ?? {};
 
   const dailyVolume = Object.values(volume).reduce((a: number, b: any) => a + Number(b || 0) / 1e30, 0);
   const dailyFees = Object.values(fees).reduce((a: number, b: any) => a + Number(b || 0) / 1e30, 0);


### PR DESCRIPTION
The moneyx-stats Goldsky subgraph (`project_clhjdosm96z2v49wghcvog65t`) has been deleted:

```
$ curl -s -X POST https://api.goldsky.com/api/public/project_clhjdosm96z2v49wghcvog65t/subgraphs/project_clhjdosm96z2v4/moneyx-stats/gn ...
{"statusCode":404,"message":"Subgraph not found. Have you deleted this subgraph recently? ..."}
```

Every single day's fetch has been failing because of this. The existing `.catch(() => ({}))` was meant to guard against subgraph failures, but it doesn't actually achieve a graceful degrade here - it turns the request rejection into `stats.volumeStat` being `undefined`, and `Object.values(undefined)` throws `TypeError: Cannot convert undefined or null to object`, a generic error with zero diagnostic value. That's why the protocol has shown no `total24h`/recent data: the adapter has been crashing on every run, just with a confusing message instead of a clear one.

## Fix

Remove the swallowing catch so the real `graphql-request` error (which already names the dead subgraph) propagates instead of being replaced by a meaningless one. Guard only the case that's actually benign - a day with literally no trades, where the subgraph legitimately returns no `volumeStat`/`feeStat` entity - with `?? {}` instead of crashing on it.

Verified against the live (broken) subgraph endpoint:
- before: `.catch(() => ({}))` → `Object.values(undefined)` → `TypeError: Cannot convert undefined or null to object`
- after: the real error propagates → `GraphQL Error (Code: 404): {"response":{"statusCode":404,"message":"Subgraph not found. Have you deleted this subgraph recently?..."}}`

No fee/revenue breakdown was added or changed, so no `breakdownMethodology` update is needed here - this is purely an error-handling fix.