### PR TITLE
fix(hylo-lst): take the epoch fee out of supply side revenue

### DIFF
--- a/fees/hylo-lst.ts
+++ b/fees/hylo-lst.ts
@@ -27,17 +27,24 @@ const fetch = async (options: FetchOptions) => {
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  results.forEach((row: any) => {
-    if (row.metric_type === 'dailyFees') {
-      dailyFees.addCGToken("solana", row.amount || 0, METRIC.STAKING_REWARDS);
-      // Staking rewards accrue to the LST stakers (the supply side).
-      dailySupplySideRevenue.addCGToken("solana", row.amount || 0, STAKING_REWARDS_TO_STAKERS);
-    } else if (row.metric_type === 'dailyRevenue') {
-      dailyRevenue.add(LST_MINT, Number(row.amount) * 1e9 || 0, METRIC.MANAGEMENT_FEES);
-    } else if (row.metric_type === 'dailyUserFees') {
-      dailyFees.add(LST_MINT, Number(row.amount) * 1e9 || 0, METRIC.DEPOSIT_WITHDRAW_FEES);
-    }
-  });
+  const addPool = (rows: any[], lstMint: string) => {
+    const amount = (metricType: string) =>
+      Number(rows.find((row: any) => row.metric_type === metricType)?.amount) || 0;
+    const stakingRewards = amount('dailyFees');
+    const feeAccountInflows = amount('dailyRevenue');
+    const userFees = amount('dailyUserFees');
+
+    // The fee account takes user transfers and the minted epoch fee, nothing else.
+    const mintedFee = feeAccountInflows - userFees;
+
+    dailyFees.addCGToken("solana", stakingRewards, METRIC.STAKING_REWARDS);
+    dailyFees.add(lstMint, userFees * 1e9, METRIC.DEPOSIT_WITHDRAW_FEES);
+    dailyRevenue.add(lstMint, feeAccountInflows * 1e9, METRIC.MANAGEMENT_FEES);
+    dailySupplySideRevenue.addCGToken("solana", stakingRewards, STAKING_REWARDS_TO_STAKERS);
+    dailySupplySideRevenue.add(lstMint, -mintedFee * 1e9, STAKING_REWARDS_TO_STAKERS);
+  };
+
+  addPool(results, LST_MINT);
 
   const STAKE_POOL_RESERVE_ACCOUNT_PLUS = "rp9wuHdLbzQzSDZmGXCwXbVNLWjuWBZCJZoXV6n6eJT";
   const STAKE_POOL_WITHDRAW_AUTHORITY_PLUS = "92rS1uTEmcATAjap6hW3M34jbNt67kK214PiSkbn25uK";
@@ -56,16 +63,7 @@ const fetch = async (options: FetchOptions) => {
 
   const results_plus = await queryDuneSql(options, query_plus);
 
-  results_plus.forEach((row: any) => {
-    if (row.metric_type === 'dailyFees') {
-      dailyFees.addCGToken("solana", row.amount || 0, METRIC.STAKING_REWARDS);
-      dailySupplySideRevenue.addCGToken("solana", row.amount || 0, STAKING_REWARDS_TO_STAKERS);
-    } else if (row.metric_type === 'dailyRevenue') {
-      dailyRevenue.add(LST_MINT_PLUS, Number(row.amount) * 1e9 || 0, METRIC.MANAGEMENT_FEES);
-    } else if (row.metric_type === 'dailyUserFees') {
-      dailyFees.add(LST_MINT_PLUS, Number(row.amount) * 1e9 || 0, METRIC.DEPOSIT_WITHDRAW_FEES);
-    }
-  });
+  addPool(results_plus, LST_MINT_PLUS);
 
   return {
     dailyFees,
@@ -79,7 +77,7 @@ const methodology = {
   Fees: 'Staking rewards from staked SOL on Hylo and Hylo+ staked solana, plus deposit/withdrawal fees paid by users',
   Revenue: 'Includes withdrawal fees and management fees collected by fee collector',
   ProtocolRevenue: 'Revenue going to treasury/team',
-  SupplySideRevenue: 'Staking rewards distributed to LST stakers',
+  SupplySideRevenue: 'Staking rewards distributed to LST stakers, net of the epoch fee',
 }
 
 const breakdownMethodology = {
@@ -94,7 +92,7 @@ const breakdownMethodology = {
     [METRIC.MANAGEMENT_FEES]: 'Withdrawal and management fees going to the treasury/team',
   },
   SupplySideRevenue: {
-    [STAKING_REWARDS_TO_STAKERS]: 'Staking rewards accruing to the LST stakers',
+    [STAKING_REWARDS_TO_STAKERS]: 'Staking rewards accruing to the LST stakers, less the epoch fee minted to the fee collector',
   },
 }
 


### PR DESCRIPTION
`fees/hylo-lst.ts` reports the epoch fee twice.

`helpers/queries/sol-lst.sql` returns three rows: staking rewards in SOL, every inflow to the LST fee token account, and that same account filtered to `action='transfer'`. Its own comment calls those transfer rows the deposit and withdrawal fees, "which are NOT part of the staking rewards". What the filter drops is the LST minted as the pool's epoch fee, which is part of them.

Passing the whole inflow row to `dailyRevenue` and the whole rewards row to `dailySupplySideRevenue` leaves

```
Revenue + SupplySide - Fees = minted
```

on every day the pool earns. `api.llama.fi/summary/fees/hylo-lsts`: 386 days, fees $1,416,638, revenue $312,719, supply side $1,275,111, ratio 1.1208. On 177 of the 195 days the pool earned, the excess is 5.5% to 27.5% of that day's fees; over the last thirty days it sits between 5.6% and 6.7%.

Eleven adapters on this query report a supply side. Ten of them hand stakers 0.90 to 0.975 of the reward. Nine of those ten also pass `AND action!='mint'`, and the tenth, jito, returns `dailyRevenue: 0` and never reads the inflow row at all. Rather than pick a rate for hyloSOL and hyloSOL+, this subtracts the mint the query already measures, which is the difference between the two fee-account rows, as `fees/maple-finance.ts` takes a manager fee off supply side. Both per-pool blocks were identical, so they became one call.

**One consequence worth your call.** Supply side becomes `fees - revenue` exactly, so it is negative on a day the fee account is credited and the pool banked nothing. Dune buckets the mint a few hours off the rewards it was taken from, so that happens on 171 of the 386 published days, worth **-$10,729 against a supply side of $1,103,919**: median -$16, 72 of them under ten dollars, worst -$1,608 on 2026-01-14. 93.7% of the fee does land on a day with rewards beside it. If you would rather have no negative days, the other route is to pass `AND action!='mint'` and leave supply side as the rewards, which is also exact and gives 0 negative days, but drops revenue from $312,719 to $141,527 because the epoch fee then leaves the record entirely. Happy to send that instead.

No Dune key here, so `queryDuneSql` is stubbed and the return value priced, over four row sets:

```
                                                   master        this branch
the pool earns and the fee is minted same day   +263.321463         0.000000
the fee is minted on a day with no rewards      +386.138393         0.000000
a silent day                                       0.000000         0.000000
a row set missing its user-fee row                 0.000000         0.000000
```

`ts-check` is clean and `package-lock.json` is untouched.

Website: https://hylo.so/leverage · Twitter: https://twitter.com/hylo_so
