### PR TITLE
fees(saber): the volume file has no date, so every day reads the same 27

### DIFF
--- a/fees/saber/index.ts
+++ b/fees/saber/index.ts
@@ -43,6 +43,9 @@ const adapter: Adapter = {
   chains: [CHAIN.SOLANA],
   start: '2022-03-10',
   runAtCurrTime: true,
+  // volume.json carries no date and one commit, 2025-08-18, so
+  // every day gets it; the series has read 27 since 2025-05-26
+  deadFrom: '2025-05-26',
   methodology: {
     Fees: "Total fees collected from all pools in USD over the last 24 hours, based on the 'feesUsd' field from the volume data.",
     Revenue: "Half of the total fees, representing the portion retained by the protocol.",


### PR DESCRIPTION
`fees/saber` reads one URL and sums `feesUsd` across its pools. Nothing in the request or the payload carries a date, so the day being asked about never enters the calculation:

```ts
const volumeData = await httpGet('https://raw.githubusercontent.com/saberdao/birdeye-data/refs/heads/main/volume.json');
for (const pool of Object.values(volumeData)) dailyFees.addUSDValue(pool.feesUsd);
```

`volume.json` has one commit, 2025-08-18, and each of its 128 pools is an OHLC row with `v`, `fees` and `feesUsd` and no date field. It sums to $27.49 today.

So the published series stopped being a measurement. `api.llama.fi/summary/fees/saber` holds 55 runs of identical daily values across 524 days; the longest is **27 on 468 consecutive days** from 2025-05-26, and the next longest is 2 days. The day before the run begins reads 16, the day before that 139.

`deadFrom: '2025-05-26'` is the day the series froze. The runner then prints `SABER is dead (deadFrom 2025-05-26); skipping run.` where master returns 27.00 fees, 14.00 revenue and 14.00 supply side. `npx tsc` on both projects exits 0 and `package-lock.json` is untouched.

Worth saying plainly: saber is not a dead protocol, only this source is. `dexs/saber/index.ts` reads per-day volume from Allium and is live, and fees could be derived the same way. That needs a per-pool fee rate this file does not carry, so it is a rewrite rather than a patch, and stopping the frozen figure does not stand in its way.

Twitter: https://twitter.com/thesaberdao (DefiLlama's config carries no website for this one)
