### PR TITLE
fix: enable hourly pulls for UniSubgraph adapters

### DIFF
--- a/factory/uniSubgraph.ts
+++ b/factory/uniSubgraph.ts
@@ -421,7 +421,7 @@ for (const [name, config] of Object.entries(configs)) {
 
   const adapter: SimpleAdapter = {
     version: 2,
-    // pullHourly: true,
+    pullHourly: true,
     adapter: chains.reduce((acc, chain) => ({
       ...acc,
       [chain]: {


### PR DESCRIPTION
## Summary

Enable hourly execution for all version 2 adapters generated by the shared UniSubgraph factory.

## Problem

The factory creates version 2 adapters, but its `pullHourly` setting was commented out.

These adapters already calculate metrics using:

- `options.startTimestamp`
- `options.endTimestamp`
- the corresponding start and end blocks
- differences between cumulative subgraph values at those blocks

They therefore support arbitrary hourly ranges and should explicitly enable `pullHourly`, as required for version 2 adapters backed by timestamped subgraph data.

## Data impact

The underlying volume and fee calculations are unchanged.

Daily totals will now be assembled from granular hourly block ranges. Because the adapters calculate differences between cumulative values, the hourly deltas should sum to the same daily result while providing more granular data and reusable hourly results.