### PR TITLE
[fix] autopilot - mark dead, veAERO position stopped generating rewards 2026-03-26

### DIFF
--- a/fees/autopilot/index.ts
+++ b/fees/autopilot/index.ts
@@ -77,6 +77,7 @@ const adapter: SimpleAdapter = {
     fetch,
     chains: [CHAIN.BASE],
     start: '2025-07-24',
+    deadFrom: '2026-03-26', // Autopilot shut down (epoch 134, 2026-03-25 was the last epoch served); no FeeCollected/nonzero RewardsSnapshot event since
     methodology,
     breakdownMethodology
 }


### PR DESCRIPTION
## What

`fees/autopilot/index.ts` has reported \$0 fees since 2026-03-26 (`total30d: 0`, `total1y: \$1,681,122`). TVL is down to ~\$64k from a reported \$12M peak.

## Root cause: confirmed shutdown, not an adapter bug

[Autopilot](https://theautopilot.xyz/) (an automated veAERO yield strategy on Base that locks AERO, votes Aerodrome gauges, and auto-compounds rewards) shut down after **epoch 134** - 2026-03-25 was the last epoch it served, with a 30-day window afterward for users to withdraw their veNFT and no further service since.

## On-chain verification

- The rewards distributor (`0xA7c68a960bA0F6726C4b7446004FE64969E2b4d4`, Base) and its swapper contract (`0xc7633b9a8035e13a145f534f0e2e329ff39d8975`) both stopped producing real activity at the **same block**, `43847132` (~2026-03-26):
  - Last `FeeCollected` event on the swapper: block 43847132 (only 2 `FeeCollected` events ever emitted, ever).
  - Last non-zero `RewardsSnapshot`: block 43847132, `reward_amount: 28087236783`, `snapshot_id: 135`.
- Every `RewardsSnapshot` since (checked snapshot_id 136 through the current 158, spanning ~5.5 months) fires with `reward_amount: 0` and an **unchanged** `acc_reward_scaled` (`129650901427613316`) - the veAERO position isn't just quiet, it has stopped accruing Aerodrome rewards entirely.
- `EmergencySnapshot` events start appearing shortly after (from block 44466014 onward), and `Withdraw` volume (1116 events total) is consistent with users exiting their positions after the shutdown announcement.

This lines up exactly with the epoch-134 shutdown date, so the adapter's own output is behaving correctly given the underlying protocol is dead - there's no fee-tracking bug to fix here.

## Dupe-check

No open issue or PR for `autopilot` (searched). Not part of the currently open #9266 batch.