### PR TITLE
fees(lighterv2): say where the buyback is measured, and how it compares

### DIFF
--- a/fees/lighterv2/index.ts
+++ b/fees/lighterv2/index.ts
@@ -225,7 +225,7 @@ async function fetch(options: FetchOptions): Promise<FetchResultV2> {
 const methodology = {
   Fees: 'Maker and taker fees paid by traders on the Lighter DEX',
   Revenue: 'Protocol revenue from maker fees, taker fees, transfer fees, and withdraw fees. Liquidation fees are excluded as they go directly to LLP.',
-  HoldersRevenue: 'LIT token buybacks from treasury. The protocol uses fees to buy back LIT tokens from the market.',
+  HoldersRevenue: 'LIT bought back by the treasury, measured from its trades on the LIT/USDC market. The buyback is not a share of the period\'s fees: since the first on 5 January 2026 it totals 27.0m against 25.8m of revenue, and the running buyback has led the running revenue on 241 of those 245 days.',
   SupplySideRevenue: 'Liquidation fees paid to the LLP (Lighter Liquidity Pool / insurance fund).',
 }
 


### PR DESCRIPTION
The `HoldersRevenue` string says the protocol uses fees to buy back LIT. The served
series contradicts it. Since the first buyback on 2026-01-05, buybacks total
26,975,230 against 25,783,843 of revenue over 245 days, the running buyback ahead of
the running revenue on 241 of them and 1,191,387 ahead at the end. A single day's
buyback exceeds that day's whole revenue on 107 of the 245, up to 7.4x.

A payout larger than the revenue it is said to come from is not drawn from it. What
the string describes now is what `fetchBuybacks` measures, the treasury account's
trades on the LIT/USDC market, and it says the size does not track the period's fees.

#9258 removed `dailyProtocolRevenue` and both `ProtocolRevenue` blocks and left this
sentence as it stood, so this is the half of that pull request which did not land.

Measured 2026-09-07 from `api.llama.fi/summary/fees/lighter-perps`, `dataType`
`dailyRevenue` and `dailyHoldersRevenue`.
