### PR TITLE
[feat] kinetiq-markets - add Markets Mobile builder code

### DIFF
--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -3,27 +3,49 @@ import { CHAIN } from "../helpers/chains";
 import { fetchBuilderCodeRevenue, fetchHIP3DeployerData } from "../helpers/hyperliquid";
 
 const KINETIQ_MARKETS_LEGACY_END_DATE = "2026-06-20";
-const KINETIQ_MARKETS_BUILDER_ADDRESS = '0x42f3226007290b02c5a0b15bccbb1ba6df04f992';
+
+const KINETIQ_MARKETS_BUILDERS = [
+  {
+    // Markets builder.
+    address: '0x42f3226007290b02c5a0b15bccbb1ba6df04f992',
+    start: '2026-01-12',
+  },
+  {
+    // Markets Mobile builder.
+    address: '0x2af94a24e1f744a8e251b4996283ffb4657e915d',
+    start: '2025-12-02',
+  },
+] as const;
 
 const fetch = async (options: FetchOptions) => {
   const deployerId = options.dateString > KINETIQ_MARKETS_LEGACY_END_DATE ? 'mkts' : 'km';
-  const { dailyVolume: builderVolume, dailyFees: builderFees } = await fetchBuilderCodeRevenue({
-    options,
-    builder_address: KINETIQ_MARKETS_BUILDER_ADDRESS,
-  });
 
+  const builderVolume = options.createBalances();
+  const builderFees = options.createBalances();
   const builderHip3OverlapVolume = options.createBalances();
 
-  // No builder activity means the builder/HIP-3 intersection is necessarily zero.
-  if (await builderVolume.getUSDValue()) {
-    const { dailyVolume: builderHip3Volume } = await fetchBuilderCodeRevenue({
+  for (const builder of KINETIQ_MARKETS_BUILDERS) {
+    if (options.dateString < builder.start) continue;
+
+    const { dailyVolume: builderDailyVolume, dailyFees: builderDailyFees } = await fetchBuilderCodeRevenue({
       options,
-      builder_address: KINETIQ_MARKETS_BUILDER_ADDRESS,
-      market: 'hip3',
-      hip3DeployerId: deployerId,
+      builder_address: builder.address,
     });
 
-    builderHip3OverlapVolume.add(builderHip3Volume);
+    builderVolume.add(builderDailyVolume);
+    builderFees.add(builderDailyFees);
+
+    // No builder activity means the builder/HIP-3 intersection is necessarily zero.
+    if (await builderDailyVolume.getUSDValue()) {
+      const { dailyVolume: builderHip3Volume } = await fetchBuilderCodeRevenue({
+        options,
+        builder_address: builder.address,
+        market: 'hip3',
+        hip3DeployerId: deployerId,
+      });
+
+      builderHip3OverlapVolume.add(builderHip3Volume);
+    }
   }
 
   const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees, dailyDeployerFee: hip3DeployerFee } = await fetchHIP3DeployerData({
@@ -63,11 +85,11 @@ const fetch = async (options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   fetch,
   chains: [CHAIN.HYPERLIQUID],
-  start: '2025-12-16',
+  start: '2025-12-02',
   doublecounted: true,
   methodology: {
-    Volume: "Unique trading volume routed through Kinetiq Markets' builder code or executed on Kinetiq's HIP-3 markets. Builder-routed trades on Kinetiq's own HIP-3 markets are counted once.",
-    Fees: "Trading fees paid by users on Hyperliquid via Kinetiq's builder code and its HIP-3 markets.",
+    Volume: "Unique trading volume routed through Kinetiq Markets' builder codes or executed on Kinetiq's HIP-3 markets. Builder-routed trades on Kinetiq's own HIP-3 markets are counted once.",
+    Fees: "Trading fees paid by users on Hyperliquid via Kinetiq's builder codes and its HIP-3 markets.",
     Revenue: "Builder-code fees (retained by Kinetiq) plus Kinetiq's deployer-fee cut of its HIP-3 market fees.",
     ProtocolRevenue: "Same as Revenue — retained by Kinetiq.",
     SupplySideRevenue: "The remainder of HIP-3 market fees, paid through to Hyperliquid.",


### PR DESCRIPTION
## Summary

Add the Markets Mobile builder address to the Kinetiq Markets adapter.

This reuses the HIP-3 dedupe added in #9064 so trades routed through either Markets builder are not counted twice when they execute on Kinetiq's own `km` / `mkts` markets.

## Changes

- Add Markets Mobile builder `0x2af94a24e1f744a8e251b4996283ffb4657e915d`.
- Aggregate volume and fees from both Markets builder addresses.
- Apply the existing `km` / `mkts` overlap deduction to each builder.
- Only query each builder from its first verified activity date:
  - Markets Mobile: `2025-12-02`
  - Existing Markets builder: `2026-01-12`
- Move the adapter start to `2025-12-02`.
- Update the methodology wording to refer to multiple builder codes.

## Start dates

I checked Hyperliquid's public daily `builder_fills` archives for both addresses.

### Markets Mobile

    2025-12-01: no archive
    2025-12-02: 11 fills, $212.60 volume, $0.212591 builder fees

### Existing Markets builder

    2026-01-11: no archive
    2026-01-12: 2,391 fills, $1,956,276.95 volume, $684.695746 builder fees

On January 12, `$1,955,451.11` of the existing builder's volume was on `km:US500`, so that volume must be removed from the builder contribution and counted through the HIP-3 dataset only once.

## Validation

- `git diff --check`
- `pnpm run ts-check`
- `pnpm run ts-check-cli`

I could not run the complete adapter locally because `LLAMA_HL_INDEXER` is not available in my local environment.

## Scope

Only `dexs/kinetiq-markets.ts` is changed.
