### PR TITLE
yuzu money: add ethereum vaults

### DIFF
--- a/fees/yuzu-money/index.ts
+++ b/fees/yuzu-money/index.ts
@@ -33,8 +33,23 @@ interface VaultConfig {
 const PLASMA_USDT0 = "0xb8ce59fc3717ada4c02eadf9682a9e934f625ebb";
 const PLASMA_YZUSD = "0x6695c0f8706c5ace3bdf8995073179cca47926dc";
 const MONAD_USD = "0x754704bc059f8c67012fed69bc8a327a5aafb603"; // yzPrime asset()
+const ETHEREUM_USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 
 const chainConfig: Record<string, { start: string, vaults: VaultConfig[] }> = {
+  [CHAIN.ETHEREUM]: {
+    start: "2026-07-18",
+    vaults: [
+    {
+      vault: "0x224e90591a2d63fb66e677d0561ea4a6ad1f098d", // yzCash
+      underlying: ETHEREUM_USDC,
+      label: "yzCash Yield To Holders",
+    },
+    {
+      vault: "0xc9854f2af89d4d26837004d1e154bd3c3c1009b1", // yzSyrup
+      underlying: ETHEREUM_USDC,
+      label: "yzSyrup Yield To Holders",
+    },
+  ]},
   [CHAIN.PLASMA]: {
     start: "2025-08-01",
     vaults: [


### PR DESCRIPTION
Fixes #9286

adds the ethereum leg to `fees/yuzu-money`: yzCash and yzSyrup, both erc-4626 on usdc, read the same way as the plasma and monad vaults. start is 2026-07-18, the first day the tvl adapter has ethereum.

harness:

```
2026-09-03  fees $2.21k   (yzCash 1,196 / yzSyrup 1,011)
2026-09-04  fees $1.82k   (yzCash   809 / yzSyrup 1,010)
```

an independent recomputation of 2026-09-04 from share rates at the day-boundary blocks on a different rpc gives $1,812.00 against the adapter's $1,819. plasma and monad are untouched.
