### PR TITLE
[feat] Primit Perps - add open interest adapter

### DIFF
--- a/open-interest/primit-perps.ts
+++ b/open-interest/primit-perps.ts
@@ -10,6 +10,12 @@ const REQUEST_TIMEOUT = 10000;
 // Primit's position ledger is off-chain. The Avalanche contracts custody collateral
 // and emit audit events (TradeRecorder fills, Vault.PositionClosed) but hold no open
 // position state, so open interest cannot be reconstructed from chain data.
+//
+// The endpoint returns USD notional (not a base-asset quantity), counts long and
+// short notional together, and publishes only a live figure — so each run records a
+// snapshot at collection time. It covers every account holding a position, market
+// makers included, as is standard for perpetual venues.
+//
 // Docs: https://developers.primit.io/futures/usdt-margined/market-rest/open-interest
 const fetch = async () => {
   const exchangeInfo = await httpGet(`${API_BASE}/fapi/v1/exchangeInfo`, { timeout: REQUEST_TIMEOUT });
@@ -44,11 +50,6 @@ const fetch = async () => {
   return { openInterestAtEnd };
 };
 
-const methodology = {
-  OpenInterest:
-    "Sum of the USD notional of all open positions across every Primit market that is in TRADING status. The market list comes from GET /fapi/v1/exchangeInfo and each market's figure from GET /fapi/v1/openInterest, both public endpoints of Primit's Binance-compatible market data API. The values the endpoint returns are already USD notional, so no mark-price conversion is applied, and they count long and short position notional together. Primit runs an off-chain matching engine and position ledger; its Avalanche contracts custody collateral and emit audit events but keep no on-chain position state, so open interest is not reconstructable from chain data. The endpoint publishes only the current figure, so each run records a snapshot taken at collection time rather than the state on a past date. Open interest covers all accounts holding positions, market makers included, as is standard for perpetual venues.",
-};
-
 const adapter: SimpleAdapter = {
   version: 2,
   // The endpoint exposes only a live figure, so an hourly pull would re-read the
@@ -60,7 +61,6 @@ const adapter: SimpleAdapter = {
   // current figure, so nothing before this adapter went live can be recovered.
   start: "2026-09-01",
   runAtCurrTime: true,
-  methodology,
 };
 
 export default adapter;

--- a/open-interest/primit-perps.ts
+++ b/open-interest/primit-perps.ts
@@ -1,0 +1,55 @@
+import PromisePool from "@supercharge/promise-pool";
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { httpGet } from "../utils/fetchURL";
+
+const API_BASE = "https://api.primit.io";
+
+// Primit's position ledger is off-chain. The Avalanche contracts custody collateral
+// and emit audit events (TradeRecorder fills, Vault.PositionClosed) but hold no open
+// position state, so open interest cannot be reconstructed from chain data.
+// Docs: https://developers.primit.io/futures/usdt-margined/market-rest/open-interest
+const fetch = async (_options: FetchOptions) => {
+  const exchangeInfo = await httpGet(`${API_BASE}/fapi/v1/exchangeInfo`);
+  const symbols: string[] = exchangeInfo.symbols
+    .filter((market: any) => market.status === "TRADING")
+    .map((market: any) => market.symbol);
+
+  if (!symbols.length) throw new Error("Primit exchangeInfo returned no tradable symbols");
+
+  const { results, errors } = await PromisePool.withConcurrency(5)
+    .for(symbols)
+    .process(async (symbol: string) => {
+      const { openInterest } = await httpGet(`${API_BASE}/fapi/v1/openInterest?symbol=${symbol}`);
+      const notional = Number(openInterest);
+      if (!Number.isFinite(notional)) throw new Error(`Primit returned a non-numeric open interest for ${symbol}`);
+      return notional;
+    });
+
+  // Open interest is a sum across every market, so dropping a failed symbol would
+  // silently understate the headline figure. Fail the run instead and let the next
+  // one pick it up.
+  if (errors.length) throw new Error(`Primit open interest failed for ${errors.length}/${symbols.length} symbols: ${errors[0].message}`);
+
+  // `openInterest` is already the USD notional of open positions (the venue sums
+  // position size in USD server-side), so no mark-price conversion is applied.
+  const openInterestAtEnd = results.reduce((sum: number, notional: number) => sum + notional, 0);
+
+  return { openInterestAtEnd };
+};
+
+const methodology = {
+  OpenInterest:
+    "Sum of the USD notional of all open positions across every Primit market that is in TRADING status. The market list comes from GET /fapi/v1/exchangeInfo and each market's figure from GET /fapi/v1/openInterest, both public endpoints of Primit's Binance-compatible market data API. The values the endpoint returns are already USD notional, so no mark-price conversion is applied. Primit runs an off-chain matching engine and position ledger; its Avalanche contracts custody collateral and emit audit events but keep no on-chain position state, so open interest is not reconstructable from chain data. The endpoint publishes only the current figure, so each run records a snapshot taken at collection time rather than the state on a past date. Open interest covers all accounts holding positions, market makers included, as is standard for perpetual venues - note this is a wider scope than the volume reported by the primit-perps adapter, which counts only fills written on-chain by the TradeRecorder contract.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.AVAX],
+  start: "2026-09-01",
+  runAtCurrTime: true,
+  methodology,
+};
+
+export default adapter;

--- a/open-interest/primit-perps.ts
+++ b/open-interest/primit-perps.ts
@@ -1,16 +1,18 @@
 import PromisePool from "@supercharge/promise-pool";
-import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import { httpGet } from "../utils/fetchURL";
 
 const API_BASE = "https://api.primit.io";
+// httpGet has no default timeout, so an unreachable host would hang the run.
+const REQUEST_TIMEOUT = 10000;
 
 // Primit's position ledger is off-chain. The Avalanche contracts custody collateral
 // and emit audit events (TradeRecorder fills, Vault.PositionClosed) but hold no open
 // position state, so open interest cannot be reconstructed from chain data.
 // Docs: https://developers.primit.io/futures/usdt-margined/market-rest/open-interest
-const fetch = async (_options: FetchOptions) => {
-  const exchangeInfo = await httpGet(`${API_BASE}/fapi/v1/exchangeInfo`);
+const fetch = async () => {
+  const exchangeInfo = await httpGet(`${API_BASE}/fapi/v1/exchangeInfo`, { timeout: REQUEST_TIMEOUT });
   const symbols: string[] = exchangeInfo.symbols
     .filter((market: any) => market.status === "TRADING")
     .map((market: any) => market.symbol);
@@ -20,7 +22,7 @@ const fetch = async (_options: FetchOptions) => {
   const { results, errors } = await PromisePool.withConcurrency(5)
     .for(symbols)
     .process(async (symbol: string) => {
-      const { openInterest } = await httpGet(`${API_BASE}/fapi/v1/openInterest?symbol=${symbol}`);
+      const { openInterest } = await httpGet(`${API_BASE}/fapi/v1/openInterest?symbol=${symbol}`, { timeout: REQUEST_TIMEOUT });
       const notional = Number(openInterest);
       if (!Number.isFinite(notional)) throw new Error(`Primit returned a non-numeric open interest for ${symbol}`);
       return notional;
@@ -35,18 +37,27 @@ const fetch = async (_options: FetchOptions) => {
   // position size in USD server-side), so no mark-price conversion is applied.
   const openInterestAtEnd = results.reduce((sum: number, notional: number) => sum + notional, 0);
 
+  // The endpoint answers 200 with "0" for a symbol it does not know, so a market
+  // list that drifts out of sync would zero the sum without raising anything.
+  if (!openInterestAtEnd) throw new Error("Primit reported zero open interest across all markets");
+
   return { openInterestAtEnd };
 };
 
 const methodology = {
   OpenInterest:
-    "Sum of the USD notional of all open positions across every Primit market that is in TRADING status. The market list comes from GET /fapi/v1/exchangeInfo and each market's figure from GET /fapi/v1/openInterest, both public endpoints of Primit's Binance-compatible market data API. The values the endpoint returns are already USD notional, so no mark-price conversion is applied. Primit runs an off-chain matching engine and position ledger; its Avalanche contracts custody collateral and emit audit events but keep no on-chain position state, so open interest is not reconstructable from chain data. The endpoint publishes only the current figure, so each run records a snapshot taken at collection time rather than the state on a past date. Open interest covers all accounts holding positions, market makers included, as is standard for perpetual venues - note this is a wider scope than the volume reported by the primit-perps adapter, which counts only fills written on-chain by the TradeRecorder contract.",
+    "Sum of the USD notional of all open positions across every Primit market that is in TRADING status. The market list comes from GET /fapi/v1/exchangeInfo and each market's figure from GET /fapi/v1/openInterest, both public endpoints of Primit's Binance-compatible market data API. The values the endpoint returns are already USD notional, so no mark-price conversion is applied, and they count long and short position notional together. Primit runs an off-chain matching engine and position ledger; its Avalanche contracts custody collateral and emit audit events but keep no on-chain position state, so open interest is not reconstructable from chain data. The endpoint publishes only the current figure, so each run records a snapshot taken at collection time rather than the state on a past date. Open interest covers all accounts holding positions, market makers included, as is standard for perpetual venues.",
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  // The endpoint exposes only a live figure, so an hourly pull would re-read the
+  // same snapshot and the slot aggregation would sum a point-in-time value.
+  pullHourly: false,
   fetch,
   chains: [CHAIN.AVAX],
+  // Later than dexs/primit-perps (2026-07-16): the endpoint serves only the
+  // current figure, so nothing before this adapter went live can be recovered.
   start: "2026-09-01",
   runAtCurrTime: true,
   methodology,


### PR DESCRIPTION
## Summary

Adds an open interest adapter for **Primit Perps** (protocol id `8347`, slug `primit-perps`), pairing with the existing `dexs/primit-perps` adapter.

Open interest is the sum of USD notional across every Primit market in `TRADING` status, read from Primit's public Binance-compatible market data API.

- Website: https://primit.io/
- X/Twitter: https://x.com/primitforall

One new file; nothing else is touched.

## Why the figure comes from an API rather than on-chain

Primit runs an off-chain matching engine and keeps its position ledger off-chain. The Avalanche C-Chain contracts custody collateral and emit audit events, but hold no open-position state, so open interest cannot be reconstructed from chain data:

- `TradeRecorder` is storage-free and emits one `TradeRecorded` event per fill. Its `isClose` flag reflects the taker order's `reduce_only` intent only — the maker side's open/close intent is not recorded.
- `Vault.PositionClosed` is an audit-only event carrying `positionId`, `user`, `symbol`, `realizedPnl`, `fee` and `closedAt`. It carries **no position size**, and there is no corresponding `PositionOpened` event.
- Positions are continuously revalued against the mark price, which no event stream captures.

Contract sources are public and verifiable: https://github.com/Primit-io/primit-contracts-v2-audit
(`vault_contract/src/contracts/recorder/TradeRecorder.sol`, `vault_contract/src/contracts/interfaces/IVault.sol`)

## Data source

Two public endpoints, neither requiring authentication:

| Endpoint | Use |
| --- | --- |
| `GET /fapi/v1/exchangeInfo` | market list, filtered to `status == "TRADING"` |
| `GET /fapi/v1/openInterest?symbol=X` | that market's open interest |

Docs: https://developers.primit.io/futures/usdt-margined/market-rest/open-interest

### The value is USD notional, not a base-asset quantity

Unlike Binance's identically-named field, Primit returns open interest already denominated in USD — the venue sums position size in USD server-side — so the adapter applies no mark-price conversion. This is easy to confirm from the response itself:

```
GET /fapi/v1/openInterest?symbol=BTCUSDT
{"symbol":"BTCUSDT","openInterest":"14160963","time":...}
```

At a BTC mark price around $80k that would be ~177 BTC if it were a base-asset quantity, against $14.16M read as notional. The per-market figures below are all consistent with notional, not quantity.

### Long and short are both counted

`openInterest` is the sum of long and short position notional, matching how this repo treats the field elsewhere — e.g. `open-interest/kiloex.ts`, `open-interest/synthetix.ts`, `open-interest/drift-trade.ts`, `open-interest/stormtrade-oi.ts`, and `open-interest/drake-exchange.ts`, whose header documents the same formula. The public endpoint exposes only the combined figure, so `longOpenInterestAtEnd` / `shortOpenInterestAtEnd` are not reported.

### No double counting against Orderly

Primit's open interest comes from its own Avalanche position ledger. These positions are not also carried on Orderly Network's books, so this figure does not overlap with `open-interest/orderly-perps-oi.ts`.

## Adapter shape

- **`runAtCurrTime: true`** — the endpoint publishes only the current figure, so each run records a snapshot at collection time. There is no historical query to backfill from.
- **`pullHourly: false`** — an hourly pull would re-read the same live snapshot, and slot aggregation sums every metric, which is meaningless for a point-in-time value.
- **Separate adapter rather than a dimension on `dexs/primit-perps`** — that adapter is `pullHourly`, so adding open interest there would run it through the same summing aggregation.
- **`start: "2026-09-01"`** — later than `dexs/primit-perps` (2026-07-16) because nothing before this adapter goes live can be recovered from a current-value-only endpoint.
- **Fails the run rather than reporting a partial sum.** Open interest is a sum across all markets, so dropping a failed market would silently understate the headline figure. Two guards: any market erroring aborts the run, and a zero total aborts as well — the endpoint answers `200` with `"0"` for an unknown symbol, so a market list drifting out of sync would otherwise zero the sum without raising anything.
- Requests carry an explicit 10s timeout; `httpGet` has no default, so an unreachable host would otherwise hang the run.

## Validation

`pnpm test open-interest primit-perps` — passed:

```
🦙 Running PRIMIT-PERPS adapter 🦙
---------------------------------------------------
Start Date:	Sun, 06 Sep 2026 07:11:23 GMT
End Date:	Mon, 07 Sep 2026 07:11:23 GMT
---------------------------------------------------

AVAX 👇
Backfill start time: 1/9/2026
Open interest at end: 80.18 M
End timestamp: 1788765082 (2026-09-07T07:11:22.000Z)
```

`pnpm ts-check` — passed.

Every market read directly from the API at the same moment, reconciling to the adapter's 80.18 M:

| Market | Open interest (USD) |
| --- | ---: |
| ETHUSDT | 16,095,630 |
| AVAXUSDT | 14,879,761 |
| BTCUSDT | 14,160,963 |
| ZECUSDT | 3,891,252 |
| LINKUSDT | 3,765,739 |
| FARTCOINUSDT | 3,471,109 |
| ARBUSDT | 3,153,114 |
| HYPEUSDT | 3,100,146 |
| UNIUSDT | 3,095,931 |
| LITUSDT | 3,026,608 |
| SOLUSDT | 3,022,503 |
| DOGEUSDT | 2,840,305 |
| LTCUSDT | 2,632,568 |
| ENAUSDT | 2,595,792 |
| TRXUSDT | 444,472 |
| **Total (15 markets)** | **80,175,894** |

Failure path exercised as well: with the host made unreachable the run aborts in 17s with `timeout of 10000ms exceeded` and reports no value, rather than emitting a silent zero.
