### PR TITLE
Kinetiq Markets: track the second builder code

### DIFF
--- a/dexs/kinetiq-markets.ts
+++ b/dexs/kinetiq-markets.ts
@@ -3,27 +3,47 @@ import { CHAIN } from "../helpers/chains";
 import { fetchBuilderCodeRevenue, fetchHIP3DeployerData } from "../helpers/hyperliquid";
 
 const KINETIQ_MARKETS_LEGACY_END_DATE = "2026-06-20";
-const KINETIQ_MARKETS_BUILDER_ADDRESS = '0x42f3226007290b02c5a0b15bccbb1ba6df04f992';
+// Kinetiq Markets routes orders through two production builder codes, one per client. Both are
+// Kinetiq-operated and their fees accrue to Kinetiq; tracking only the web one understates revenue.
+const KINETIQ_MARKETS_BUILDER_ADDRESSES = [
+  '0x42f3226007290b02c5a0b15bccbb1ba6df04f992', // markets.xyz web
+  '0x2af94a24e1f744a8e251b4996283ffb4657e915d', // markets.xyz mobile
+];
+
+// Hyperliquid only publishes a builder_fills CSV for days on which the builder had fills, and the
+// helper turns the resulting 403 into an error. A day with no fills is a genuine zero, not a
+// failure, so it is logged and skipped rather than taking down the whole day's fetch (which would
+// also drop the other builder and the HIP-3 leg).
+const NO_DATA_ERROR = 'Builder fee data is not available';
+
+const builderCodeRevenue = async (options: FetchOptions, builder_address: string, market?: 'hip3', hip3DeployerId?: string) => {
+  try {
+    return await fetchBuilderCodeRevenue({ options, builder_address, market, hip3DeployerId });
+  } catch (error: any) {
+    if (!String(error?.message).includes(NO_DATA_ERROR)) throw error;
+    console.error(`kinetiq-markets: no builder fills for ${builder_address} on ${options.dateString}`);
+    return { dailyVolume: options.createBalances(), dailyFees: options.createBalances() };
+  }
+};
 
 const fetch = async (options: FetchOptions) => {
   const deployerId = options.dateString > KINETIQ_MARKETS_LEGACY_END_DATE ? 'mkts' : 'km';
-  const { dailyVolume: builderVolume, dailyFees: builderFees } = await fetchBuilderCodeRevenue({
-    options,
-    builder_address: KINETIQ_MARKETS_BUILDER_ADDRESS,
-  });
-
+  const builderVolume = options.createBalances();
+  const builderFees = options.createBalances();
   const builderHip3OverlapVolume = options.createBalances();
 
-  // No builder activity means the builder/HIP-3 intersection is necessarily zero.
-  if (await builderVolume.getUSDValue()) {
-    const { dailyVolume: builderHip3Volume } = await fetchBuilderCodeRevenue({
-      options,
-      builder_address: KINETIQ_MARKETS_BUILDER_ADDRESS,
-      market: 'hip3',
-      hip3DeployerId: deployerId,
-    });
+  for (const builder_address of KINETIQ_MARKETS_BUILDER_ADDRESSES) {
+    const { dailyVolume, dailyFees } = await builderCodeRevenue(options, builder_address);
 
-    builderHip3OverlapVolume.add(builderHip3Volume);
+    builderVolume.add(dailyVolume);
+    builderFees.add(dailyFees);
+
+    // No builder activity means the builder/HIP-3 intersection is necessarily zero.
+    if (await dailyVolume.getUSDValue()) {
+      const { dailyVolume: builderHip3Volume } = await builderCodeRevenue(options, builder_address, 'hip3', deployerId);
+
+      builderHip3OverlapVolume.add(builderHip3Volume);
+    }
   }
 
   const { dailyPerpVolume: hip3Volume, dailyPerpFee: hip3Fees, dailyDeployerFee: hip3DeployerFee } = await fetchHIP3DeployerData({


### PR DESCRIPTION
Kinetiq team here, fixing an undercount in our own adapter.

Website: https://kinetiq.xyz · Twitter: https://x.com/kinetiq_xyz

## The second builder code was untracked

Kinetiq Markets routes orders through **two** production builder codes, one per client. The adapter hardcoded only the web one, and the mobile one turns out to be the larger of the two:

| date | web `0x42f3…f992` | mobile `0x2af9…915d` | tracked before | missed |
|---|---:|---:|---:|---:|
| 2026-09-05 | $2,718 | $3,278 | $2,718 | **55%** |
| 2026-08-20 | $1,111 | $3,030 | $1,111 | **73%** |
| 2026-02-10 | $379 | $1.42 | $379 | 0.4% |

Both addresses are Kinetiq-operated and both sets of fees accrue to Kinetiq. The fix loops over both and adds into the same balances, so the existing breakdown labels and the builder/HIP-3 overlap subtraction are unchanged.

This is also visible from the other side: over 2026-06-16…09-03, sweeps *into* Kinetiq's buyback wallet from the web builder, the mobile builder's sweep intermediary `0x9cb4ac2598bf72d3f0b53efd817aac5cebe796fc`, and the km/mkts fee recipient total **$139,673**, which exceeds the adapter's gross-based revenue of **$125,179** for the same window. Routed cannot exceed gross, so revenue was being missed.

## A pre-existing failure this made more likely

Hyperliquid publishes a `builder_fills` CSV only for days on which a builder had fills, and `fetchBuilderCodeRevenue` turns the resulting 403 into a thrown error — which takes down the whole day, including the other builder and the HIP-3 leg. This already affected the single-builder adapter (`20251216` and `20260101` both 403 for the web builder). Adding a second address doubles the chance of hitting it, so a day with no fills is now logged and treated as zero. **Every other error still propagates** — the catch matches only that one message.

```
$ pnpm test dexs zz-probe-kinetiq-builders 2025-12-17     # builder legs only, see note below
kinetiq-markets: no builder fills for 0x42f3226007290b02c5a0b15bccbb1ba6df04f992 on 2025-12-16
Daily volume: 6.57 k
Daily fees: 6.14
label  | Daily fees | Daily revenue
mobile | 6.14       | 6.14

$ pnpm test dexs zz-probe-kinetiq-builders 2026-01-02
kinetiq-markets: no builder fills for 0x42f3226007290b02c5a0b15bccbb1ba6df04f992 on 2026-01-01
kinetiq-markets: no builder fills for 0x2af94a24e1f744a8e251b4996283ffb4657e915d on 2026-01-01
Daily volume: 0.00
Daily fees: 0.00
```

## ⚠️ The `test` job cannot pass for this file from a fork

`fetchHIP3DeployerData` throws `missing LLAMA_HL_INDEXER env`, and that secret is not available to fork PRs. This is pre-existing and unrelated to the change — it happens on `master` too, and it is why the numbers above come from a throwaway probe adapter containing this PR's exact builder loop and error wrapper with the HIP-3 leg removed (deleted before committing). The CI log for this PR shows the new error handling working correctly on 2026-09-06 (both builders logged no-fills) before dying on the missing env:

```
kinetiq-markets: no builder fills for 0x42f3226007290b02c5a0b15bccbb1ba6df04f992 on 2026-09-06
kinetiq-markets: no builder fills for 0x2af94a24e1f744a8e251b4996283ffb4657e915d on 2026-09-06
------ ERROR ------
Error: missing LLAMA_HL_INDEXER env
    at queryHyperliquidIndexer (helpers/hyperliquid.ts:308:11)
    at fetchHIP3DeployerData (helpers/hyperliquid.ts:595:24)
```

Please re-run on your side with the secret to confirm the HIP-3 half is untouched.

## Two things we are flagging but did not change

**`fees/kinetiq-launch` still defers the HIP-3 protocol fee share.** Its source carries `// HIP-3 trading-fee revenue is not included yet. Deferred until the first market goes LIVE`. Markets are live now, so the gap is real and growing. We did not implement it because we could not do so cleanly: `LaunchFeeSplitter.split()` sends Kinetiq's `protocolFeeShare` (from `GlobalConfig` `0x23CcD0f1926E4f97d9292683B45fAdBDb066AE50`, currently 1000 bps) to `protocolFeeTreasury` `0xAA3b7392052D62928cC87701e3CA6fb6630bB6e2` as a HyperCore `sendAsset`, which we could not reach from the existing helpers for an arbitrary recipient. Deriving it from `fetchHIP3DeployerData` per partner market instead would need a verified mapping from each bonded market (`MarketBonded` → `getMarketContracts()`) to its HIP-3 deployer id, which we do not have, and could not be tested locally for the same env reason.

**Freshness.** On a 2026-09-07 run the `kinetiq-markets` series ended 2026-09-04, so the parent `kinetiq` total silently lacked Markets for 09-05 and 09-06. Consumers treating only the last day as provisional will be short by two.

Related: #9309 adds a validator commission adapter for a source with no coverage at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfnGvCZgcZfrFaNizyMYDx
