### PR TITLE
[add] bulk-trade - volume, open interest, fees and revenue

### DIFF
--- a/dexs/bulk-trade/index.ts
+++ b/dexs/bulk-trade/index.ts
@@ -11,7 +11,6 @@ const MAINNET_VOLUME_START_TIMESTAMP = 1_788_615_060
 interface Market {
   symbol: string
   quoteAsset: string
-  status: string
 }
 
 interface Candle {
@@ -27,10 +26,10 @@ const fetch = async (options: FetchOptions) => {
     throw new Error('BULK exchangeInfo response is invalid')
 
   const symbols = [...new Set(markets
-    .filter((market: Market) => market?.status === 'TRADING' && market?.quoteAsset === 'USD')
+    .filter((market: Market) => market?.quoteAsset === 'USD')
     .map((market: Market) => market.symbol))]
   if (!symbols.length || symbols.some(symbol => typeof symbol !== 'string' || !symbol.length))
-    throw new Error('BULK exchangeInfo response has no valid trading USD markets')
+    throw new Error('BULK exchangeInfo response has no valid USD markets')
 
   const startTime = Math.max(options.startTimestamp, MAINNET_VOLUME_START_TIMESTAMP) * 1000
   const endTime = options.endTimestamp * 1000

--- a/dexs/bulk-trade/index.ts
+++ b/dexs/bulk-trade/index.ts
@@ -1,0 +1,85 @@
+import { PromisePool } from '@supercharge/promise-pool'
+import { FetchOptions, SimpleAdapter } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+import fetchURL from '../../utils/fetchURL'
+
+const API_URL = 'https://mainnet-api1.bulk.trade/api/v1'
+// Public mainnet launch: https://x.com/bulktrade/status/2096229604654551302.
+// Candle range selection starts with the first complete minute at 13:31 UTC.
+const MAINNET_VOLUME_START_TIMESTAMP = 1_788_615_060
+
+interface Market {
+  symbol: string
+  quoteAsset: string
+  status: string
+}
+
+interface Candle {
+  t: number
+  T: number
+  c: number
+  v: number
+}
+
+const fetch = async (options: FetchOptions) => {
+  const markets: unknown = await fetchURL(`${API_URL}/exchangeInfo`)
+  if (!Array.isArray(markets))
+    throw new Error('BULK exchangeInfo response is invalid')
+
+  const symbols = [...new Set(markets
+    .filter((market: Market) => market?.status === 'TRADING' && market?.quoteAsset === 'USD')
+    .map((market: Market) => market.symbol))]
+  if (!symbols.length || symbols.some(symbol => typeof symbol !== 'string' || !symbol.length))
+    throw new Error('BULK exchangeInfo response has no valid trading USD markets')
+
+  const startTime = Math.max(options.startTimestamp, MAINNET_VOLUME_START_TIMESTAMP) * 1000
+  const endTime = options.endTimestamp * 1000
+  const { results, errors } = await PromisePool
+    .withConcurrency(5)
+    .useCorrespondingResults()
+    .for(symbols)
+    .process(async symbol => {
+      const candles: unknown = await fetchURL(
+        `${API_URL}/klines?symbol=${encodeURIComponent(symbol)}&interval=1m&startTime=${startTime}&endTime=${endTime}`,
+      )
+      if (!Array.isArray(candles))
+        throw new Error(`BULK ${symbol} candle response is invalid`)
+
+      let volume = 0
+      let lastOpenTime = startTime - 1
+      for (const candle of candles as Candle[]) {
+        if (!Number.isFinite(candle?.t) || !Number.isFinite(candle?.T)
+          || candle.t < startTime || candle.t >= endTime || candle.T <= candle.t || candle.T > endTime
+          || candle.t <= lastOpenTime || !Number.isFinite(candle.c) || candle.c < 0
+          || !Number.isFinite(candle.v) || candle.v < 0)
+          throw new Error(`BULK ${symbol} candle response is invalid`)
+        volume += candle.c * candle.v
+        lastOpenTime = candle.t
+      }
+      if (!Number.isFinite(volume))
+        throw new Error(`BULK ${symbol} candle volume is invalid`)
+      return volume
+    })
+  if (errors.length)
+    throw errors[0].raw ?? errors[0]
+
+  const dailyVolume = results.reduce((sum, volume) => sum + volume, 0)
+  if (!Number.isFinite(dailyVolume) || dailyVolume < 0)
+    throw new Error('BULK aggregate candle volume is invalid')
+  return { dailyVolume }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  // Twenty markets across 24 hourly slices triggers the public API's HTTP 429 limit; one daily
+  // range keeps the run to one discovery request plus one bounded request per market.
+  pullHourly: false,
+  fetch,
+  chains: [CHAIN.BULK],
+  start: '2026-09-05',
+  methodology: {
+    Volume: 'One-sided perpetual volume for every trading USD market, calculated from BULK mainnet one-minute candles as base volume multiplied by each candle close price.',
+  },
+}
+
+export default adapter

--- a/fees/bulk-trade/index.ts
+++ b/fees/bulk-trade/index.ts
@@ -123,7 +123,7 @@ async function fetch(options: FetchOptions) {
   dailyFees.addUSDValue(metrics.fees, 'Taker Trading Fees')
   dailySupplySideRevenue.addUSDValue(metrics.supplySideRevenue, 'Trading Fees To Makers')
   dailyRevenue.addUSDValue(metrics.revenue, 'Trading Fees After Maker Rebates')
-  return { dailyFees, dailyUserFees: dailyFees, dailySupplySideRevenue, dailyRevenue }
+  return { dailyFees, dailyUserFees: dailyFees, dailySupplySideRevenue, dailyRevenue, dailyProtocolRevenue: dailyRevenue }
 }
 
 const adapter: SimpleAdapter = {
@@ -137,12 +137,14 @@ const adapter: SimpleAdapter = {
     Fees: 'Taker trading fees measured from daily changes in BULK mainnet cumulative fee settlement.',
     SupplySideRevenue: 'Realized trading-fee rebates credited to makers during the sampling window.',
     Revenue: 'Net fee settlement after realized maker rebates during the sampling window.',
+    ProtocolRevenue: 'Net fee settlement allocated to the BULK protocol treasury after realized maker rebates.',
   },
   breakdownMethodology: {
     Fees: { 'Taker Trading Fees': 'Taker trading fees charged during the sampling window.' },
     UserFees: { 'Taker Trading Fees': 'Taker trading fees debited from users during the sampling window.' },
     SupplySideRevenue: { 'Trading Fees To Makers': 'Realized trading-fee rebates credited to makers.' },
     Revenue: { 'Trading Fees After Maker Rebates': 'Net trading-fee settlement after realized maker rebates.' },
+    ProtocolRevenue: { 'Trading Fees After Maker Rebates': 'Net trading-fee settlement allocated to the BULK protocol treasury.' },
   },
 }
 

--- a/fees/bulk-trade/index.ts
+++ b/fees/bulk-trade/index.ts
@@ -135,7 +135,6 @@ const adapter: SimpleAdapter = {
   allowNegativeValue: true, // A carried rebate reserve can make net revenue negative for a sampling window.
   methodology: {
     Fees: 'Taker trading fees measured from daily changes in BULK mainnet cumulative fee settlement.',
-    UserFees: 'Taker trading fees debited from users during the sampling window.',
     SupplySideRevenue: 'Realized trading-fee rebates credited to makers during the sampling window.',
     Revenue: 'Net fee settlement after realized maker rebates during the sampling window.',
   },

--- a/fees/bulk-trade/index.ts
+++ b/fees/bulk-trade/index.ts
@@ -1,0 +1,150 @@
+import { FetchOptions, SimpleAdapter } from '../../adapters/types'
+import { getCache, setCache } from '../../helpers/cache'
+import { CHAIN } from '../../helpers/chains'
+import { httpGet } from '../../utils/fetchURL'
+
+const FEE_STATE_URL = 'https://mainnet-api1.bulk.trade/api/v1/feeState'
+const CACHE_SCHEMA = 1
+const ACCOUNTING_TOLERANCE = 1e-6
+
+type FeeCounters = {
+  slot: number
+  settledFills: number
+  totalMakerFees: number
+  totalTakerFees: number
+  totalProtocolSettlement: number
+}
+
+type FeePolicy = {
+  tiers: { maker_bps: number }[]
+}
+
+type FeeScope = {
+  instrument: string
+  active_policy: FeePolicy | null
+}
+
+type FeeState = FeeCounters & {
+  globalPolicyActive: boolean
+  scopes: FeeScope[]
+}
+
+type FeeCache = {
+  schema: number
+  day: string
+  baseline: FeeCounters
+  latest: FeeCounters
+}
+
+function counters(state: FeeCounters): FeeCounters {
+  return {
+    slot: state.slot,
+    settledFills: state.settledFills,
+    totalMakerFees: state.totalMakerFees,
+    totalTakerFees: state.totalTakerFees,
+    totalProtocolSettlement: state.totalProtocolSettlement,
+  }
+}
+
+function validateCounters(state: FeeCounters) {
+  if (!Number.isSafeInteger(state.slot) || state.slot < 0
+    || !Number.isSafeInteger(state.settledFills) || state.settledFills < 0
+    || !Number.isFinite(state.totalMakerFees) || state.totalMakerFees < 0
+    || !Number.isFinite(state.totalTakerFees) || state.totalTakerFees > 0
+    || !Number.isFinite(state.totalProtocolSettlement))
+    throw new Error('BULK feeState contains invalid counters')
+  if (Math.abs(state.totalMakerFees + state.totalTakerFees + state.totalProtocolSettlement) > ACCOUNTING_TOLERANCE)
+    throw new Error('BULK feeState accounting identity failed')
+}
+
+function validatePolicy(state: FeeState) {
+  if (state.globalPolicyActive !== true || !Array.isArray(state.scopes) || !state.scopes.length)
+    throw new Error('BULK feeState scopes are invalid')
+  const globalPolicy = state.scopes.find(scope => scope?.instrument === 'global')?.active_policy
+  if (!globalPolicy || !Array.isArray(globalPolicy.tiers) || !globalPolicy.tiers.length)
+    throw new Error('BULK feeState global policy is invalid')
+  for (const scope of state.scopes) {
+    if (!scope || typeof scope.instrument !== 'string'
+      || !Object.prototype.hasOwnProperty.call(scope, 'active_policy')
+      || (scope.active_policy !== null && typeof scope.active_policy !== 'object'))
+      throw new Error('BULK feeState scopes are invalid')
+    const policy = scope.active_policy
+    if (policy && (!Array.isArray(policy.tiers) || !policy.tiers.length
+      || policy.tiers.some(tier => typeof tier?.maker_bps !== 'number' || !Number.isFinite(tier.maker_bps) || tier.maker_bps !== 0)))
+      throw new Error('BULK fee adapter requires zero base maker fees')
+  }
+}
+
+function validateProgress(previous: FeeCounters, current: FeeCounters) {
+  if (current.slot < previous.slot || current.settledFills < previous.settledFills
+    || current.totalMakerFees < previous.totalMakerFees
+    || current.totalTakerFees > previous.totalTakerFees)
+    throw new Error('BULK feeState counters regressed')
+}
+
+function deriveFeeWindow(current: FeeState, cached: FeeCache | undefined, day: string) {
+  validateCounters(current)
+  validatePolicy(current)
+  const latest = counters(current)
+  if (!cached)
+    return {
+      metrics: { fees: 0, supplySideRevenue: 0, revenue: 0 },
+      cache: { schema: CACHE_SCHEMA, day, baseline: latest, latest },
+    }
+  if (cached.schema !== CACHE_SCHEMA || typeof cached.day !== 'string' || day < cached.day)
+    throw new Error('BULK fee cache day regressed')
+  validateCounters(cached.baseline)
+  validateCounters(cached.latest)
+  validateProgress(cached.baseline, cached.latest)
+  validateProgress(cached.latest, latest)
+  const baseline = day === cached.day ? cached.baseline : cached.latest
+  const metrics = {
+    fees: -(latest.totalTakerFees - baseline.totalTakerFees),
+    supplySideRevenue: latest.totalMakerFees - baseline.totalMakerFees,
+    revenue: latest.totalProtocolSettlement - baseline.totalProtocolSettlement,
+  }
+  if (Math.abs(metrics.fees - metrics.supplySideRevenue - metrics.revenue) > ACCOUNTING_TOLERANCE)
+    throw new Error('BULK daily fee accounting identity failed')
+  return {
+    metrics,
+    cache: { schema: CACHE_SCHEMA, day, baseline, latest },
+  }
+}
+
+async function fetch(options: FetchOptions) {
+  const state: FeeState = await httpGet(FEE_STATE_URL)
+  const cached = await getCache('bulk-trade', 'fee-state-v1')
+  const { metrics, cache } = deriveFeeWindow(state, Object.keys(cached).length ? cached as FeeCache : undefined, options.dateString)
+  await setCache('bulk-trade', 'fee-state-v1', cache)
+
+  const dailyFees = options.createBalances()
+  const dailySupplySideRevenue = options.createBalances()
+  const dailyRevenue = options.createBalances()
+  dailyFees.addUSDValue(metrics.fees, 'Taker Trading Fees')
+  dailySupplySideRevenue.addUSDValue(metrics.supplySideRevenue, 'Trading Fees To Makers')
+  dailyRevenue.addUSDValue(metrics.revenue, 'Trading Fees After Maker Rebates')
+  return { dailyFees, dailyUserFees: dailyFees, dailySupplySideRevenue, dailyRevenue }
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.BULK],
+  start: '2026-09-05',
+  runAtCurrTime: true,
+  allowNegativeValue: true, // A carried rebate reserve can make net revenue negative for a sampling window.
+  methodology: {
+    Fees: 'Taker trading fees measured from daily changes in BULK mainnet cumulative fee settlement.',
+    UserFees: 'Taker trading fees debited from users during the sampling window.',
+    SupplySideRevenue: 'Realized trading-fee rebates credited to makers during the sampling window.',
+    Revenue: 'Net fee settlement after realized maker rebates during the sampling window.',
+  },
+  breakdownMethodology: {
+    Fees: { 'Taker Trading Fees': 'Taker trading fees charged during the sampling window.' },
+    UserFees: { 'Taker Trading Fees': 'Taker trading fees debited from users during the sampling window.' },
+    SupplySideRevenue: { 'Trading Fees To Makers': 'Realized trading-fee rebates credited to makers.' },
+    Revenue: { 'Trading Fees After Maker Rebates': 'Net trading-fee settlement after realized maker rebates.' },
+  },
+}
+
+export default adapter

--- a/helpers/chains.ts
+++ b/helpers/chains.ts
@@ -17,6 +17,7 @@ export enum CHAIN {
   ASSETCHAIN = "assetchain",
   AVAX = "avax",
   BLAST = "blast",
+  BULK = "bulk",
   BAHAMUT = "ftn",
   BOBA = "boba",
   BOBA_BNB = "boba_bnb",

--- a/open-interest/bulk-trade/index.ts
+++ b/open-interest/bulk-trade/index.ts
@@ -10,11 +10,13 @@ type StatsResponse = {
   openInterest?: { totalUsd?: unknown }
 }
 
-async function fetch(_options: FetchOptions): Promise<FetchResultVolume> {
+async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
   const response: StatsResponse = await httpGet(STATS_URL)
   const timestamp = response.timestamp
   const openInterest = response.openInterest?.totalUsd
-  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || Math.abs(Date.now() - timestamp) > MAX_STATS_AGE_MS)
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)
+    || Math.abs(Date.now() - timestamp) > MAX_STATS_AGE_MS
+    || Math.abs(Date.now() - options.endTimestamp * 1000) > 24 * 60 * 60 * 1000)
     throw new Error('BULK stats response is stale')
   if (typeof openInterest !== 'number' || !Number.isFinite(openInterest) || openInterest < 0)
     throw new Error('BULK stats response has invalid open interest')

--- a/open-interest/bulk-trade/index.ts
+++ b/open-interest/bulk-trade/index.ts
@@ -1,6 +1,6 @@
 import { FetchOptions, FetchResultVolume, SimpleAdapter } from '../../adapters/types'
 import { CHAIN } from '../../helpers/chains'
-import { httpGet } from '../../utils/fetchURL'
+import fetchURL from '../../utils/fetchURL'
 
 const STATS_URL = 'https://mainnet-api1.bulk.trade/api/v1/stats?period=1d'
 const MAX_STATS_AGE_MS = 20 * 60 * 1000
@@ -11,7 +11,7 @@ type StatsResponse = {
 }
 
 async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
-  const response: StatsResponse = await httpGet(STATS_URL)
+  const response: StatsResponse = await fetchURL(STATS_URL)
   const timestamp = response.timestamp
   const openInterest = response.openInterest?.totalUsd
   if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)

