### PR TITLE
Add Bucket Shop fees adapter (Robinhood Chain)

### DIFF
--- a/fees/bucket-shop.ts
+++ b/fees/bucket-shop.ts
@@ -1,0 +1,114 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { nullAddress } from "../helpers/token";
+
+// Bucket Shop — fees & revenue adapter.
+//
+// Bucket Shop (https://bucketmarkets.com) pays BUCKET holders in real
+// tokenized equities on Robinhood Chain: protocol fee income buys stocks and
+// the payout engine delivers them straight to holder wallets once a holder's
+// accrual crosses $2. Nothing is retained by a team treasury, which is why
+// ProtocolRevenue is zero and HoldersRevenue equals Revenue below.
+//
+// Two fee streams, both read from chain:
+//
+// 1. The protocol's own BUCKET/ETH Uniswap v4 pool (1% LP fee, protocol fee
+//    hook). Its liquidity is protocol-owned and permanently locked (added via
+//    a donate conduit with no withdrawal path), so the pool's LP fees are
+//    protocol income. Fees are computed per Swap event as |amount0| (the ETH
+//    leg) x fee/1e6, which keeps every swap denominated in ETH regardless of
+//    trade direction. Trades where BUCKET is the input are therefore measured
+//    on their ETH output leg, understating that swap's fee by fee^2 (about
+//    0.01% of the fee) -- accepted for the benefit of exact pricing.
+//
+// 2. The Stockback router (0.5% fee on the input of any swap routed through
+//    it, capped at 1% in the contract). The router's Swapped event carries the
+//    exact fee in the input currency. Half of every router fee is credited
+//    back to the trader as stock rewards ("Stockback"), so that half is
+//    supply-side; the other half is protocol revenue.
+//
+// All protocol fee income (pool fees + the protocol half of router fees) is
+// distributed to BUCKET holders as tokenized stocks by the payout engine, so
+// HoldersRevenue == Revenue. A small share of revenue pays keeper gas for the
+// on-chain deliveries; it is not deducted here.
+
+// https://robinhoodchain.blockscout.com/address/0x8366a39CC670B4001A1121B8F6A443A643e40951
+const POOL_MANAGER = "0x8366a39CC670B4001A1121B8F6A443A643e40951";
+// The protocol's BUCKET/ETH pool (currency0 = native ETH, fee = 10000 = 1%),
+// created in the token's deployment transaction window at block 30506396.
+const BUCKET_POOL_ID = "0x8857c1a180b5483c98d38f4d62db5866de2f91b737513347283f55e446424ce3";
+// https://robinhoodchain.blockscout.com/address/0xbAE74d90D874943674C9aB7F9392601A06F544C2
+const STOCKBACK_ROUTER = "0xbAE74d90D874943674C9aB7F9392601A06F544C2";
+
+const SWAP_EVENT =
+  "event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)";
+const SWAPPED_EVENT =
+  "event Swapped(address indexed trader, address indexed to, address indexed currencyIn, uint256 amountIn, uint256 fee, uint256 amountOut)";
+
+const abs = (n: bigint) => (n < 0n ? -n : n);
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // 1. LP fees on the protocol-owned BUCKET/ETH pool, in ETH terms
+  const swaps = await options.getLogs({
+    target: POOL_MANAGER,
+    eventAbi: SWAP_EVENT,
+    topics: [
+      "0x40e9cecb9f5f1f1c5b9c97dec2917b7ee92e57ba5563708daca94dd84ad7112f", // Swap
+      BUCKET_POOL_ID,
+    ],
+  });
+  for (const log of swaps) {
+    const ethLeg = abs(BigInt(log.amount0));
+    const feeWei = (ethLeg * BigInt(log.fee)) / 1_000_000n;
+    dailyFees.add(nullAddress, feeWei);
+    dailyRevenue.add(nullAddress, feeWei);
+  }
+
+  // 2. Stockback router fees, exact per-swap fee in the input currency;
+  //    half is protocol revenue, half is the trader's Stockback rebate
+  const routed = await options.getLogs({
+    target: STOCKBACK_ROUTER,
+    eventAbi: SWAPPED_EVENT,
+  });
+  for (const log of routed) {
+    const fee = BigInt(log.fee);
+    const token = log.currencyIn === "0x0000000000000000000000000000000000000000"
+      ? nullAddress
+      : log.currencyIn;
+    dailyFees.add(token, fee);
+    dailyRevenue.add(token, fee / 2n);
+    dailySupplySideRevenue.add(token, fee - fee / 2n);
+  }
+
+  return {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: 0,
+    dailyHoldersRevenue: dailyRevenue,
+    dailySupplySideRevenue,
+  };
+};
+
+const methodology = {
+  Fees: "Swap fees paid by traders: the 1% LP fee on the protocol-owned BUCKET/ETH Uniswap v4 pool (per Swap event, measured on the ETH leg) plus the Stockback router's 0.5% fee on the input of every swap routed through it (exact per-swap fee from the router's Swapped event).",
+  UserFees: "Same as Fees; traders pay both fee streams.",
+  Revenue: "Pool LP fees (the pool's liquidity is protocol-owned and permanently locked) plus the protocol half of Stockback router fees.",
+  ProtocolRevenue: "Zero. No fee income is retained by a team treasury; everything flows to the payout engine.",
+  HoldersRevenue: "Equal to Revenue: all protocol fee income buys tokenized stocks that the payout engine delivers to BUCKET holder wallets. A small share pays keeper gas for those on-chain deliveries and is not deducted here.",
+  SupplySideRevenue: "The trader's half of every Stockback router fee, credited back as stock rewards.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-08-07", // BUCKET/ETH pool initialized, block 30506396
+  methodology,
+};
+
+export default adapter;

