### PR TITLE
uniswap: filterPools should not call balanceOf on the zero address, and should retry before it counts a failure

### DIFF
--- a/helpers/uniswap.ts
+++ b/helpers/uniswap.ts
@@ -102,11 +102,18 @@ export async function getEstablishedTokens(chain: string, tokens: string[]): Pro
 // reporting a mostly-failed batch of pools as legitimately empty. See PR #8565 for the
 // original all-or-nothing precedent this threshold replaces.
 const MAX_FAILED_BALANCE_CALL_RATIO = 0.1
+const MAX_BALANCE_CALL_RETRIES = 2
 
 export async function filterPools({ api, pairs, createBalances, maxPairSize = 42, minUSDValue = 200 }: { api: ChainApi, pairs: IJSON<string[]>, createBalances: any, maxPairSize?: number, minUSDValue?: number }): Promise<IJSON<number>> {
-  const balanceCalls = Object.entries(pairs).map(([pair, tokens]) => tokens.map(i => ({ target: i, params: pair }))).flat()
+  const balanceCalls = Object.entries(pairs).map(([pair, tokens]) => tokens.filter((i) => i !== ZERO_ADDRESS).map(i => ({ target: i, params: pair }))).flat()
   const res = await api.multiCall({ abi: 'erc20:balanceOf', calls: balanceCalls, permitFailure: true, })
-  const failedCalls = res.filter((bal) => bal == null).length
+  let failedIndices = res.map((bal, i) => bal == null ? i : -1).filter((i) => i > -1)
+  for (let attempt = 0; attempt < MAX_BALANCE_CALL_RETRIES && failedIndices.length; attempt++) {
+    const retried = await api.multiCall({ abi: 'erc20:balanceOf', calls: failedIndices.map((i) => balanceCalls[i]), permitFailure: true, })
+    retried.forEach((bal, j) => { if (bal != null) res[failedIndices[j]] = bal })
+    failedIndices = failedIndices.filter((_, j) => retried[j] == null)
+  }
+  const failedCalls = failedIndices.length
   if (balanceCalls.length && failedCalls / balanceCalls.length > MAX_FAILED_BALANCE_CALL_RATIO)
     throw new Error(`filterPools: ${failedCalls}/${balanceCalls.length} pooled balance calls failed on ${api.chain}, refusing to report ${Object.keys(pairs).length} pools as (partly) empty`)
   const balances: Balances = createBalances()


### PR DESCRIPTION
Fixes #9299.

klayswap-v1, mimo-v2 and dswap all published their last point on 09-03, the day #9140 merged, and
all three throw its guard. Two changes, independent of each other, both in `filterPools`:

**1. Do not call `balanceOf` on the zero address.** On klaytn every single one of the 260 failures
is that call:

```
klaytn  calls 1246  failed 260 (20.9%)  distinct failing targets: 1
        [["0x0000000000000000000000000000000000000000", 260]]
        retry of the failed set: 260 still null of 260
```

130 of klayswap's cached pairs carry a native-KLAY leg stored as `address(0)`. That call cannot
succeed on any rpc, so the ratio sits permanently over the threshold and the adapter can never
publish again. Before #9140 those nulls fell through `add(target, bal ?? 0)` and the pair was
weighed on its other leg, which is exactly what skipping the call restores.

**2. Retry the failed calls before measuring the ratio.** mimo failed 439/1338 (32.8%) on one run
and 1/1338 on a re-probe a minute later, a transient burst, not a degraded chain. Retrying only the
failed calls is what separates that from a chain that is actually down.

## verification

| adapter | chain | master | this branch |
|---|---|---|---|
| klayswap | klaytn | `260/1246 pooled balance calls failed` | Daily volume: 12.08 k |
| mimo | iotex | `439/1338 pooled balance calls failed` | Daily volume: 3.85 k |
| daoaas-swap | eni | `619/1032 pooled balance calls failed` | `214/1032`, still throws |

ENI is left throwing on purpose. Its failures spread across 147 distinct token contracts and stay
at ~20% after two retries, so that is the guard doing its job rather than a false positive.

Control, so this is not just "the guard stopped firing": klayswap for **09-02**, a day DefiLlama
published under the pre-#9140 code, reads **12.57 k** on this branch against **12,448** published, 
1.0% apart. 09-04 reads 12.08 k on two separate runs. `npx tsc --noEmit` is clean.