--- a/open-interest/bulk-trade/index.ts
+++ b/open-interest/bulk-trade/index.ts
@@ -1,0 +1,42 @@
+import { FetchOptions, FetchResultVolume, SimpleAdapter } from '../../adapters/types'
+import { CHAIN } from '../../helpers/chains'
+import { httpGet } from '../../utils/fetchURL'
+
+const STATS_URL = 'https://mainnet-api1.bulk.trade/api/v1/stats?period=1d'
+const MAX_STATS_AGE_MS = 20 * 60 * 1000
+
+type StatsResponse = {
+  timestamp?: unknown
+  openInterest?: { totalUsd?: unknown }
+}
+
+async function fetch(_options: FetchOptions): Promise<FetchResultVolume> {
+  const response: StatsResponse = await httpGet(STATS_URL)
+  const timestamp = response.timestamp
+  const openInterest = response.openInterest?.totalUsd
+  if (typeof timestamp !== 'number' || !Number.isFinite(timestamp) || Math.abs(Date.now() - timestamp) > MAX_STATS_AGE_MS)
+    throw new Error('BULK stats response is stale')
+  if (typeof openInterest !== 'number' || !Number.isFinite(openInterest) || openInterest < 0)
+    throw new Error('BULK stats response has invalid open interest')
+  if (!Number.isFinite(openInterest * 2))
+    throw new Error('BULK stats response has invalid open interest')
+  return {
+    openInterestAtEnd: openInterest * 2,
+    longOpenInterestAtEnd: openInterest,
+    shortOpenInterestAtEnd: openInterest,
+  }
+}
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.BULK],
+  runAtCurrTime: true,
+  // Open interest is a point-in-time snapshot and must not be summed across hourly runs.
+  pullHourly: false,
+  methodology: {
+    OpenInterest: 'Current gross long-plus-short open interest across all BULK perpetual markets. The BULK API exposes one-sided open interest from positive positions; aggregate longs equal aggregate shorts, so the adapter reports the API value for each side and their sum as gross open interest.',
+  },
+}
+
+export default adapter