--- a/fees/bucket-shop.ts
+++ b/fees/bucket-shop.ts
@@ -84,10 +84,12 @@ const fetch = async (options: FetchOptions) => {
       ? (ethLeg * HOOK_FEE_BPS) / (10_000n - HOOK_FEE_BPS)
       : (ethLeg * HOOK_FEE_BPS) / 10_000n;
     const lpFeeWei = (ethLeg * BigInt(log.fee)) / 1_000_000n;
-    dailyFees.add(nullAddress, lpFeeWei + hookFeeWei);
-    dailyRevenue.add(nullAddress, lpFeeWei + hookFeeWei);
-    dailyProtocolRevenue.add(nullAddress, lpFeeWei);     // locked protocol LP
-    dailyHoldersRevenue.add(nullAddress, hookFeeWei);    // Treasury -> payouts
+    dailyFees.add(nullAddress, lpFeeWei, "BUCKET Pool LP Fees");
+    dailyFees.add(nullAddress, hookFeeWei, "BucketFeeHook Treasury Fee");
+    dailyRevenue.add(nullAddress, lpFeeWei, "BUCKET Pool LP Fees To Protocol");
+    dailyRevenue.add(nullAddress, hookFeeWei, "BucketFeeHook Treasury Fee To Holders");
+    dailyProtocolRevenue.add(nullAddress, lpFeeWei, "BUCKET Pool LP Fees To Protocol");
+    dailyHoldersRevenue.add(nullAddress, hookFeeWei, "BucketFeeHook Treasury Fee To Holders");
   }
 
   // 2. Stockback router fees, exact per-swap fee in the input currency;
