### PR TITLE
mark seven adapters dead: depeg, dead hosts, and confirmed shutdowns

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -988,14 +988,22 @@ const validatorConfigs: Record<string, ValidatorConfig> = {
 }
 
 // HIP3 deployer dex configs: protocol name -> { dexId, start, methodology }
-const hip3DexConfigs: Record<string, { dexId: string; start: string; methodologyName: string }> = {
-  "dreamcash-markets": { dexId: "cash", start: "2026-01-20", methodologyName: "Dreamcash" },
+const hip3DexConfigs: Record<string, { dexId: string; start: string; deadFrom?: string; methodologyName: string }> = {
+  // Tether-backed Dreamcash kept its main frontend but retired the CASH
+  // HIP-3 market once USDC became the dominant Hyperliquid quote asset,
+  // making a USDT-quoted deployer market unviable. Last fees 2026-07-02.
+  "dreamcash-markets": { dexId: "cash", start: "2026-01-20", deadFrom: "2026-07-03", methodologyName: "Dreamcash" },
   "entropy": { dexId: "io", start: "2026-08-19", methodologyName: "Entropy" },
-  "felix-perp": { dexId: "flx", start: "2025-11-13", methodologyName: "Felix protocol" },
+  // Felix, the first HIP-3 platform on Hyperliquid, announced its shutdown
+  // on 2026-06-19 with all perp markets liquidated (Felix's CDP/Vaults/USDhl
+  // products are unrelated and still live).
+  "felix-perp": { dexId: "flx", start: "2025-11-13", deadFrom: "2026-06-20", methodologyName: "Felix protocol" },
   "hyena": { dexId: "hyna", start: "2025-12-01", methodologyName: "Based and Ethena teams" },
   // "kinetiq-markets" fees/volume is handled by the standalone dexs/kinetiq-markets.ts (builder code + HIP-3 dex "mkts")
   "tradexyz": { dexId: "xyz", start: "2025-11-01", methodologyName: "Trade.xyz" },
-  "ventuals": { dexId: "vntl", start: "2025-11-13", methodologyName: "Ventuals" },
+  // Ventuals shut down 2026-06-19, halting all HIP-3 markets (incl. its
+  // OPENAI/ANTHROPIC pre-IPO perps) and settling every open position.
+  "ventuals": { dexId: "vntl", start: "2025-11-13", deadFrom: "2026-06-20", methodologyName: "Ventuals" },
   "paragon": { dexId: "para", start: "2026-03-30", methodologyName: "Paragon" },
 };
 
@@ -1035,6 +1043,7 @@ for (const [name, config] of Object.entries(hip3DexConfigs)) {
   dexsProtocols[name] = exportHIP3DeployerAdapter(config.dexId, {
     type: "dexs",
     start: config.start,
+    deadFrom: config.deadFrom,
     methodology: hip3Methodology(config.methodologyName),
   });
 }

--- a/fees/chopcorp/index.ts
+++ b/fees/chopcorp/index.ts
@@ -161,6 +161,9 @@ const adapter: SimpleAdapter = {
     isExpensiveAdapter: true,
     dependencies: [Dependencies.DUNE],
     methodology,
+    // chopcorp.io's Vercel deployment has been torn down (DEPLOYMENT_NOT_FOUND),
+    // TVL is down to $43, and no fees since 2026-05-18.
+    deadFrom: '2026-05-19',
 }
 
 export default adapter

--- a/fees/equilibria.ts
+++ b/fees/equilibria.ts
@@ -47,6 +47,10 @@ const adapter: SimpleAdapter = {
       [METRIC.PROTOCOL_FEES]: "One-third of total reward distributions retained as Equilibria protocol revenue.",
     },
   },
+  // Pendle replaced vePENDLE with sPENDLE (snapshot 2026-01-29), which made
+  // Equilibria's ePENDLE model obsolete; Equilibria proposed a structured
+  // wind-down and RewardAdded events stopped on 2026-03-25.
+  deadFrom: '2026-03-26',
 };
 
 export default adapter;

