### PR TITLE
uniswap v2: pull daily while the clickhouse chains have no indexer sync guard

### DIFF
--- a/dexs/uniswap-v2.ts
+++ b/dexs/uniswap-v2.ts
@@ -287,7 +287,8 @@ const methodology = {
 
 const adapter: Adapter = {
   version: 2,
-  pullHourly: true,
+  // clickhouse chains: evm_indexer has no sync guard, an hourly window reads a partial hour (#9100)
+  pullHourly: false,
   fetch,
   adapter: chainConfig,
   methodology,


### PR DESCRIPTION
for #9100.

`fetchClickhouse` sums `evm_indexer.logs` over the run window with no check that the indexer has reached `toTimestamp`. the sdk's indexer `getLogs` does have that check (throws past 50% missing, fills the rest from rpc), which is why the `LOGS` chains in this same file publish `fees / volume` at exactly 30 bps while the five clickhouse chains sit at 55 to 131 bps: each job gets whatever the indexer had ingested when its hourly run fired, and the volume job and the fees job fire at different times.

the day it started is #8027 (2026-07-09), a three-line `version: 1` -> `version: 2, pullHourly: true` change. ethereum, daily averages from `api.llama.fi/summary/dexs/uniswap-v2` and the fee series divided by 0.003:

```
2026-06-01 .. 07-08   volume $12.8m/d   fee-implied $13.7m/d   ratio 1.07
2026-07-09 .. 09-05   volume  $1.9m/d   fee-implied  $7.2m/d   ratio 3.71
```

visible to the day: 07-08 $11.3m, 07-09 $0.84m, with the fee-implied figure still $4.9m.

this puts the adapter back on daily windows. it is the smaller of the two fixes. the right one is a sync guard in `fetchClickhouse` (the chain's max indexed block timestamp against `toTimestamp`, throw when short) so hourly can come back, but the clickhouse path cannot be run from outside and i did not want to send a guard i have not executed. `pullHourly: false` is the pre-07-09 state, which held ethereum within 7% of the fee series for the nine weeks before the change.

`dexs/flap.ts` has the same shape (clickhouse source, `pullHourly: true`) and deserves the same look; not touched here.

ts-check clean. tempo, on the `LOGS` path the flag does not touch, runs unchanged in the harness. the clickhouse chains cannot run locally (`Missing env CLICKHOUSE_CONFIG`), so the `test` check will be red the way it is for every pr touching this file. the days from 07-10 on need a refill once this lands; the issue stays open for that.