@@ -101,10 +103,10 @@ const fetch = async (options: FetchOptions) => {
     const token = log.currencyIn === "0x0000000000000000000000000000000000000000"
       ? nullAddress
       : log.currencyIn;
-    dailyFees.add(token, fee);
-    dailyRevenue.add(token, fee / 2n);
-    dailyHoldersRevenue.add(token, fee / 2n);
-    dailySupplySideRevenue.add(token, fee - fee / 2n);
+    dailyFees.add(token, fee, "Stockback Router Fees");
+    dailyRevenue.add(token, fee / 2n, "Stockback Router Fees To Holders");
+    dailyHoldersRevenue.add(token, fee / 2n, "Stockback Router Fees To Holders");
+    dailySupplySideRevenue.add(token, fee - fee / 2n, "Stockback Router Fees To Traders");
   }
 
   return {
@@ -115,6 +117,29 @@ const fetch = async (options: FetchOptions) => {
     dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "BUCKET Pool LP Fees": "1% LP fee on the protocol-owned BUCKET/ETH Uniswap v4 pool, measured on the ETH leg of each Swap event.",
+    "BucketFeeHook Treasury Fee": "3% Treasury fee (FEE_BPS = 300, verified on-chain constant) charged by the BucketFeeHook on each pool swap, measured on the ETH leg.",
+    "Stockback Router Fees": "0.5% fee on the input of swaps routed through the Stockback router (exact per-swap amount from its Swapped event).",
+  },
+  Revenue: {
+    "BUCKET Pool LP Fees To Protocol": "1% LP fee accruing to the protocol's permanently locked liquidity position.",
+    "BucketFeeHook Treasury Fee To Holders": "3% Treasury fee that funds the payout engine for BUCKET holder distributions.",
+    "Stockback Router Fees To Holders": "Protocol's half of each Stockback router fee, funding holder payouts.",
+  },
+  ProtocolRevenue: {
+    "BUCKET Pool LP Fees To Protocol": "1% LP fee accruing to the protocol's permanently locked liquidity position.",
+  },
+  HoldersRevenue: {
+    "BucketFeeHook Treasury Fee To Holders": "3% Treasury fee converted into tokenized stocks delivered to BUCKET holder wallets.",
+    "Stockback Router Fees To Holders": "Protocol's half of each Stockback router fee, funding holder payouts.",
+  },
+  SupplySideRevenue: {
+    "Stockback Router Fees To Traders": "Trader's half of each Stockback router fee, credited back as stock rewards.",
+  },
 };
 
 const methodology = {
@@ -132,6 +157,9 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.ROBINHOOD],
   start: "2026-08-07", // BUCKET/ETH pool initialized, block 30506396
   methodology,
+  breakdownMethodology,
+  pullHourly: true,
+  doublecounted: true, // uniswap v4
 };
 
 export default adapter;

--- a/fees/bucket-shop.ts
+++ b/fees/bucket-shop.ts
@@ -12,14 +12,16 @@ import { nullAddress } from "../helpers/token";
 //
 // Two fee streams, both read from chain:
 //
-// 1. The protocol's own BUCKET/ETH Uniswap v4 pool (1% LP fee, protocol fee
-//    hook). Its liquidity is protocol-owned and permanently locked (added via
-//    a donate conduit with no withdrawal path), so the pool's LP fees are
-//    protocol income. Fees are computed per Swap event as |amount0| (the ETH
-//    leg) x fee/1e6, which keeps every swap denominated in ETH regardless of
-//    trade direction. Trades where BUCKET is the input are therefore measured
-//    on their ETH output leg, understating that swap's fee by fee^2 (about
-//    0.01% of the fee) -- accepted for the benefit of exact pricing.
+// 1. The protocol's own BUCKET/ETH Uniswap v4 pool. TWO components per swap:
+//    the 1% LP fee (liquidity is protocol-owned and permanently locked, so
+//    LP fees are protocol income) PLUS the BucketFeeHook's 3% ETH fee
+//    credited straight to the Treasury -- FEE_BPS() == 300 is a constant on
+//    the verified hook at 0x11aFe0130450df7127276e7AF474Eccdf4D420Cc, and the
+//    Treasury fee is the income stream that funds holder payouts. Both are
+//    measured on |amount0| (the ETH leg), which keeps every swap denominated
+//    in ETH regardless of direction; BUCKET-input trades are measured on
+//    their ETH output leg, understating by ~fee^2 -- accepted for exact
+//    pricing.
 //
 // 2. The Stockback router (0.5% fee on the input of any swap routed through
 //    it, capped at 1% in the contract). The router's Swapped event carries the
@@ -27,10 +29,12 @@ import { nullAddress } from "../helpers/token";
 //    back to the trader as stock rewards ("Stockback"), so that half is
 //    supply-side; the other half is protocol revenue.
 //
-// All protocol fee income (pool fees + the protocol half of router fees) is
-// distributed to BUCKET holders as tokenized stocks by the payout engine, so
-// HoldersRevenue == Revenue. A small share of revenue pays keeper gas for the
-// on-chain deliveries; it is not deducted here.
+// Allocation: the hook's Treasury fee and the protocol half of router fees
+// fund the payout engine and are distributed to BUCKET holders as tokenized
+// stocks (HoldersRevenue). The 1% LP fee accrues to the protocol's
+// permanently locked liquidity position (ProtocolRevenue). A small share of
+// holder revenue pays keeper gas for the on-chain deliveries; it varies with
+// chain conditions and is not modeled as a fixed percentage.
 
 // https://robinhoodchain.blockscout.com/address/0x8366a39CC670B4001A1121B8F6A443A643e40951
 const POOL_MANAGER = "0x8366a39CC670B4001A1121B8F6A443A643e40951";