--- a/fees/macaron-bid.ts
+++ b/fees/macaron-bid.ts
@@ -160,6 +160,10 @@ const adapter: SimpleAdapter = {
    start: '2024-12-09',
    dependencies: [Dependencies.DUNE],
    isExpensiveAdapter: true,
+   // macaron.bid no longer has an A record (nothing hosted, just parked
+   // nameservers), and both mining programs have received no fees since
+   // 2026-02-25.
+   deadFrom: '2026-02-26',
    methodology: {
       Fees: 'Total fees from both Auction-based Mining and Block-based Mining. Auction: Dutch auction mechanism where price doubles after each bid then decreases to 0 over 1 hour. Block: Players deploy SOL to mine blocks and earn tokens.',
       Revenue:

--- a/fees/usdx.ts
+++ b/fees/usdx.ts
@@ -24,7 +24,7 @@ const fetch: FetchV2 = async (option: FetchOptions) => {
 };
 
 const adapter: SimpleAdapter = {
-  fetch, 
+  fetch,
   methodology: info.methodology,
   adapter: {
     [CHAIN.ETHEREUM]: { start: "2024-03-18", },
@@ -33,6 +33,10 @@ const adapter: SimpleAdapter = {
   },
   version: 2,
   pullHourly: true,
+  // The USDX/sUSDX V2 pool was drained in the 2025-11-06 Balancer V2 Vault
+  // exploit, USDX depegged from $1 to under $0.01, and the rewards
+  // distributor has emitted nothing since.
+  deadFrom: '2025-11-08',
 };
 
 export default adapter;

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -622,7 +622,7 @@ export const fetchHIP3DeployerData = async ({
 
 export const exportHIP3DeployerAdapter = (
   dexId: string,
-  props: { type: "dexs" | "oi"; start?: string; methodology?: any },
+  props: { type: "dexs" | "oi"; start?: string; deadFrom?: string; methodology?: any },
 ) => {
   const adapter: SimpleAdapter = {
     version: 1,
@@ -686,6 +686,8 @@ export const exportHIP3DeployerAdapter = (
       }
     }
   };
+
+  if (props.deadFrom) adapter.deadFrom = props.deadFrom;
 
   return adapter;
 };


### PR DESCRIPTION
Batch hygiene pass over a set of long-flatlined adapters, each individually verified dead (not just flatlined) before marking:

- **usdx** (Stables Labs USDX): the USDX/sUSDX V2 pool was drained in the 2025-11-06 Balancer V2 Vault exploit; USDX depegged from $1 to under $0.01 and the rewards distributor has emitted nothing since. `deadFrom: 2025-11-08`.
- **chopcorp**: chopcorp.io's Vercel deployment has been torn down (`DEPLOYMENT_NOT_FOUND`), TVL is down to $43, no fees since 2026-05-18. `deadFrom: 2026-05-19`.
- **macaron-bid** (Macaron.bid): macaron.bid has no A record left (nothing hosted, just parked nameservers), and neither mining program has paid fees since 2026-02-25. `deadFrom: 2026-02-26`.
- **equilibria**: Pendle replaced vePENDLE with sPENDLE (2026-01-29 snapshot), obsoleting Equilibria's ePENDLE model. Equilibria proposed a structured wind-down and on-chain `RewardAdded` events stopped 2026-03-25. `deadFrom: 2026-03-26`.
- **felix-perp** (Hyperliquid HIP-3): Felix announced its perps shutdown on 2026-06-19 with every market liquidated. Felix's CDP/Vaults/USDhl products are separate, still-live adapters and are unaffected. `deadFrom: 2026-06-20`.
- **ventuals** (Hyperliquid HIP-3): shut down 2026-06-19, halting every HIP-3 market (including its OPENAI/ANTHROPIC pre-IPO perps) and settling all open positions. `deadFrom: 2026-06-20`.
- **dreamcash-markets** (Hyperliquid HIP-3 "cash" dex): Tether-backed Dreamcash retired its USDT-quoted CASH market once USDC became the dominant Hyperliquid quote asset; the main Dreamcash frontend (tracked by a separate `dreamcash` adapter) is unaffected. `deadFrom: 2026-07-03`.

`helpers/hyperliquid.ts`'s `exportHIP3DeployerAdapter` didn't support `deadFrom` yet (only the builder-code path did), so this widens its props to accept it, same as `exportBuilderAdapter` already does.

**Not marked dead** - initially flagged as candidates but confirmed still alive on closer inspection, so left untouched:
- `yieldfi` - $11.4M TVL, live site; zero fees look like an adapter bug, not protocol death.
- `avalon-usda` - Avalon Labs still markets USDa prominently, ~$169M TVL; the specific pools this adapter reads are likely stale/deprecated addresses, not a dead protocol.
- `helium-network` - Helium Network is very much alive; the adapter's own code and methodology already document that Nova Labs discontinued this specific on-chain buyback program on 2026-01-02 and deliberately reports 0 after that date without hitting Dune. Not an adapter bug, not a dead protocol.
- `sideshift` - SideShift.ai is a live, established product; the on-chain fee read likely needs a methodology fix, not a `deadFrom`.
- `autopilot` - active docs/socials, no shutdown news found; fees have been zero since 2026-03-26 but that's not enough to call the protocol dead.

## Testing

- `npx tsc --project tsconfig.json --noEmit` - clean, zero errors (repo-wide).
- `npx ts-node --transpile-only cli/testAdapter.ts fees usdx 2025-11-05` and `... fees equilibria 2026-03-20` - both adapters load and execute correctly for dates before `deadFrom` (network errors seen were public RPC rate limits, unrelated to this change).
- Verified `getAdapter('ventuals'|'felix-perp'|'dreamcash-markets').deadFrom` resolves to the expected dates via the factory export, and a sibling like `entropy` correctly has no `deadFrom`.