### PR DESCRIPTION
Fixes #6306.
Supersedes #6629, which was closed because BULK had not yet launched mainnet.

## Protocol

- Name: Bulk Trade
- Website: https://www.bulk.trade/
- X: https://x.com/bulktrade
- Live app: https://app.bulk.trade/trade/BTC-USD
- Mainnet launch: https://x.com/bulktrade/status/2096229604654551302
- Category: Derivatives
- Network: BULK for execution metrics; Solana remains the custody/TVL chain

## Adapters

- Volume: discovers every `TRADING` USD market, requests the exact UTC window from one-minute `/klines`, and sums one-sided `base volume × candle close` once per matched fill with bounded concurrency of five. `pullHourly` is disabled because 20 markets across 24 hourly slices hit the public API HTTP 429 limit; the daily run uses 21 requests. Start: 2026-09-05, clamped to the first complete minute after launch.
- Open interest: samples current `/stats.openInterest.totalUsd`. BULK exposes one-sided OI, so the adapter reports that value for each side and 2× for gross long-plus-short OI.
- Fees: takes daily deltas of `/feeState` cumulative taker fees, maker rebates, and net protocol settlement using the repository cache. It reports taker fees as fees/user fees, maker rebates as supply-side revenue, and net protocol settlement as both revenue and protocol revenue. The accounting identity is validated. The first scheduler observation seeds the cumulative baseline and emits zero; reporting is prospective from the next persisted run.

API docs: [candles](https://docs.bulk.trade/api-reference/getKlines), [statistics](https://docs.bulk.trade/api-reference/getStats), [fee state](https://docs.bulk.trade/api-reference/getFeeState).

## Validation

- `pnpm test dexs bulk-trade 2026-09-06`
- `pnpm test open-interest bulk-trade`
- `DEBUG_BREAKDOWN_FEES=1 pnpm test fees bulk-trade 2026-09-06`
- `pnpm exec tsc --noEmit --esModuleInterop --resolveJsonModule --skipLibCheck --target es2020 --module commonjs dexs/bulk-trade/index.ts open-interest/bulk-trade/index.ts fees/bulk-trade/index.ts`
- `pnpm run ts-check`
- `pnpm run ts-check-cli`
- `pnpm run build`

Observed live outputs during validation:

- Volume: approximately $8.60M
- Gross OI: approximately $2.27M total, $1.14M per side
- Validation `/feeState` snapshot checked on 2026-09-06: $3,166.47 cumulative taker fees, $651.46 cumulative maker rebates, and $2,515.01 cumulative protocol settlement. Adapter daily outputs are deltas from the cached baseline; the identity balances.