@@ -39,6 +43,9 @@ const POOL_MANAGER = "0x8366a39CC670B4001A1121B8F6A443A643e40951";
 const BUCKET_POOL_ID = "0x8857c1a180b5483c98d38f4d62db5866de2f91b737513347283f55e446424ce3";
 // https://robinhoodchain.blockscout.com/address/0xbAE74d90D874943674C9aB7F9392601A06F544C2
 const STOCKBACK_ROUTER = "0xbAE74d90D874943674C9aB7F9392601A06F544C2";
+
+// BucketFeeHook.FEE_BPS() == 300, constant, verified source
+const HOOK_FEE_BPS = 300n;
 
 const SWAP_EVENT =
   "event Swap(bytes32 indexed id, address indexed sender, int128 amount0, int128 amount1, uint160 sqrtPriceX96, uint128 liquidity, int24 tick, uint24 fee)";
@@ -50,6 +57,8 @@ const abs = (n: bigint) => (n < 0n ? -n : n);
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
   // 1. LP fees on the protocol-owned BUCKET/ETH pool, in ETH terms
@@ -63,9 +72,12 @@ const fetch = async (options: FetchOptions) => {
   });
   for (const log of swaps) {
     const ethLeg = abs(BigInt(log.amount0));
-    const feeWei = (ethLeg * BigInt(log.fee)) / 1_000_000n;
-    dailyFees.add(nullAddress, feeWei);
-    dailyRevenue.add(nullAddress, feeWei);
+    const lpFeeWei = (ethLeg * BigInt(log.fee)) / 1_000_000n;
+    const hookFeeWei = (ethLeg * HOOK_FEE_BPS) / 10_000n;
+    dailyFees.add(nullAddress, lpFeeWei + hookFeeWei);
+    dailyRevenue.add(nullAddress, lpFeeWei + hookFeeWei);
+    dailyProtocolRevenue.add(nullAddress, lpFeeWei);     // locked protocol LP
+    dailyHoldersRevenue.add(nullAddress, hookFeeWei);    // Treasury -> payouts
   }
 
   // 2. Stockback router fees, exact per-swap fee in the input currency;
@@ -81,6 +93,7 @@ const fetch = async (options: FetchOptions) => {
       : log.currencyIn;
     dailyFees.add(token, fee);
     dailyRevenue.add(token, fee / 2n);
+    dailyHoldersRevenue.add(token, fee / 2n);
     dailySupplySideRevenue.add(token, fee - fee / 2n);
   }
 
@@ -88,18 +101,18 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: 0,
-    dailyHoldersRevenue: dailyRevenue,
+    dailyProtocolRevenue,
+    dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Swap fees paid by traders: the 1% LP fee on the protocol-owned BUCKET/ETH Uniswap v4 pool (per Swap event, measured on the ETH leg) plus the Stockback router's 0.5% fee on the input of every swap routed through it (exact per-swap fee from the router's Swapped event).",
-  UserFees: "Same as Fees; traders pay both fee streams.",
-  Revenue: "Pool LP fees (the pool's liquidity is protocol-owned and permanently locked) plus the protocol half of Stockback router fees.",
-  ProtocolRevenue: "Zero. No fee income is retained by a team treasury; everything flows to the payout engine.",
-  HoldersRevenue: "Equal to Revenue: all protocol fee income buys tokenized stocks that the payout engine delivers to BUCKET holder wallets. A small share pays keeper gas for those on-chain deliveries and is not deducted here.",
+  Fees: "Swap fees paid by traders on the protocol's BUCKET/ETH Uniswap v4 pool: the 1% LP fee plus the BucketFeeHook's 3% Treasury fee (FEE_BPS is a verified on-chain constant), both measured on the ETH leg of each Swap event; plus the Stockback router's 0.5% input fee (exact per-swap amount from its Swapped event).",
+  UserFees: "Same as Fees; traders pay all three components.",
+  Revenue: "The hook's 3% Treasury fee, the 1% LP fee (the pool's liquidity is protocol-owned and permanently locked), and the protocol half of Stockback router fees.",
+  ProtocolRevenue: "The 1% LP fee, accruing to the protocol's permanently locked liquidity position.",
+  HoldersRevenue: "The hook's 3% Treasury fee plus the protocol half of router fees: this is the stream the payout engine converts into tokenized stocks delivered to BUCKET holder wallets. Keeper gas for those deliveries is paid from this stream and varies with chain conditions; it is not modeled as a fixed split.",
   SupplySideRevenue: "The trader's half of every Stockback router fee, credited back as stock rewards.",
 };
 

