### PR TITLE
feat: track Bonker fees on Robinhood Chain

### DIFF
--- a/fees/bonker.ts
+++ b/fees/bonker.ts
@@ -1,5 +1,6 @@
-// Bonker is a token launchpad on Base. Tokens launched through its factory trade in
-// Uniswap v4 pools whose hooks charge two swap-fee streams:
+// Bonker is a token launchpad on Base and Robinhood Chain. Tokens launched
+// through its factory trade in Uniswap v4 pools whose hooks charge two
+// swap-fee streams:
 //   - the Uniswap LP fee, paid to launch-configured reward recipients; and
 //   - an additional protocol fee equal to 20% of that LP fee, paid to Bonker.
 //
@@ -9,25 +10,39 @@
 // configured reward recipients. Counting both flows avoids estimating the LP side
 // from the nominal 20% protocol-fee rate and its per-swap integer rounding.
 //
-// Sources:
-//   https://basescan.org/address/0x963E91A45148b39737b9DF10c5b897B55cA9e8cC#code
-//   https://basescan.org/address/0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc#code
-
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { METRIC } from "../helpers/metrics";
 
-// Current Base mainnet hooks, deployed with the factory at block 43,000,832.
-const BONKER_HOOKS = [
-  "0x963E91A45148b39737b9DF10c5b897B55cA9e8cC", // dynamic-fee hook
-  "0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc", // static-fee hook
-];
-// Bonker LP locker; emits swap-fee deposits to the fee locker.
-// Source: https://basescan.org/address/0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0#code
-const LP_LOCKER = "0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0";
-// Bonker fee locker; credits LP fees to launch-configured reward recipients.
-// Source: https://basescan.org/address/0x473e52D89bE6ea78f94d1b5c62Bd1f01b1E32e21#code
-const FEE_LOCKER = "0x473e52D89bE6ea78f94d1b5c62Bd1f01b1E32e21";
+type ChainConfig = {
+  hooks: string[];
+  lpLockers: string[];
+  feeLocker: string;
+  start: string;
+};
+
+const CHAIN_CONFIG: Record<string, ChainConfig> = {
+  [CHAIN.BASE]: {
+    hooks: [
+      "0x963E91A45148b39737b9DF10c5b897B55cA9e8cC", // dynamic-fee hook
+      "0xC9156C1868E122eF5b3e6ed946e1E88ff7da68Cc", // static-fee hook
+    ],
+    lpLockers: ["0xBf05b1d5E356f3219D0086A4e09c969ADbe2e7d0"],
+    feeLocker: "0x473e52D89bE6ea78f94d1b5c62Bd1f01b1E32e21",
+    start: "2026-03-06",
+  },
+  [CHAIN.ROBINHOOD]: {
+    hooks: [
+      "0x79e394e79C54936C7582452736d18890cE1368cC", // dynamic-fee hook
+      "0xbbF58750Eb8cD2d24254B0af9167D6e5857fe8cc", // static-fee hook
+    ],
+    // Keep historical lockers here after successors are deployed so their fee
+    // deposits remain part of the protocol's time series.
+    lpLockers: ["0xae2a15309cd4401AF710CE014ec61246a7706B08"],
+    feeLocker: "0x04f034649b72e7f4F167BeE683797C0C35067528",
+    start: "2026-09-03",
+  },
+};
 
 const CLAIM_PROTOCOL_FEES =
   "event ClaimProtocolFees(address indexed token, uint256 amount)";
