### PR TITLE
[fix] garden - refuse to publish fees when the orders feed has gone stale

### DIFF
--- a/bridge-aggregators/garden/index.ts
+++ b/bridge-aggregators/garden/index.ts
@@ -198,6 +198,18 @@ async function fetchTransactionsInDateRange(startTimestamp: number, endTimestamp
             }
             break;
         }
+
+        // Pages are newest-first, so a stale first row means paging further is
+        // pointless and would publish the same silent zeros as an empty feed.
+        if (currentPage === 1) {
+            const newestTimestamp = new Date(response.result.data[0].created_at).getTime() / 1000;
+            if (newestTimestamp < startTimestamp) {
+                throw new Error(
+                    `garden bridge: freshest completed order (${response.result.data[0].created_at}) predates the requested window — the orders feed looks stale, not zero`
+                );
+            }
+        }
+
         for (const tx of response.result.data) {
             const txTimestamp = new Date(tx.created_at).getTime() / 1000;
             if (!insideDateRange && txTimestamp >= endTimestamp) {

--- a/fees/garden/index.ts
+++ b/fees/garden/index.ts
@@ -134,6 +134,17 @@ async function fetchTransactionsInDateRange(startTimestamp: number, endTimestamp
             break;
         }
 
+        // Pages are newest-first, so a stale first row means paging further is
+        // pointless and would publish the same silent zeros as an empty feed.
+        if (currentPage === 1) {
+            const newestTimestamp = new Date(response.result.data[0].created_at).getTime() / 1000;
+            if (newestTimestamp < startTimestamp) {
+                throw new Error(
+                    `garden fees: freshest completed order (${response.result.data[0].created_at}) predates the requested window — the orders feed looks stale, not zero`
+                );
+            }
+        }
+
         for (const tx of response.result.data) {
             const txTimestamp = new Date(tx.created_at).getTime() / 1000;
 


### PR DESCRIPTION
tl;dr `fees/garden` and `bridge-aggregators/garden` were about to silently publish $0 for every chain, every day, forever - because the existing stale-feed guard only covers a fully empty page 1, not a page 1 that's non-empty but entirely outside the requested window.

## What's actually happening right now

`api.garden.finance/v2/orders?status=completed` is live-proven stale as of today (2026-09-07): the freshest completed order is `2026-08-26T14:35:55.798Z`, 12+ days old.

Both adapters already learned this lesson once - issue #8814 ("fees dark since 2026-07-27, 404") was fixed by #8819, which throws when page 1 comes back completely empty. That guard is still correct and untouched by this PR. It just doesn't fire here, because page 1 right now has 500 real rows - they're all just older than the requested window.

Traced the loop for any day after 2026-08-26: every row fails all three branches (`!insideDateRange && txTimestamp >= endTimestamp` is false since nothing's in the future; `txTimestamp < endTimestamp && txTimestamp >= startTimestamp` is false since nothing's within the window; `insideDateRange && txTimestamp < startTimestamp` is false since `insideDateRange` never flips true). So the loop just keeps incrementing `currentPage` all the way to `total_pages` (238 today, ~119k rows) before exiting normally with an **empty** `fees`/`volumes` object - no error. `fetch()` then reads that as a real `$0` for every chain. Same silent-zero failure class as #8814, second distinct trigger.

Bonus: this also means every failed run currently burns ~238 sequential paginated HTTP calls to arrive at that silent zero.

## The fix

Pages are confirmed newest-first (verified live: page 1 descends `2026-08-26` -> `2026-07-24`, page 2 continues `2026-07-24` -> `2026-07-22`, monotonic). So checking only page 1's first row is enough: if the single newest order in the whole feed already predates `startTimestamp`, throw immediately instead of paging further - same error-throwing style as the existing #8819 guard, just for the second trigger.

Legit historical zero-order days are untouched: the check only fires when the newest row in the *entire* feed is older than the window, which is never true for a genuinely-quiet day sandwiched inside otherwise-active history (the newest row is always from well after such a day). Confirmed this doesn't change behavior for a real historical window - the check is a no-op whenever the feed has anything newer than the requested day, which is every non-degenerate case except the one being fixed.

## Receipts

Live, against the real API, right now:

```
npm run test -- fees garden 2026-09-07
------ ERROR ------
Error: garden fees: freshest completed order (2026-08-26T14:35:55.798Z) predates the requested window — the orders feed looks stale, not zero

npm run test -- bridge-aggregators garden 2026-09-07
------ ERROR ------
Error: garden bridge: freshest completed order (2026-08-26T14:35:55.798Z) predates the requested window — the orders feed looks stale, not zero
```

Both throw in a single request (~650ms) instead of silently returning 0 after ~238 paginated requests. `npx tsc --noEmit` clean.

## Risk

Low - purely additive guard mirroring an already-merged, already-precedented pattern in the same two files. Doesn't touch the empty-page-1 path or the pagination/date-window logic itself.

related to #8814 (already closed by #8819 - this fixes a second, distinct trigger of the same silent-zero class; no open issue tracks this one, filed as a direct PR)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Lh6V2uPTUqauqq45BM7m5k

🤖 Generated with [Claude Code](https://claude.com/claude-code)