### PR TITLE
feat: add TRUE DEX (Solana perps) volume and fees

### DIFF
--- a/dexs/true-dex/index.ts
+++ b/dexs/true-dex/index.ts
@@ -2,13 +2,13 @@ import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { httpGet } from "../../utils/fetchURL";
 
-// TRUE DEX: perpetuals venue on Solana (https://app.truefinance.ai/perps).
-// Trades match on an off-chain sequencer and settle on Solana through a ZK
-// verifier program (ttaiNybR4ncnBFsBCQKdVus8BNHepErToRp5cuULduL), so there
-// are no per-trade on-chain logs to index. Daily aggregates come from the
-// project's public per-UTC-day endpoint, which is built from the venue trade
-// tape (one row per venue trade id); the same tape backs the live
-// https://dex-prod.truefinance.ai/v1/markets/stats volume_24h figure.
+// TRUE DEX: perpetuals venue (https://app.truefinance.ai/perps). Trades match
+// on an off-chain sequencer; only ZK-verified block roots settle on Solana
+// (verifier ttaiNybR4ncnBFsBCQKdVus8BNHepErToRp5cuULduL), so individual
+// trades are not Solana transactions and the volume is listed as off-chain.
+// Daily aggregates come from the project's public per-UTC-day endpoint, built
+// from the venue trade tape (one row per venue trade id); the same tape backs
+// the live https://dex-prod.truefinance.ai/v1/markets/stats volume_24h figure.
 const STATS_URL = "https://app.truefinance.ai/api/public/dex/stats";
 
 interface DayStats {
@@ -67,7 +67,9 @@ const adapter: SimpleAdapter = {
   // version 1: the project endpoint returns per-UTC-day aggregates only.
   version: 1,
   fetch,
-  chains: [CHAIN.SOLANA],
+  // Trades are not Solana transactions (see header); collateral custody is on
+  // Solana and is covered by the TVL adapter.
+  chains: [CHAIN.OFF_CHAIN],
   // First UTC day covered by the venue trade tape.
   start: "2026-08-23",
   methodology,

--- a/dexs/true-dex/index.ts
+++ b/dexs/true-dex/index.ts
@@ -1,0 +1,77 @@
+import { FetchOptions, SimpleAdapter } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { httpGet } from "../../utils/fetchURL";
+
+// TRUE DEX: perpetuals venue on Solana (https://app.truefinance.ai/perps).
+// Trades match on an off-chain sequencer and settle on Solana through a ZK
+// verifier program (ttaiNybR4ncnBFsBCQKdVus8BNHepErToRp5cuULduL), so there
+// are no per-trade on-chain logs to index. Daily aggregates come from the
+// project's public per-UTC-day endpoint, which is built from the venue trade
+// tape (one row per venue trade id); the same tape backs the live
+// https://dex-prod.truefinance.ai/v1/markets/stats volume_24h figure.
+const STATS_URL = "https://app.truefinance.ai/api/public/dex/stats";
+
+interface DayStats {
+  date: string;
+  volumeUsd: number;
+  feesUsd: number;
+  trades: number;
+  complete: boolean;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const data: DayStats = await httpGet(`${STATS_URL}?date=${options.dateString}`);
+  if (!data || data.date !== options.dateString) {
+    throw new Error(`TRUE DEX: no stats for ${options.dateString}`);
+  }
+
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+
+  // Taker volume only: one venue trade = one taker fill, both sides counted once.
+  dailyVolume.addUSDValue(data.volumeUsd);
+  // Per-market taker fee (fee_config.taker_fee_ppm, 0.1% on most markets) on
+  // that market's volume. Maker fees (0.02%) are excluded.
+  dailyFees.addUSDValue(data.feesUsd, "Perp Trading Fees");
+  dailyRevenue.addUSDValue(data.feesUsd, "Perp Trading Fees");
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Volume: "Taker volume of all perpetual fills on the TRUE DEX venue (one fill counted once), summed per UTC day from the venue trade tape.",
+  Fees: "Taker trading fees: each market's taker_fee_ppm (0.1% on most markets) applied to that market's volume. Maker fees are not charged to takers and are excluded.",
+  Revenue: "All trading fees are collected by the protocol. Partner commissions and trader fee rebates are paid from the treasury after the fact and are not netted here.",
+  ProtocolRevenue: "Same as Revenue: the protocol treasury receives all trading fees.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Perp Trading Fees": "Taker fees on perpetual fills.",
+  },
+  Revenue: {
+    "Perp Trading Fees": "Taker fees on perpetual fills, kept by the protocol treasury.",
+  },
+  ProtocolRevenue: {
+    "Perp Trading Fees": "Taker fees on perpetual fills, kept by the protocol treasury.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  // version 1: the project endpoint returns per-UTC-day aggregates only.
+  version: 1,
+  fetch,
+  chains: [CHAIN.SOLANA],
+  // First UTC day covered by the venue trade tape.
+  start: "2026-08-23",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;


### PR DESCRIPTION
Adds TRUE DEX, a perpetuals exchange on Solana (orders match on a sequencer, every block settles on-chain through a ZK verifier program). Website: https://app.truefinance.ai/perps . Twitter: https://x.com/truetradingai . TVL adapter submitted separately to DefiLlama-Adapters (Category: Derivatives).

**Data source.** Trades match off-chain and settle on Solana as ZK-verified blocks, so there are no per-trade on-chain logs to index. The adapter reads the project's public per-UTC-day endpoint `https://app.truefinance.ai/api/public/dex/stats?date=YYYY-MM-DD`, built from the venue trade tape (one row per venue trade id). The same tape backs the live `volume_24h` at https://dex-prod.truefinance.ai/v1/markets/stats?market=BTCUSDC , which cross-checks it (BTC 24h: 19.61M venue vs 19.69M tape at the time of writing). The endpoint returns the methodology and a per-market breakdown; `version: 1` because it only returns daily aggregates. Backfill from 2026-08-23 (first day of the tape).

**Dimensions.** `dailyVolume` = taker volume (one fill counted once). `dailyFees` = each market's taker fee (`fee_config.taker_fee_ppm`, 0.1% on most markets) on that market's volume; maker fees excluded. `dailyRevenue` = `dailyProtocolRevenue` = fees (all trading fees go to the protocol; partner commissions and trader rebates are paid from treasury after the fact and not netted).

**Test** (`npm test dexs true-dex 2026-09-05`):
```
SOLANA
Backfill start time: 23/8/2026
Daily volume: 39.53 M
Daily fees: 39.53 k
Daily revenue: 39.53 k
Daily protocol revenue: 39.53 k
Perp Trading Fees | 39527 | 39527
```
