### PR TITLE
Fix Pennysia volume: Settlement indexer + CoW/UniswapX/Velora tagging

### DIFF
--- a/aggregators/pennysia/index.ts
+++ b/aggregators/pennysia/index.ts
@@ -1,6 +1,9 @@
+import { ethers } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
+import { getTransactionsWithRetry } from "../../helpers/getTxReceipts";
+import { httpGet } from "../../utils/fetchURL";
 
 // PennysiaSettlement on Ethereum Mainnet
 // https://etherscan.io/address/0x3Aad97E5a91b8e43b7Dc830aCEb004307678795E
@@ -8,11 +11,11 @@ const SETTLEMENT = "0x3Aad97E5a91b8e43b7Dc830aCEb004307678795E";
 // Default NEXT_PUBLIC_INTENT_FEE_BPS. Used only to invert UniswapX fee outputs
 // back to quoted output volume (fee = output * bps / 10000).
 const INTENT_FEE_BPS = 50n;
+// CoW CIP-75 withholds 25% of partner fees before the weekly payout.
+const COW_RETAINED_BPS = 75n;
 
 const COW_SETTLEMENT = "0x9008D19f58AAbD9eD0D60971565AA8510560ab41";
-const COW_VAULT_RELAYER = "0xC92E8bdf79f0507f65a392b0ab4667716BFE0110";
 const VELORA_DELTA = "0x0000000000bbF5c5Fd284e657F01Bd000933C96D";