@@ -35,12 +50,13 @@ const STORE_TOKENS =
   "event StoreTokens(address indexed sender, address indexed feeOwner, address indexed token, uint256 balance, uint256 amount)";
 
 const fetch = async (options: FetchOptions) => {
+  const config = CHAIN_CONFIG[options.chain];
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
   const protocolFeeLogs = await options.getLogs({
-    targets: BONKER_HOOKS,
+    targets: config.hooks,
     eventAbi: CLAIM_PROTOCOL_FEES,
   });
 
@@ -50,14 +66,19 @@ const fetch = async (options: FetchOptions) => {
   }
 
   const rewardLogs = await options.getLogs({
-    target: FEE_LOCKER,
+    target: config.feeLocker,
     eventAbi: STORE_TOKENS,
   });
 
   for (const log of rewardLogs) {
     // The fee locker also accepts deposits from MEV modules. Restricting the
     // sender to the LP locker counts only Uniswap swap-fee rewards.
-    if (log.sender.toLowerCase() !== LP_LOCKER.toLowerCase()) continue;
+    if (
+      !config.lpLockers.some(
+        (locker) => log.sender.toLowerCase() === locker.toLowerCase(),
+      )
+    )
+      continue;
     dailyFees.add(log.token, log.amount, METRIC.SWAP_FEES);
     dailySupplySideRevenue.add(
       log.token,
@@ -107,8 +128,10 @@ const breakdownMethodology = {
 const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
-  chains: [CHAIN.BASE],
-  start: "2026-03-06",
+  chains: Object.entries(CHAIN_CONFIG).map(([chain, config]) => [
+    chain,
+    { start: config.start },
+  ]),
   fetch,
   methodology,
   breakdownMethodology,

--- a/fees/bonker.ts
+++ b/fees/bonker.ts
@@ -38,7 +38,10 @@ const CHAIN_CONFIG: Record<string, ChainConfig> = {
     ],
     // Keep historical lockers here after successors are deployed so their fee
     // deposits remain part of the protocol's time series.
-    lpLockers: ["0xae2a15309cd4401AF710CE014ec61246a7706B08"],
+    lpLockers: [
+      "0xae2a15309cd4401AF710CE014ec61246a7706B08", // superseded 2026-09-09 (issue #762)
+      "0x97d863C592ffe30c8D8621c869f143cF34F18A9D", // live locker for new launches
+    ],
     feeLocker: "0x04f034649b72e7f4F167BeE683797C0C35067528",
     start: "2026-09-03",
   },


### PR DESCRIPTION
## Summary

Extends the existing Bonker fees/revenue adapter from Base to Robinhood Chain (chain ID 4663). This updates the existing protocol listing rather than creating a duplicate.

## Robinhood Chain configuration

- Dynamic-fee hook: [`0x79e394e79C54936C7582452736d18890cE1368cC`](https://robinhoodchain.blockscout.com/address/0x79e394e79C54936C7582452736d18890cE1368cC)
- Static-fee hook: [`0xbbF58750Eb8cD2d24254B0af9167D6e5857fe8cc`](https://robinhoodchain.blockscout.com/address/0xbbF58750Eb8cD2d24254B0af9167D6e5857fe8cc)
- LP locker: [`0xae2a15309cd4401AF710CE014ec61246a7706B08`](https://robinhoodchain.blockscout.com/address/0xae2a15309cd4401AF710CE014ec61246a7706B08)
- FeeLocker: [`0x04f034649b72e7f4F167BeE683797C0C35067528`](https://robinhoodchain.blockscout.com/address/0x04f034649b72e7f4F167BeE683797C0C35067528)
- Start date: 2026-09-03

## Methodology

The adapter preserves the existing event-based accounting on both chains:

- `ClaimProtocolFees` from Bonker's dynamic and static hooks measures protocol revenue.
- `StoreTokens` from the chain's FeeLocker measures LP fees credited to launch-configured reward recipients.
- FeeLocker deposits are included only when `sender` is one of Bonker's LP lockers, excluding deposits from MEV modules.

Locker addresses are stored as a list so historical events remain attributable after a successor locker is deployed.

## Validation

`DISABLE_PULL_HOURLY=true pnpm test fees bonker 1788729000`

This 24-hour window contains a confirmed Robinhood Chain Bonker trade:

- Base fees: $5.31; protocol revenue: $0.89; supply-side revenue: $4.42
- Robinhood fees: $0.03; protocol revenue: $0.03; supply-side revenue: $0.00
- Aggregate fees: $5.34

The Robinhood protocol-fee event proves the hook path is being read. No matching `StoreTokens` event occurred in the tested window, so the supply-side value correctly remains zero rather than being estimated from the nominal fee ratio.

Also passed:

- `pnpm ts-check --pretty false`
- `git diff --check`
- No package or lockfile changes

## Draft status

Bonker has a successor Robinhood LP locker redeploy planned because the current locker's fee-conversion route is incompatible with this chain's forked Universal Router. Keep this PR in draft until the successor address is known; then append it to `lpLockers` without removing the historical locker and rerun the event test.