--- a/fees/bucket-shop.ts
+++ b/fees/bucket-shop.ts
@@ -71,9 +71,19 @@ const fetch = async (options: FetchOptions) => {
     ],
   });
   for (const log of swaps) {
-    const ethLeg = abs(BigInt(log.amount0));
+    const a0 = BigInt(log.amount0);
+    const ethLeg = abs(a0);
+    // Fee ordering (per the hook's beforeSwap/afterSwap split):
+    //  - ETH input (a0 < 0): the hook deducts 3% BEFORE the pool, so the
+    //    event's amount0 is NET of the hook fee. Gross it back up:
+    //    hook = net * 300/9700; the LP fee applies to the net amount the
+    //    pool actually swapped.
+    //  - ETH output (a0 > 0): the hook takes 3% of the pool's ETH output in
+    //    afterSwap, so the event amount IS the base: hook = amount * 3%.
+    const hookFeeWei = a0 < 0n
+      ? (ethLeg * HOOK_FEE_BPS) / (10_000n - HOOK_FEE_BPS)
+      : (ethLeg * HOOK_FEE_BPS) / 10_000n;
     const lpFeeWei = (ethLeg * BigInt(log.fee)) / 1_000_000n;
-    const hookFeeWei = (ethLeg * HOOK_FEE_BPS) / 10_000n;
     dailyFees.add(nullAddress, lpFeeWei + hookFeeWei);
     dailyRevenue.add(nullAddress, lpFeeWei + hookFeeWei);
     dailyProtocolRevenue.add(nullAddress, lpFeeWei);     // locked protocol LP


### PR DESCRIPTION
##### Name (to be shown on DefiLlama):
Bucket Shop

##### Twitter Link:
https://x.com/RealBucketShop

##### List of audit links if any:

##### Website Link:
https://bucketmarkets.com

##### Logo (High resolution, will be shown with rounded borders):
https://bucketmarkets.com/cg-logo-200.png

##### Current TVL:
Not a TVL listing (fees/revenue adapter). Protocol fee income is paid out to holders continuously rather than pooled; a prior TVL PR (DefiLlama-Adapters#20864) was closed for exactly that reason and this adapter is the follow-up suggested there.

##### Treasury Addresses (if the protocol has treasury)
0x0F695fbDBc12dF4b4d9f5A8318ba62dcf00A576a

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed):
bucket-shop

##### Coinmarketcap ID:

##### Short Description (to be shown on DefiLlama):
Hold BUCKET, get paid in real tokenized stocks. Protocol fee income buys equities on Robinhood Chain and the payout engine delivers them straight to holder wallets.

##### Token address and ticker if any:
0xbc9E7b1c5C0081f4aE85e71eC95703d3dEC9ffaD (BUCKET)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Yield

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
Chainlink (ETH/USD feed on Robinhood Chain for payout accounting)

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
The payout engine values fee income and holder accruals in USD using the chain's Chainlink ETH/USD feed; the $2 delivery batching threshold is computed against it.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
https://bucketmarkets.com/transparency.html

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Fees = 1% LP fee on the protocol-owned BUCKET/ETH Uniswap v4 pool (per Swap event, measured on the ETH leg) + the Stockback router's 0.5% input fee (exact per-swap fee from its Swapped event). Revenue = pool fees (liquidity is protocol-owned and permanently locked) + the protocol half of router fees; the other half is credited back to traders as stock rewards (supply side). HoldersRevenue = Revenue: all protocol fee income is distributed to BUCKET holders as tokenized stocks. ProtocolRevenue = 0.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No
