### PR TITLE
feat: report skate amm volume on robinhood chain

### DIFF
--- a/dexs/skate-amm/index.ts
+++ b/dexs/skate-amm/index.ts
@@ -15,7 +15,8 @@ const chainConfig: Record<string, { id: number, start: string }> = {
     [CHAIN.SUI]: { id: 1001, start: '2025-06-22' },
     [CHAIN.MONAD]: { id: 143, start: '2025-11-25' },
     [CHAIN.MEGAETH]: { id: 4326, start: '2026-02-18' },
-    [CHAIN.TEMPO]: { id: 4217, start: '2026-04-13' }
+    [CHAIN.TEMPO]: { id: 4217, start: '2026-04-13' },
+    [CHAIN.ROBINHOOD]: { id: 4663, start: '2026-07-09' }
 }
 
 // Skate AMM v2 only. v1 was retired in Aug 2026 once its liquidity was fully


### PR DESCRIPTION
Adds `CHAIN.ROBINHOOD` (4663) to the `skate-amm` adapter's `chainConfig`. Skate AMM has had a live pool on Robinhood Chain since 2026-07-09 and its volume has not been reported.

`CHAIN.ROBINHOOD` already exists in `helpers/chains.ts` and is used by ~120 other adapters, so this is a one-line additive change with no new chain constant.

Start date `2026-07-09` is the first day the upstream stats API returns non-empty data for chainId 4663 (07-08 returns empty), and matches the day the pool went live.

Verified: `pnpm run ts-check` and `pnpm run ts-check-cli` both exit 0, and `npx ts-node cli/testAdapter.ts dexs skate-amm` produces a clean run with a `robinhood` row and no `---- ERROR ----` marker. Stashing the change removes the row, confirming the line is what enables the fetch.