### PR TITLE
[fix] hipo - read the widened treasury state, and fix the reward it reports

### DIFF
--- a/fees/hipo/index.ts
+++ b/fees/hipo/index.ts
@@ -42,6 +42,15 @@ export default {
                 // the round length that used to come from a second get_times call: the treasury only
                 // moves the rates when a round it lent into settles, so a round in which nothing was
                 // lent widens this interval rather than passing unnoticed.
+                //
+                // Zero on a treasury that has never settled a round, which would make normalize()
+                // return Infinity and carry it into the USD conversion. Mainnet cannot be in that
+                // state -- the migration seeded round_duration from the network's round length --
+                // but the sibling yield adaptor guards the same value, so this one does too.
+                if (!Number.isFinite(roundDuration) || roundDuration <= 0) {
+                    throw new Error('Expected a positive round duration, but got ' + roundDuration)
+                }
+
                 const normalize = normalizer(roundDuration)
 
                 // The reward that accrued to stakers, in nanoGRAM. It is the rate move applied to the

--- a/fees/hipo/index.ts
+++ b/fees/hipo/index.ts
@@ -28,27 +28,34 @@ export default {
                     throw new Error('Expected a zero exit code, but got ' + getTreasuryState.exit_code)
                 }
 
-                const getTimes = await postURL('https://toncenter.com/api/v3/runGetMethod', {
-                    address,
-                    method: 'get_times',
-                    stack: [],
-                })
-                if (getTimes.exit_code !== 0) {
-                    throw new Error('Expected a zero exit code, but got ' + getTimes.exit_code)
-                }
+                // get_treasury_state mirrors the treasury's storage order. The upgrade of 2026-09-06
+                // inserted deficit at index 5 and round_duration + last_settled_round after the rate
+                // pair, taking the tuple from 21 values to 24, so every index from 5 on moved.
+                const totalTokens = Number(getTreasuryState.stack[1].value)
+                const previousRate = Number(getTreasuryState.stack[12].value)
+                const currentRate = Number(getTreasuryState.stack[13].value)
+                const roundDuration = Number(getTreasuryState.stack[14].value)
+                const governanceFee = Number(getTreasuryState.stack[19].value)
 
-                const lastStaked = Number(getTreasuryState.stack[11].value)
-                const lastRecovered = Number(getTreasuryState.stack[12].value)
-                const governanceFee = Number(getTreasuryState.stack[16].value)
+                // round_duration is the number of seconds current_rate took to grow out of
+                // previous_rate, measured on chain between the last two settled rounds. It replaces
+                // the round length that used to come from a second get_times call: the treasury only
+                // moves the rates when a round it lent into settles, so a round in which nothing was
+                // lent widens this interval rather than passing unnoticed.
+                const normalize = normalizer(roundDuration)
 
-                const currentRoundSince = Number(getTimes.stack[0].value)
-                const nextRoundSince = Number(getTimes.stack[3].value)
-
-                const duration = nextRoundSince - currentRoundSince
-                const normalize = normalizer(duration)
-
-                const newCoins = lastRecovered - lastStaked
-                const treasuryReward = Math.floor(newCoins * 65535 / (65535 - governanceFee))
+                // The reward that accrued to stakers, in nanoGRAM. It is the rate move applied to the
+                // whole hGRAM supply -- total_coins = total_tokens * rate / 1e9, so a rate move of
+                // (current - previous) is worth total_tokens * (current - previous) / 1e9 in coins.
+                // Indices 11 and 12 used to hold last_staked and last_recovered, and this adapter was
+                // still subtracting them as if they were coin amounts long after the treasury
+                // replaced those fields with the 1e9-scaled rate pair. That reported a few hundred
+                // thousand nanoGRAM per round -- about six millionths of the real figure.
+                const newCoins = (totalTokens * (currentRate - previousRate)) / 1_000_000_000
+                // Not floored. newCoins used to be a difference of two integers, so flooring the
+                // reward was a no-op; it is a scaled product now, and flooring it leaves protocolFee
+                // holding the negative fractional remainder -- a revenue of -1e-9 when the fee is 0.
+                const treasuryReward = newCoins * 65535 / (65535 - governanceFee)
                 const protocolFee = treasuryReward - newCoins
 
                 const supplySideRevenue = newCoins / 1000000000

--- a/fees/hipo/index.ts
+++ b/fees/hipo/index.ts
@@ -52,6 +52,13 @@ export default {
                 // replaced those fields with the 1e9-scaled rate pair. That reported a few hundred
                 // thousand nanoGRAM per round -- about six millionths of the real figure.
                 const newCoins = (totalTokens * (currentRate - previousRate)) / 1_000_000_000
+                // governance_fee is a uint16 out of 65535, and set_governance_fee in the treasury
+                // bounds it only by the governor's signature -- 65535 is a reachable value, and it
+                // would divide by zero below and publish Infinity. Reject it rather than emit it.
+                if (!Number.isFinite(governanceFee) || governanceFee < 0 || governanceFee >= 65535) {
+                    throw new Error('Expected a governance fee below 65535, but got ' + governanceFee)
+                }
+
                 // Not floored. newCoins used to be a difference of two integers, so flooring the
                 // reward was a no-op; it is a scaled product now, and flooring it leaves protocolFee
                 // holding the negative fractional remainder -- a revenue of -1e-9 when the fee is 0.

--- a/fees/hipo/index.ts
+++ b/fees/hipo/index.ts
@@ -43,6 +43,15 @@ export default {
                 // moves the rates when a round it lent into settles, so a round in which nothing was
                 // lent widens this interval rather than passing unnoticed.
                 //
+                // One caveat, in the contract rather than here. The treasury moves the rate pair on
+                // every settlement but only advances round_duration when a round settles in order,
+                // so the two are exactly paired in steady state and briefly mismatched if the
+                // elector rejects a newer round's stake and it settles ahead of an older round that
+                // is still validating. Two readings then normalise one round's reward over a
+                // two-round window -- understating, never overstating -- and the next in-order
+                // settlement restores the pairing. Their sum over that window is still the correct
+                // time-average, so a daily sampler sees the right figure on average.
+                //
                 // Zero on a treasury that has never settled a round, which would make normalize()
                 // return Infinity and carry it into the USD conversion. Mainnet cannot be in that
                 // state -- the migration seeded round_duration from the network's round length --


### PR DESCRIPTION
Hipo upgraded its treasury contract on 2026-09-06. `get_treasury_state` mirrors the contract's storage order, and the upgrade inserted `deficit` at index 5 and `round_duration` + `last_settled_round` after the exchange-rate pair, taking the tuple from 21 values to 24. Every index from 5 on moved, so this adapter was reading `loan_codes` where it expected the rate pair, and `halter` where it expected `governance_fee`.

While fixing the indices I found a second, older problem in the same lines.

## The reported reward was ~6 millionths of the real figure

Indices 11 and 12 once held `last_staked` and `last_recovered`, and this adapter still subtracted them as if they were coin amounts. The treasury replaced those fields with the 1e9-scaled exchange rate pair some time ago, so `newCoins` has been `current_rate - previous_rate` — a **rate difference reported as nanoGRAM**.

On live state that is 365,415 nano, or 0.000365 GRAM per round, which is why Hipo's fees have been reading as approximately zero.

The reward is that rate move applied to the whole hGRAM supply, since `total_coins = total_tokens * rate / 1e9`:

```
newCoins = total_tokens * (current_rate - previous_rate) / 1e9
```

Against live state that gives **dailyFees ≈ 2,901 GRAM**, or 15.1% of TVL annualised simple — which lines up with the 16.3% compounded APY the protocol publishes through its own gauge.

## The `get_times` call is gone

`round_duration` is the number of seconds `current_rate` took to grow out of `previous_rate`, measured on chain between the last two settled rounds, so the period now comes from the same read as the rates it belongs to.

It is deliberately not a round length. The treasury only moves the rates when a round it lent into settles, so a round in which nothing was lent widens the interval rather than passing unnoticed — dividing by a round length would report an unchanged figure for a pool whose real rate of growth had halved.

## One smaller fix

`treasuryReward` is no longer floored. `newCoins` used to be a difference of two integers, so flooring was a no-op; it is a scaled product now, and flooring left `protocolFee` holding the negative fractional remainder — a reported revenue of `-1e-9` whenever the governance fee is zero, which it currently is.

## Verification

Ran the adapter's arithmetic against live contract state:

```
total_tokens=6022617962641058  previous_rate=1163036853  current_rate=1163402268
round_duration=65536  governance_fee=0

dailySupplySideRevenue = 2901.385910942 GRAM
dailyProtocolRevenue   = 0.000000000 GRAM
dailyFees              = 2901.385910942 GRAM
```

I am from the Hipo team.