### PR TITLE
curve: add etherlink volume

### DIFF
--- a/dexs/curve/index.ts
+++ b/dexs/curve/index.ts
@@ -528,6 +528,21 @@ const CurveDexConfigs: { [key: string]: ICurveDexConfig } = {
     ],
   },
 
+  [CHAIN.ETHERLINK]: {
+    start: "2025-08-02",
+    factory_stable_ng: [
+      "0x8271e06E5887FE5ba05234f5315c19f3Ec90E8aD",
+    ],
+    factory_twocrypto: [
+      "0xe7FBd704B938cB8fe26313C3464D4b7B7348c88C",
+    ],
+    factory_tricrypto: [
+      "0x6E28493348446503db04A49621d8e6C9A40015FB",
+    ],
+    customPools: {},
+    blacklistedPools: [
+    ],
+  },
   // [CHAIN.TAC]: {
   //   start: '2025-06-25',
   //   factory_stable_ng: [


### PR DESCRIPTION
Fixes #9283

adds etherlink to `dexs/curve` through the on-chain path, since `prices.curve.finance` has no etherlink entry. the three ng factories are the same addresses stable, monad, plasma and robinhood already use, so the block mirrors those (start 2025-08-02, the first day the tvl adapter has etherlink).

harness:

```
2026-09-03  volume $101.16k  fees $10.00
2026-09-04  volume $133.49k  fees $13.00   (two runs, identical)
```

independent reconstruction of 2026-09-04 from the pools' `TokenExchange` logs priced with coins.llama.fi lands at $133,119, 0.3% apart, the gap being one token coins.llama.fi has no price for. details in the issue.
