### PR TITLE
[fix] americafun - refuse days the upstream fees API contradicts itself on

### DIFF
--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -30,6 +30,22 @@ const fetch = async (options: FetchOptions) => {
   const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
   const lpFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
 
+  const revenueUsd = protocolRevenueUsd + holdersRevenueUsd
+  const supplySideUsd = meteoraFeeUsd + Math.max(lpFeeUsd, 0)
+
+  // 20% tolerance: the known-bad days (#9277) all run 1.33x-79x over fees, while
+  // ordinary day-to-day noise on this adapter tops out around 1.15x (verified
+  // against a broad sample of the adapter's history) - a maintainer already
+  // declined a stricter fix (#8229) as over-correcting on that kind of noise.
+  // This only fires on the clearly-broken class, never on routine timing lag.
+  if (feesUsd > 0 && (revenueUsd + supplySideUsd) > feesUsd * 1.2) {
+    throw new Error(
+      `Upstream defillama.america.fun API returned internally inconsistent fee/revenue/supplySide figures for ${options.dateString}: ` +
+      `feesUsd=${feesUsd}, revenueUsd=${revenueUsd}, supplySideUsd=${supplySideUsd}. ` +
+      `This is a known upstream data issue (GitHub issue #9277), not an adapter bug.`
+    )
+  }
+
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")
   if (holdersRevenueUsd > 0) dailyHoldersRevenue.addUSDValue(holdersRevenueUsd, "Swap Fees To Stakers")


### PR DESCRIPTION
closes #9277

`fees/americafun.ts` relays `defillama.america.fun`'s own `/api/v1/fees` breakdown as-is. On 13 of ~139 days since the adapter's start, that endpoint's own numbers violate `Fees = Revenue + SupplySideRevenue` by 1.33x-79x: `dailySupplySideRevenue` comes back exactly `0` while `meteoraFee` (part of supply side per this adapter's own methodology - "Meteora's protocol cut") is nonzero, and `dailyRevenue` runs far above `dailyFees`.

The adapter cannot fix a source that disagrees with itself, so this doesn't try to reconstruct a "correct" number - it throws instead of publishing the day, same shape as the guards already shipped for `invariant`, `aera-v2`, `maverick-v2` etc. in this repo.

## Why not `#8229`'s approach

A prior attempt (#8229, closed) tried flooring `dailyFees` at the sum of the booked components to force the identity to hold. A maintainer declined it: *"as long as cumulative fees > cumulative revenue, its acceptable"* - reading the daily mismatch as timing lag between fee collection and revenue distribution, which self-corrects over time.

That reasoning doesn't cover this case. Over the current 135-day published record, cumulative **still doesn't reconcile**: fees $356,064 vs. revenue+supplySide $463,787 - a persistent ~30% gap, not one that's closing. And unlike #8229, this PR doesn't touch the math for any day - it only refuses to publish the ones that are internally inconsistent.

## Threshold

20% tolerance, chosen from the data rather than picked arbitrarily:

| set | ratio range |
|---|---|
| the 13 known-bad days from #9277 | 1.33x - 79.2x |
| ordinary day-to-day noise (sampled ~25 other days across the full history) | up to 1.15x |

20% sits cleanly in the gap between those two clusters - it rejects every one of the 13 known-bad days and none of the routine-noise days, so it doesn't re-litigate the timing-lag leniency the maintainer already established on this adapter.

## Verification

Live, today, against `defillama.america.fun`:

```
$ npx ts-node --transpile-only cli/testAdapter.ts fees americafun 2026-05-18   # covers calendar day 05-17
------ ERROR ------
Error: Upstream defillama.america.fun API returned internally inconsistent fee/revenue/supplySide
figures for 2026-05-17: feesUsd=306.452749, revenueUsd=24222.289850999998, supplySideUsd=61.29055.
This is a known upstream data issue (GitHub issue #9277), not an adapter bug.
```

```
$ npx ts-node --transpile-only cli/testAdapter.ts fees americafun 2026-06-11   # healthy day, unaffected
Daily fees: 2910, Daily revenue: 1199 (867 treasury + 332 stakers), Daily supply side revenue: 1711
```

Scripted the guard's exact logic against live API responses for all 13 known-bad days plus a spread of ~25 other days across the adapter's full history (2026-04-25 through 2026-09-05): rejects all 13, passes everything else, including three borderline days (1.04x-1.15x) that are NOT in the original 13 and would have been false positives at a tighter tolerance.

`npx tsc --project tsconfig.json --noEmit` - clean, zero errors, repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)