-// UniswapX reactors on Ethereum (UNISWAPX_V2 quotes settle on V2; include Exclusive + V3)
 const UNISWAPX_REACTORS = [
   "0x00000011F84B9aa48e5f8aA8B9897600006289Be", // V2 Dutch
   "0x6000da47483062A0D734Ba3dc7576Ce6A0B645C4", // Exclusive Dutch
@@ -34,6 +37,10 @@ const uniswapxFillEvent =
 const veloraSettledEvent =
   "event OrderSettled(address indexed owner, address indexed beneficiary, uint8 kind, address srcToken, address destToken, uint256 srcAmount, uint256 destAmount, uint256 returnAmount, uint256 protocolFee, uint256 partnerFee, bytes32 indexed orderHash)";
 
+const cowIface = new ethers.Interface([
+  "function settle(address[] tokens, uint256[] clearingPrices, (uint256 sellTokenIndex, uint256 buyTokenIndex, address receiver, uint256 sellAmount, uint256 buyAmount, uint32 validTo, bytes32 appData, uint256 feeAmount, uint256 flags, uint256 executedAmount, bytes signature)[] trades, (address target, uint256 value, bytes callData)[][3] interactions)",
+]);
+
 const SETTLEMENT_FEE = "Settlement Fees";
 const INTENT_FEE = "Intent Fees";
 
@@ -49,6 +56,8 @@ type PartnerTransfer = {
   value: any;
   used: boolean;
 };
+
+type CowPartner = { recipient: string; bps: bigint };
 
 function addAmount(balances: any, token: string, amount: any, label?: string) {
   if (!token || amount == null) return;
@@ -97,6 +106,7 @@ function takePartnerFee(
   tx: string,
   tokens?: Set<string>,
   froms?: Set<string>,
+  strictFroms = false,
 ): PartnerTransfer | undefined {
   const unused = transfers.filter((t) => !t.used && t.tx === tx);
   const match = (pool: PartnerTransfer[]) => {
@@ -107,6 +117,7 @@ function takePartnerFee(
   if (froms) {
     const strict = match(unused.filter((t) => froms.has(t.from)));
     if (strict) return strict;
+    if (strictFroms) return undefined;
   }
   return match(unused);
 }
@@ -126,6 +137,7 @@ async function feeRecipientsInWindow(options: FetchOptions): Promise<string[]> {
     target: SETTLEMENT,
     eventAbi: feeRecipientUpdatedEvent,
     entireLog: true,
+    skipIndexer: true,
   });
   for (const log of updates) {
     const recipient = argsOf(log).recipient;
@@ -151,6 +163,105 @@ async function loadPartnerTransfers(
   return all;
 }
 
+function cowPartnerFromAppData(fullAppData: any): CowPartner | undefined {
+  let doc = fullAppData;
+  if (typeof fullAppData === "string") {
+    try {
+      doc = JSON.parse(fullAppData);
+    } catch {
+      return;
+    }
+  }
+  const raw = doc?.metadata?.partnerFee;
+  const items = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  for (const item of items) {
+    const recipient = asAddr(
+      item?.recipient || item?.volume?.recipient || item?.surplus?.recipient,
+    );
+    const bps = BigInt(
+      item?.bps ??
+        item?.volumeBps ??
+        item?.volume_bps ??
+        item?.volume?.volumeBps ??
+        0,
+    );
+    if (recipient && recipient !== "0x" && bps > 0n) return { recipient, bps };
+  }
+}
+
+const cowAppDataCache = new Map<string, CowPartner | null>();
+
+async function resolveCowAppData(appData: string): Promise<CowPartner | undefined> {
+  const hash = String(appData || "").toLowerCase();
+  if (!hash.startsWith("0x") || hash === "0x" + "00".repeat(32)) return;
+  if (cowAppDataCache.has(hash)) return cowAppDataCache.get(hash) || undefined;
+  try {
+    const res = await httpGet(`https://api.cow.fi/mainnet/api/v1/app_data/${hash}`);
+    const partner = cowPartnerFromAppData(res?.fullAppData ?? res);
+    cowAppDataCache.set(hash, partner ?? null);
+    return partner;
+  } catch {
+    cowAppDataCache.set(hash, null);
+  }
+}
+
+async function cowTradesFromSettleTxs(
+  options: FetchOptions,
+  cowTradeLogs: any[],
+  recipients: Set<string>,
+) {
+  const logsByTx = new Map<string, any[]>();
+  for (const log of cowTradeLogs) {
+    const tx = txHash(log);
+    if (!tx) continue;
+    const list = logsByTx.get(tx) || [];
+    list.push(log);
+    logsByTx.set(tx, list);
+  }
+  const unique = [...logsByTx.keys()];
+  if (!unique.length) {
+    return [] as { sellToken: string; sellAmount: any; buyToken: string; buyAmount: any; bps: bigint }[];
+  }
+  const txs = await getTransactionsWithRetry(options.chain, unique);
+  const out: { sellToken: string; sellAmount: any; buyToken: string; buyAmount: any; bps: bigint }[] = [];
+  for (const tx of txs) {
+    if (!tx) continue;
+    const data = (tx as any).data || (tx as any).input;
+    if (!data) continue;
+    let decoded: ethers.TransactionDescription | null = null;
+    try {
+      decoded = cowIface.parseTransaction({ data });
+    } catch {
+      continue;
+    }
+    if (!decoded || decoded.name !== "settle") continue;
+    const hash = String(tx.hash || "").toLowerCase();
+    const unused = (logsByTx.get(hash) || []).map((log) => ({ log, used: false }));
+    const tokens: string[] = decoded.args.tokens.map(asAddr);
+    for (const trade of decoded.args.trades) {
+      const partner = await resolveCowAppData(trade.appData);
+      if (!partner || !recipients.has(partner.recipient)) continue;
+      const sellToken = tokens[Number(trade.sellTokenIndex)];
+      const executed = BigInt(trade.executedAmount);
+      const hit = unused.find((row) => {
+        if (row.used) return false;
+        const a = argsOf(row.log);
+        return asAddr(a.sellToken) === sellToken && BigInt(a.sellAmount) === executed;
+      });
+      if (hit) hit.used = true;
+      const a = hit ? argsOf(hit.log) : undefined;
+      out.push({
+        sellToken,
+        buyToken: a ? asAddr(a.buyToken) : tokens[Number(trade.buyTokenIndex)],
+        sellAmount: a?.sellAmount ?? trade.executedAmount,
+        buyAmount: a?.buyAmount ?? trade.buyAmount,
+        bps: partner.bps,
+      });
+    }
+  }
+  return out;
+}
+
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
@@ -163,6 +274,8 @@ const fetch = async (options: FetchOptions) => {
     addAmount(dailyRevenue, token, amount, label);
     addAmount(dailyProtocolRevenue, token, amount, label);
   };
+
+  const recipients = new Set(await feeRecipientsInWindow(options));
 
   const swapLogs = await options.getLogs({
     target: SETTLEMENT,
@@ -183,40 +296,38 @@ const fetch = async (options: FetchOptions) => {
     addRetainedFee(log.token, log.amount, SETTLEMENT_FEE);
   }
 
-  // Incoming ERC-20 to the active Settlement fee recipient(s) tags CoW /
-  // UniswapX / Velora hard intents (partnerAddress + partnerFeeBps).
-  // extraTopics[1] is Transfer `to`, so this is not a full-chain scan.
-  const partnerTransfers = await loadPartnerTransfers(
-    options,
-    await feeRecipientsInWindow(options),
-  );
+  // Incoming ERC-20 to the active Settlement fee recipient tags UniswapX /
+  // Velora fills (partner fee is paid in the fill transaction).
+  const partnerTransfers = await loadPartnerTransfers(options, [...recipients]);
 
-  const cowTrades = await options.getLogs({
+  const cowTradeLogs = await options.getLogs({
     target: COW_SETTLEMENT,
     eventAbi: cowTradeEvent,
     entireLog: true,
   });
-  const cowFroms = new Set([COW_SETTLEMENT, COW_VAULT_RELAYER].map(asAddr));
-  for (const log of cowTrades) {
-    const a = argsOf(log);
-    const fee = takePartnerFee(
-      partnerTransfers,
-      txHash(log),
-      new Set([asAddr(a.buyToken), asAddr(a.sellToken)]),
-      cowFroms,
-    );
-    if (!fee) continue;
-    addAmount(dailyVolume, a.sellToken, a.sellAmount);
-    // Receipts at the Settlement fee recipient are already Pennysia's share.
-    // CIP-75's 25% CoW service fee is withheld before payout and never
-    // appears in these logs.
-    addRetainedFee(fee.token, fee.value, INTENT_FEE);
+  const cowDecoded = await cowTradesFromSettleTxs(
+    options,
+    cowTradeLogs,
+    recipients,
+  );
+  for (const trade of cowDecoded) {
+    addAmount(dailyVolume, trade.sellToken, trade.sellAmount);
+    const gross = BigInt(trade.buyAmount) * trade.bps / 10000n;
+    const retained = gross * COW_RETAINED_BPS / 100n;
+    const cowShare = gross - retained;
+    addAmount(dailyFees, trade.buyToken, gross, INTENT_FEE);
+    addAmount(dailyRevenue, trade.buyToken, retained, INTENT_FEE);
+    addAmount(dailyProtocolRevenue, trade.buyToken, retained, INTENT_FEE);
+    if (cowShare > 0n) {
+      addAmount(dailySupplySideRevenue, trade.buyToken, cowShare, INTENT_FEE);
+    }
   }
 
   const veloraSettled = await options.getLogs({
     target: VELORA_DELTA,
     eventAbi: veloraSettledEvent,
     entireLog: true,
+    skipIndexer: true,
   });
   const veloraFroms = new Set([VELORA_DELTA].map(asAddr));
   for (const log of veloraSettled) {
@@ -249,6 +360,7 @@ const fetch = async (options: FetchOptions) => {
       txHash(log),
       undefined,
       new Set([asAddr(log.address), asAddr(a.filler)]),
+      true,
     );
     if (!fee) continue;
     addRetainedFee(fee.token, fee.value, INTENT_FEE);
@@ -266,13 +378,13 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Volume:
-    "Pennysia-routed volume only (not inner DEX swaps): sell-token input from SwapExecuted on Settlement, plus each hard-intent fill that has a matching fee-output Transfer to the Settlement fee recipient (CoW Trade.sellAmount, Velora Delta OrderSettled.srcAmount, UniswapX Fill output inferred as that fee × 10000 / 50).",
+    "Pennysia-routed volume only (not inner DEX swaps): sell-token input from SwapExecuted on Settlement (SYNC and SODAX opens), CoW GPv2 settle trades whose appData partnerFee.recipient is the Settlement fee recipient, Velora Delta OrderSettled.srcAmount when a partner-fee Transfer hits that recipient, and UniswapX Fill output inferred as that fee × 10000 / 50.",
   Fees:
-    "Settlement FeeCollected (SYNC surplus capped at 10% of gross, leftover token/ETH sweeps, and gas markup on extra executeSwap msg.value) and the matched hard-intent partner-fee Transfer (Velora uses OrderSettled.partnerFee when present). No FeeCollected on SODAX intent opens. Hard intents have no Settlement gas markup.",
+    "Settlement FeeCollected (SYNC surplus capped at 10% of gross, leftover token/ETH sweeps, and gas markup on extra executeSwap msg.value); CoW partner fee on executed buy at the order's partner bps (CIP-75: 75% protocol / 25% CoW); Velora OrderSettled.partnerFee or the matched Transfer; UniswapX fee-output Transfer. No FeeCollected on SODAX intent opens.",
   Revenue:
-    "Pennysia retains 100% of Settlement FeeCollected and of hard-intent partner-fee receipts at the Settlement fee recipient. UniswapX fee outputs and Velora Delta partner fees are paid in full to that address. CoW CIP-75's 25% service fee is withheld before payout, so it is not in these logs and is not counted as supply-side here.",
-  ProtocolRevenue: "All retained amounts go to the Settlement fee recipient.",
-  SupplySideRevenue: "None on these logs. CoW's off-chain service fee does not arrive at the Settlement fee recipient.",
+    "Pennysia retains 100% of Settlement FeeCollected, UniswapX fee outputs, and Velora partner fees at the Settlement fee recipient. CoW protocol revenue is 75% of the partner fee; CIP-75's 25% is supply-side.",
+  ProtocolRevenue: "All retained amounts go to the Settlement fee recipient, except CoW's 25% service fee.",
+  SupplySideRevenue: "CoW CIP-75 25% service fee on Pennysia-tagged CoW trades. UniswapX and Velora partner fees are paid in full to Pennysia.",
 };
 
 const breakdownMethodology = {
@@ -280,15 +392,18 @@ const breakdownMethodology = {
     [SETTLEMENT_FEE]:
       "FeeCollected on Settlement: surplus above the quoted output (capped at 10% of gross), leftover token/ETH sweeps, and gas markup (extra ETH on executeSwap msg.value). ETH↔WETH wrap/unwrap leftover is transferred without FeeCollected and is not in this bucket.",
     [INTENT_FEE]:
-      "Matched partner-fee Transfer (or Velora OrderSettled.partnerFee) to the active Settlement feeRecipient() on CoW, UniswapX, and Velora Delta fills.",
+      "CoW: partner bps on executed buy from appData (tagged by Settlement feeRecipient). UniswapX / Velora: matched partner-fee Transfer (or Velora OrderSettled.partnerFee) in the fill transaction.",
   },
   Revenue: {
     [SETTLEMENT_FEE]: "Pennysia retains 100% of FeeCollected (surplus, leftover sweeps, and gas markup).",
-    [INTENT_FEE]: "Pennysia retains 100% of partner-fee receipts at the Settlement fee recipient.",
+    [INTENT_FEE]: "UniswapX / Velora: 100% of the fill-tx partner fee. CoW: 75% after CIP-75.",
   },
   ProtocolRevenue: {
     [SETTLEMENT_FEE]: "Collected amounts are sent to the Settlement fee recipient.",
-    [INTENT_FEE]: "Matched hard-intent partner fees are sent to the Settlement fee recipient.",
+    [INTENT_FEE]: "Matched hard-intent partner fees except CoW's 25% service fee.",
+  },
+  SupplySideRevenue: {
+    [INTENT_FEE]: "CoW CIP-75 25% withheld from the partner fee before payout.",
   },
 };
 

--- a/aggregators/pennysia/index.ts
+++ b/aggregators/pennysia/index.ts
@@ -1,9 +1,7 @@
-import { ethers } from "ethers";
 import { FetchOptions, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import ADDRESSES from "../../helpers/coreAssets.json";
-import { getTransactionsWithRetry } from "../../helpers/getTxReceipts";
-import { httpGet } from "../../utils/fetchURL";
+import { httpPost } from "../../utils/fetchURL";
 
 // PennysiaSettlement on Ethereum Mainnet
 // https://etherscan.io/address/0x3Aad97E5a91b8e43b7Dc830aCEb004307678795E
@@ -36,10 +34,6 @@ const uniswapxFillEvent =
   "event Fill(bytes32 indexed orderHash, address indexed filler, address indexed swapper, uint256 nonce)";
 const veloraSettledEvent =
   "event OrderSettled(address indexed owner, address indexed beneficiary, uint8 kind, address srcToken, address destToken, uint256 srcAmount, uint256 destAmount, uint256 returnAmount, uint256 protocolFee, uint256 partnerFee, bytes32 indexed orderHash)";
-
-const cowIface = new ethers.Interface([
-  "function settle(address[] tokens, uint256[] clearingPrices, (uint256 sellTokenIndex, uint256 buyTokenIndex, address receiver, uint256 sellAmount, uint256 buyAmount, uint32 validTo, bytes32 appData, uint256 feeAmount, uint256 flags, uint256 executedAmount, bytes signature)[] trades, (address target, uint256 value, bytes callData)[][3] interactions)",
-]);
 
 const SETTLEMENT_FEE = "Settlement Fees";
 const INTENT_FEE = "Intent Fees";
@@ -189,74 +183,29 @@ function cowPartnerFromAppData(fullAppData: any): CowPartner | undefined {
   }
 }
 
-const cowAppDataCache = new Map<string, CowPartner | null>();
-
-async function resolveCowAppData(appData: string): Promise<CowPartner | undefined> {
-  const hash = String(appData || "").toLowerCase();
-  if (!hash.startsWith("0x") || hash === "0x" + "00".repeat(32)) return;
-  if (cowAppDataCache.has(hash)) return cowAppDataCache.get(hash) || undefined;
-  try {
-    const res = await httpGet(`https://api.cow.fi/mainnet/api/v1/app_data/${hash}`);
-    const partner = cowPartnerFromAppData(res?.fullAppData ?? res);
-    cowAppDataCache.set(hash, partner ?? null);
-    return partner;
-  } catch {
-    cowAppDataCache.set(hash, null);
-  }
+function toOrderUid(value: any): string {
+  const raw = String(value || "").toLowerCase();
+  if (raw.startsWith("0x")) return raw;
+  return "";
 }
 
-async function cowTradesFromSettleTxs(
-  options: FetchOptions,
-  cowTradeLogs: any[],
-  recipients: Set<string>,
-) {
-  const logsByTx = new Map<string, any[]>();
-  for (const log of cowTradeLogs) {
-    const tx = txHash(log);
-    if (!tx) continue;
-    const list = logsByTx.get(tx) || [];
-    list.push(log);
-    logsByTx.set(tx, list);
-  }
-  const unique = [...logsByTx.keys()];
-  if (!unique.length) {
-    return [] as { sellToken: string; sellAmount: any; buyToken: string; buyAmount: any; bps: bigint }[];
-  }
-  const txs = await getTransactionsWithRetry(options.chain, unique);
-  const out: { sellToken: string; sellAmount: any; buyToken: string; buyAmount: any; bps: bigint }[] = [];
-  for (const tx of txs) {
-    if (!tx) continue;
-    const data = (tx as any).data || (tx as any).input;
-    if (!data) continue;
-    let decoded: ethers.TransactionDescription | null = null;
+async function cowPartnersByUid(uids: string[]): Promise<Map<string, CowPartner>> {
+  const unique = [...new Set(uids.filter((uid) => uid.length >= 114))];
+  const out = new Map<string, CowPartner>();
+  for (let i = 0; i < unique.length; i += 128) {
+    const chunk = unique.slice(i, i + 128);
+    let rows: any[] = [];
     try {
-      decoded = cowIface.parseTransaction({ data });
+      rows = await httpPost("https://api.cow.fi/mainnet/api/v1/orders/by_uids", chunk);
     } catch {
       continue;
     }
-    if (!decoded || decoded.name !== "settle") continue;
-    const hash = String(tx.hash || "").toLowerCase();
-    const unused = (logsByTx.get(hash) || []).map((log) => ({ log, used: false }));
-    const tokens: string[] = decoded.args.tokens.map(asAddr);
-    for (const trade of decoded.args.trades) {
-      const partner = await resolveCowAppData(trade.appData);
-      if (!partner || !recipients.has(partner.recipient)) continue;
-      const sellToken = tokens[Number(trade.sellTokenIndex)];
-      const executed = BigInt(trade.executedAmount);
-      const hit = unused.find((row) => {
-        if (row.used) return false;
-        const a = argsOf(row.log);
-        return asAddr(a.sellToken) === sellToken && BigInt(a.sellAmount) === executed;
-      });
-      if (hit) hit.used = true;
-      const a = hit ? argsOf(hit.log) : undefined;
-      out.push({
-        sellToken,
-        buyToken: a ? asAddr(a.buyToken) : tokens[Number(trade.buyTokenIndex)],
-        sellAmount: a?.sellAmount ?? trade.executedAmount,
-        buyAmount: a?.buyAmount ?? trade.buyAmount,
-        bps: partner.bps,
-      });
+    if (!Array.isArray(rows)) continue;
+    for (const row of rows) {
+      const order = row?.order || row;
+      const uid = toOrderUid(order?.uid);
+      const partner = cowPartnerFromAppData(order?.fullAppData);
+      if (uid && partner) out.set(uid, partner);
     }
   }
   return out;
@@ -305,21 +254,22 @@ const fetch = async (options: FetchOptions) => {
     eventAbi: cowTradeEvent,
     entireLog: true,
   });
-  const cowDecoded = await cowTradesFromSettleTxs(
-    options,
-    cowTradeLogs,
-    recipients,
+  const cowPartners = await cowPartnersByUid(
+    cowTradeLogs.map((log) => toOrderUid(argsOf(log).orderUid)),
   );
-  for (const trade of cowDecoded) {
-    addAmount(dailyVolume, trade.sellToken, trade.sellAmount);
-    const gross = BigInt(trade.buyAmount) * trade.bps / 10000n;
+  for (const log of cowTradeLogs) {
+    const a = argsOf(log);
+    const partner = cowPartners.get(toOrderUid(a.orderUid));
+    if (!partner || !recipients.has(partner.recipient)) continue;
+    addAmount(dailyVolume, a.sellToken, a.sellAmount);
+    const gross = BigInt(a.buyAmount) * partner.bps / 10000n;
     const retained = gross * COW_RETAINED_BPS / 100n;
     const cowShare = gross - retained;
-    addAmount(dailyFees, trade.buyToken, gross, INTENT_FEE);
-    addAmount(dailyRevenue, trade.buyToken, retained, INTENT_FEE);
-    addAmount(dailyProtocolRevenue, trade.buyToken, retained, INTENT_FEE);
+    addAmount(dailyFees, a.buyToken, gross, INTENT_FEE);
+    addAmount(dailyRevenue, a.buyToken, retained, INTENT_FEE);
+    addAmount(dailyProtocolRevenue, a.buyToken, retained, INTENT_FEE);
     if (cowShare > 0n) {
-      addAmount(dailySupplySideRevenue, trade.buyToken, cowShare, INTENT_FEE);
+      addAmount(dailySupplySideRevenue, a.buyToken, cowShare, INTENT_FEE);
     }
   }
 
@@ -378,7 +328,7 @@ const fetch = async (options: FetchOptions) => {
 
 const methodology = {
   Volume:
-    "Pennysia-routed volume only (not inner DEX swaps): sell-token input from SwapExecuted on Settlement (SYNC and SODAX opens), CoW GPv2 settle trades whose appData partnerFee.recipient is the Settlement fee recipient, Velora Delta OrderSettled.srcAmount when a partner-fee Transfer hits that recipient, and UniswapX Fill output inferred as that fee × 10000 / 50.",
+    "Pennysia-routed volume only (not inner DEX swaps): sell-token input from SwapExecuted on Settlement (SYNC and SODAX opens), CoW Trade.sellAmount when the order's appData partnerFee.recipient is the Settlement fee recipient, Velora Delta OrderSettled.srcAmount when a partner-fee Transfer hits that recipient, and UniswapX Fill output inferred as that fee × 10000 / 50.",
   Fees:
     "Settlement FeeCollected (SYNC surplus capped at 10% of gross, leftover token/ETH sweeps, and gas markup on extra executeSwap msg.value); CoW partner fee on executed buy at the order's partner bps (CIP-75: 75% protocol / 25% CoW); Velora OrderSettled.partnerFee or the matched Transfer; UniswapX fee-output Transfer. No FeeCollected on SODAX intent opens.",
   Revenue:

--- a/aggregators/pennysia/index.ts
+++ b/aggregators/pennysia/index.ts
@@ -167,6 +167,8 @@ const fetch = async (options: FetchOptions) => {
   const swapLogs = await options.getLogs({
     target: SETTLEMENT,
     eventAbi: swapExecutedEvent,
+    // Indexer returns empty for this custom event. RPC is cheap (one address).
+    skipIndexer: true,
   });
   for (const log of swapLogs) {
     addAmount(dailyVolume, log.sellToken, log.amountIn);
@@ -175,6 +177,7 @@ const fetch = async (options: FetchOptions) => {
   const feeLogs = await options.getLogs({
     target: SETTLEMENT,
     eventAbi: feeCollectedEvent,
+    skipIndexer: true,
   });
   for (const log of feeLogs) {
     addRetainedFee(log.token, log.amount, SETTLEMENT_FEE);

--- a/aggregators/pennysia/index.ts
+++ b/aggregators/pennysia/index.ts
@@ -37,6 +37,7 @@ const veloraSettledEvent =
 
 const SETTLEMENT_FEE = "Settlement Fees";
 const INTENT_FEE = "Intent Fees";
+const COW_PARTNER_FEE = "Partner Fees for CoW";
 
 const NATIVE = new Set([
   ADDRESSES.null.toLowerCase(),
@@ -131,7 +132,6 @@ async function feeRecipientsInWindow(options: FetchOptions): Promise<string[]> {
     target: SETTLEMENT,
     eventAbi: feeRecipientUpdatedEvent,
     entireLog: true,
-    skipIndexer: true,
   });
   for (const log of updates) {
     const recipient = argsOf(log).recipient;
@@ -229,8 +229,6 @@ const fetch = async (options: FetchOptions) => {
   const swapLogs = await options.getLogs({
     target: SETTLEMENT,
     eventAbi: swapExecutedEvent,
-    // Indexer returns empty for this custom event. RPC is cheap (one address).
-    skipIndexer: true,
   });
   for (const log of swapLogs) {
     addAmount(dailyVolume, log.sellToken, log.amountIn);
@@ -239,7 +237,6 @@ const fetch = async (options: FetchOptions) => {
   const feeLogs = await options.getLogs({
     target: SETTLEMENT,
     eventAbi: feeCollectedEvent,
-    skipIndexer: true,
   });
   for (const log of feeLogs) {
     addRetainedFee(log.token, log.amount, SETTLEMENT_FEE);
@@ -269,7 +266,7 @@ const fetch = async (options: FetchOptions) => {
     addAmount(dailyRevenue, a.buyToken, retained, INTENT_FEE);
     addAmount(dailyProtocolRevenue, a.buyToken, retained, INTENT_FEE);
     if (cowShare > 0n) {
-      addAmount(dailySupplySideRevenue, a.buyToken, cowShare, INTENT_FEE);
+      addAmount(dailySupplySideRevenue, a.buyToken, cowShare, COW_PARTNER_FEE);
     }
   }
 
@@ -277,7 +274,6 @@ const fetch = async (options: FetchOptions) => {
     target: VELORA_DELTA,
     eventAbi: veloraSettledEvent,
     entireLog: true,
-    skipIndexer: true,
   });
   const veloraFroms = new Set([VELORA_DELTA].map(asAddr));
   for (const log of veloraSettled) {
@@ -334,7 +330,7 @@ const methodology = {
   Revenue:
     "Pennysia retains 100% of Settlement FeeCollected, UniswapX fee outputs, and Velora partner fees at the Settlement fee recipient. CoW protocol revenue is 75% of the partner fee; CIP-75's 25% is supply-side.",
   ProtocolRevenue: "All retained amounts go to the Settlement fee recipient, except CoW's 25% service fee.",
-  SupplySideRevenue: "CoW CIP-75 25% service fee on Pennysia-tagged CoW trades. UniswapX and Velora partner fees are paid in full to Pennysia.",
+  SupplySideRevenue: "Partner Fees for CoW: CIP-75 service fee (~25% of the partner fee) withheld by CoW Swap on Pennysia-tagged trades. UniswapX and Velora partner fees are paid in full to Pennysia.",
 };
 
 const breakdownMethodology = {
@@ -353,7 +349,8 @@ const breakdownMethodology = {
     [INTENT_FEE]: "Matched hard-intent partner fees except CoW's 25% service fee.",
   },
   SupplySideRevenue: {
-    [INTENT_FEE]: "CoW CIP-75 25% withheld from the partner fee before payout.",
+    [COW_PARTNER_FEE]:
+      "Service fee from partner integrations (~25% on average). CIP-75 withholds this share of the CoW partner fee before payout to Pennysia.",
   },
 };
 


### PR DESCRIPTION
**NOTE**

#### Please enable "Allow edits by maintainers" while putting up the PR.

Enabled.

---

Follow-up to #9227. Live Pennysia volume was stuck at the two PR-test hours ($4.95 all-time, $0 for 2026-09-06 and 2026-09-07) even though Settlement `executeSwap` txs landed (e.g. `0xa75112b4…`, `0x6ee98f12…`, `0x93c8c7e4…`).

This makes every live Pennysia path countable:

| Path | How it is tagged |
|---|---|
| SYNC Settlement | `SwapExecuted` / `FeeCollected` with `skipIndexer: true` (custom events are empty in the indexer) |
| SODAX opens | Same `SwapExecuted` (no surplus `FeeCollected`) |
| CoW | `Trade` logs + POST `https://api.cow.fi/mainnet/api/v1/orders/by_uids` (chunks of 128). Keep trades whose `fullAppData.metadata.partnerFee.recipient` is the Settlement `feeRecipient()`. Volume = `sellAmount`. CIP-75: 75% protocol / 25% supply-side. Same-tx Transfers cannot tag CoW because partner fees pay out weekly. |
| Velora Delta | `OrderSettled` + partner-fee Transfer to the Settlement fee recipient (`skipIndexer` on the custom event) |
| UniswapX | `Fill` + fee-output Transfer **from** the reactor or filler (no fallback to an unrelated Transfer in the same tx) |

EIP-7702 is launch-disabled; if enabled it still settles through Settlement.

Local adapter tests:

- `pnpm test aggregators pennysia 1788674400` (2026-09-06 05:00–06:00 UTC) → volume **676.00**, Settlement Fees **2.05**
- `pnpm test aggregators pennysia 1788768000` (2026-09-07 07:00–08:00 UTC) → volume **674.00**, Settlement Fees **2.18**

After merge, please re-run / backfill **2026-09-06 onward** so the stored $0 hours are replaced.