### PR TITLE
feat(azverse): reintroduce xox-perps broker interface; temporarily remove azx-perps

### DIFF
--- a/factory/azverse.ts
+++ b/factory/azverse.ts
@@ -1,7 +1,7 @@
 import { azverseBrokerFeesExports, azverseBrokerVolumeExports } from "../helpers/azverse";
 import { createFactoryExports } from "./registry";
 
-// broker_id values are returned by https://app.azverse.xyz/exapi/stats/v1/stats/public/defillama/brokers
+// broker_id values are returned by https://app.azverse.net/exapi/stats/v1/stats/public/defillama/brokers
 const brokerConfigs = {
   "xox-perps": { brokerId: "XOX", brokerName: "XOX", start: "2025-12-11" },
 };

--- a/factory/azverse.ts
+++ b/factory/azverse.ts
@@ -3,7 +3,7 @@ import { createFactoryExports } from "./registry";
 
 // broker_id values are returned by https://app.azverse.xyz/exapi/stats/v1/stats/public/defillama/brokers
 const brokerConfigs = {
-  "azx-perps": { brokerId: "AZVERSE", brokerName: "AZX", start: "2025-12-31" },
+  "xox-perps": { brokerId: "XOX", brokerName: "XOX", start: "2025-12-11" },
 };
 
 const dexsProtocols = Object.fromEntries(

--- a/helpers/azverse.ts
+++ b/helpers/azverse.ts
@@ -2,7 +2,7 @@ import { httpGet } from "../utils/fetchURL";
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "./chains";
 
-const BASE_URL = "https://app.azverse.xyz/exapi/stats/v1/stats/public/defillama";
+const BASE_URL = "https://app.azverse.net/exapi/stats/v1/stats/public/defillama";
 
 export type AzverseMarket = "perp" | "spot";
 


### PR DESCRIPTION
## Summary

This PR makes two changes to the AZverse broker-interface factory, following the same phased approach as #8913:

1. Reintroduce `xox-perps` (volume + fees). This restores one of the four lines removed in #8913, where we noted these partner interfaces "may be reintroduced once ready". XOX is now ready. `start` is set to `2025-12-11`, the first day the AZverse stats API returns data for broker `XOX`.

2. Temporarily remove `azx-perps`, exactly as was done for the other four interfaces in #8913. AZX does not yet have its own landing page; until it does, it should not be listed separately or roll up into AZverse (Combined). We will reintroduce it once its brand page is live.

```diff
 const brokerConfigs = {
-  "azx-perps": { brokerId: "AZVERSE", brokerName: "AZX", start: "2025-12-31" },
+  "xox-perps": { brokerId: "XOX", brokerName: "XOX", start: "2025-12-11" },
 };
```

## Stats API

Daily statistics are retrieved from the current AZverse public endpoint which has also been updated:

`GET https://app.azverse.net/exapi/stats/v1/stats/public/defillama/daily-stats?date=YYYY-MM-DD`

Broker-interface requests additionally pass `broker_id=XOX`. The shared helper on the base branch already constructs this endpoint with `URLSearchParams`, so no helper change is required in this PR.

## Methodology

Methodology is unchanged from the previously aligned treatment: single-side counting via `volume / 2`, with `doublecounted: true`. See “AZverse: add canonical trading stats and broker interface adapters” by `defiwizard1002`.

## About XOX

XOX is an independent perpetuals DEX brand built on AZverse infrastructure, with its own website, app, and community:

- Website: https://www.xox.exchange/en
- Twitter/X: https://x.com/xox_DEX
- AZverse broker list: https://app.azverse.net/exapi/stats/v1/stats/public/defillama/brokers

## Server-side request

Since the `xox-perps` protocol page was hidden after #8913, could you please restore or create the XOX protocol metadata so the adapter has a page to attach to:

- name: XOX
- slug: xox-perps
- url: https://www.xox.exchange/en
- twitter: https://x.com/xox_DEX
- category: same as `azx-perps` (Interface), or Derivatives if preferred
- description: XOX is a high-performance, orderbook-based perpetual decentralized exchange designed to deliver a centralized-exchange-level trading experience while remaining fully on-chain, non-custodial, and secured by Ethereum.
- logo: attached (`xox-icon-512.png`, 512×512 PNG; SVG source also attached)
- parentProtocol: none

XOX is its own brand and should not roll up under AZverse (Combined). AZverse's own combined total should include only its first-party products: AZverse Perps and AZverse Spot.

## Related: hide the azx-perps page

As with the four interfaces in #8913, could you please also hide the `azx-perps` protocol page now that its adapter is removed?

https://defillama.com/protocol/azx-perps

It is currently grouped under AZverse (Combined). AZX volume already flows through the canonical AZverse adapter, so that grouping inflates the combined figure. After this change, AZverse (Combined) = AZverse Perps + AZverse Spot only.

## Testing

- `pnpm run ts-check`
- Verified the AZverse factory lists contain only `xox-perps` for both dexs and fees
- `pnpm test dexs xox-perps 2026-09-04` → Backfill start time: 11/12/2025 · Daily volume: 24.76 M
- `pnpm test fees xox-perps 2026-09-04` → Daily fees: 2.50 k · Daily revenue: 1.84 k · Daily supply side revenue: 662.00
