### PR TITLE
Feat: native add Pool distribution as supply side revenue

### DIFF
--- a/fees/native-core/index.ts
+++ b/fees/native-core/index.ts
@@ -2,6 +2,7 @@ import type { Balances } from "@defillama/sdk";
 import type { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { fetchURLAutoHandleRateLimit, httpPost } from "../../utils/fetchURL";
+import { sleep } from "../../utils/utils";
 
 // Native Core CLOB fees — same listing slug as `dexs/native-core`.
 // Public stats: GET /api/v3/stats/window (https://api-ui.native.org)
@@ -155,6 +156,15 @@ function rescaleAtoms(
 let poolAssets: Map<number, PoolAsset> | undefined;
 let coreAssetTokens: CoreAssetTokens | undefined;
 let venuePrices: Map<string, VenuePrice> | undefined;
+let distributionCache:
+  | {
+      items: PoolDistribution[];
+      oldestMs: number;
+      nextBeforeId?: number;
+      exhausted: boolean;
+    }
+  | undefined;
+let distributionMutex: Promise<void> = Promise.resolve();
 
 async function getVenuePrices(): Promise<Map<string, VenuePrice>> {
   if (venuePrices) return venuePrices;
@@ -181,16 +191,25 @@ async function getVenuePrices(): Promise<Map<string, VenuePrice>> {
   return prices;
 }
 
-async function postEarn<T>(body: Record<string, unknown>): Promise<T> {
-  const response: EarnEnvelope<T> = await httpPost(EARN_URL, body, {
-    headers: { "content-type": "application/json" },
-  });
-  if (response.code !== 0 || response.data === undefined) {
-    throw new Error(
-      `Native Pool earn ${JSON.stringify(body)} failed: ${response.message ?? "no data"}`,
-    );
+async function postEarn<T>(body: Record<string, unknown>, retries = 5): Promise<T> {
+  let lastMessage = "no data";
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const response: EarnEnvelope<T> = await httpPost(EARN_URL, body, {
+      headers: { "content-type": "application/json" },
+    });
+    if (response.code === 0 && response.data !== undefined) {
+      return response.data;
+    }
+    lastMessage = response.message ?? "no data";
+    const rateLimited = /rate/i.test(lastMessage);
+    if (!rateLimited || attempt === retries - 1) {
+      break;
+    }
+    await sleep(5000 * (attempt + 1));
   }
-  return response.data;
+  throw new Error(
+    `Native Pool earn ${JSON.stringify(body)} failed: ${lastMessage}`,
+  );
 }
 
 async function getPoolAssets(): Promise<Map<number, PoolAsset>> {
@@ -232,34 +251,64 @@ async function getPoolDistributions(
   fromMilliseconds: number,
   toMilliseconds: number,
 ): Promise<PoolDistribution[]> {
-  const distributions: PoolDistribution[] = [];
-  let beforeId: number | undefined;
+  const previous = distributionMutex;
+  let release!: () => void;
+  distributionMutex = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
 
-  do {
-    const page = await postEarn<DistributionPage>({
-      type: "distributions",
-      limit: 200,
-      ...(beforeId === undefined ? {} : { before_id: beforeId }),
-    });
+  try {
+    if (!distributionCache) {
+      distributionCache = {
+        items: [],
+        oldestMs: Number.POSITIVE_INFINITY,
+        exhausted: false,
+      };
+    }
 
-    for (const distribution of page.items ?? []) {
-      if (!Number.isFinite(distribution.completed_at_unix_ms)) {
-        throw new Error(
-          `Native Pool distribution ${distribution.id} has an invalid completion timestamp`,
+    while (
+      !distributionCache.exhausted &&
+      distributionCache.oldestMs > fromMilliseconds
+    ) {
+      const page = await postEarn<DistributionPage>({
+        type: "distributions",
+        limit: 200,
+        ...(distributionCache.nextBeforeId === undefined
+          ? {}
+          : { before_id: distributionCache.nextBeforeId }),
+      });
+
+      for (const distribution of page.items ?? []) {
+        if (!Number.isFinite(distribution.completed_at_unix_ms)) {
+          throw new Error(
+            `Native Pool distribution ${distribution.id} has an invalid completion timestamp`,
+          );
+        }
+        distributionCache.items.push(distribution);
+        distributionCache.oldestMs = Math.min(
+          distributionCache.oldestMs,
+          distribution.completed_at_unix_ms,
         );
       }
-      if (distribution.completed_at_unix_ms < fromMilliseconds) {
-        return distributions;
-      }
-      if (distribution.completed_at_unix_ms < toMilliseconds) {
-        distributions.push(distribution);
+
+      distributionCache.nextBeforeId = page.next_before_id ?? undefined;
+      if (
+        distributionCache.nextBeforeId === undefined ||
+        !(page.items ?? []).length
+      ) {
+        distributionCache.exhausted = true;
       }
     }
 
-    beforeId = page.next_before_id ?? undefined;
-  } while (beforeId !== undefined);
-
-  return distributions;
+    return distributionCache.items.filter(
+      (distribution) =>
+        distribution.completed_at_unix_ms >= fromMilliseconds &&
+        distribution.completed_at_unix_ms < toMilliseconds,
+    );
+  } finally {
+    release();
+  }
 }
 
 async function addFee(

--- a/fees/native-core/index.ts
+++ b/fees/native-core/index.ts
@@ -1,15 +1,17 @@
 import type { Balances } from "@defillama/sdk";
 import type { FetchOptions, FetchV2, SimpleAdapter } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
-import { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
+import { fetchURLAutoHandleRateLimit, httpPost } from "../../utils/fetchURL";
 
 // Native Core CLOB fees — same listing slug as `dexs/native-core`.
 // Public stats: GET /api/v3/stats/window (https://api-ui.native.org)
 //   from/to: unix seconds on exact hour boundaries, half-open [from, to)
 //   35-day rolling coverage; a window past coverage_end is 404, never a zero.
-// Maker and taker each pay independently; the protocol keeps 100%.
+// Native Pool distributions: https://app.native.org/native-pool/distributions
+// Maker and taker each pay independently; Pool payouts are supply-side revenue.
 const STATS_WINDOW_URL = "https://api-ui.native.org/api/v3/stats/window";
 const TICKERS_URL = "https://api-ui.native.org/api/v3/cg/tickers";
+const EARN_URL = "https://api-ui.native.org/api/v3/earn";
 const HOUR = 3600;
 const USD_QUOTES = new Set(["USDC", "USDT"]);
 
@@ -17,6 +19,7 @@ const MAKER_FEES = "Maker Fees";
 const TAKER_FEES = "Taker Fees";
 const MAKER_TO_TREASURY = "Maker Fees To Treasury";
 const TAKER_TO_TREASURY = "Taker Fees To Treasury";
+const POOL_YIELD_TO_LPS = "Native Pool Yield To LPs";
 
 // CoinGecko slugs for assets DefiLlama already prices. Everything else is
 // converted through a USDC/USDT CLOB last price from /cg/tickers.
@@ -58,6 +61,30 @@ type CgTicker = {
 
 type VenuePrice = { cgId: string; price: number };
 
+type EarnEnvelope<T> = {
+  code: number;
+  data?: T;
+  message?: string;
+};
+
+type PoolAsset = {
+  asset_id: number;
+  symbol: string;
+  balance_decimals: number;
+};
+
+type PoolDistribution = {
+  id: number;
+  asset_id: number;
+  distribution_amount: string;
+  completed_at_unix_ms: number;
+};
+
+type DistributionPage = {
+  items: PoolDistribution[] | null;
+  next_before_id: number | null;
+};
+
 function hourWindow(endTimestamp: number): { from: number; to: number } {
   // FetchOptions.startTimestamp is (end - window - 1s). Flooring that would
   // request the previous hour; Native rejects any from/to not on an hour mark.
@@ -73,7 +100,35 @@ function parseAmount(raw: string, symbol: string, side: string): number {
   return amount;
 }
 
+function parseAtoms(raw: string, decimals: number, symbol: string): number {
+  let atoms: bigint;
+  try {
+    atoms = BigInt(raw);
+  } catch {
+    throw new Error(
+      `Native Pool distribution for ${symbol} has invalid atom amount: ${raw}`,
+    );
+  }
+  if (atoms < 0n || !Number.isInteger(decimals) || decimals < 0) {
+    throw new Error(
+      `Native Pool distribution for ${symbol} has invalid amount or decimals`,
+    );
+  }
+
+  const scale = 10n ** BigInt(decimals);
+  const wholeAmount = atoms / scale;
+  if (wholeAmount > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error(
+      `Native Pool distribution for ${symbol} cannot be represented safely: ${raw}`,
+    );
+  }
+  const amount =
+    Number(wholeAmount) + Number(atoms % scale) / Number(scale);
+  return amount;
+}
+
 let venuePrices: Map<string, VenuePrice> | undefined;
+let poolAssets: Map<number, PoolAsset> | undefined;
 
 async function getVenuePrices(): Promise<Map<string, VenuePrice>> {
   if (venuePrices) return venuePrices;
@@ -98,6 +153,60 @@ async function getVenuePrices(): Promise<Map<string, VenuePrice>> {
 
   venuePrices = prices;
   return prices;
+}
+
+async function postEarn<T>(body: Record<string, unknown>): Promise<T> {
+  const response: EarnEnvelope<T> = await httpPost(EARN_URL, body, {
+    headers: { "content-type": "application/json" },
+  });
+  if (response.code !== 0 || response.data === undefined) {
+    throw new Error(
+      `Native Pool earn ${JSON.stringify(body)} failed: ${response.message ?? "no data"}`,
+    );
+  }
+  return response.data;
+}
+
+async function getPoolAssets(): Promise<Map<number, PoolAsset>> {
+  if (poolAssets) return poolAssets;
+
+  const config = await postEarn<{ assets: PoolAsset[] | null }>({ type: "config" });
+  poolAssets = new Map((config.assets ?? []).map((asset) => [asset.asset_id, asset]));
+  return poolAssets;
+}
+
+async function getPoolDistributions(
+  fromMilliseconds: number,
+  toMilliseconds: number,
+): Promise<PoolDistribution[]> {
+  const distributions: PoolDistribution[] = [];
+  let beforeId: number | undefined;
+
+  do {
+    const page = await postEarn<DistributionPage>({
+      type: "distributions",
+      limit: 200,
+      ...(beforeId === undefined ? {} : { before_id: beforeId }),
+    });
+
+    for (const distribution of page.items ?? []) {
+      if (!Number.isFinite(distribution.completed_at_unix_ms)) {
+        throw new Error(
+          `Native Pool distribution ${distribution.id} has an invalid completion timestamp`,
+        );
+      }
+      if (distribution.completed_at_unix_ms < fromMilliseconds) {
+        return distributions;
+      }
+      if (distribution.completed_at_unix_ms < toMilliseconds) {
+        distributions.push(distribution);
+      }
+    }
+
+    beforeId = page.next_before_id ?? undefined;
+  } while (beforeId !== undefined);
+
+  return distributions;
 }
 
 async function addFee(
@@ -137,6 +246,7 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   for (const row of snap.fees ?? []) {
     const maker = parseAmount(row.maker, row.symbol, "maker");
@@ -147,12 +257,30 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
     await addFee(dailyRevenue, row.symbol, taker, TAKER_TO_TREASURY);
   }
 
+  const assets = await getPoolAssets();
+  const distributions = await getPoolDistributions(from * 1000, to * 1000);
+  for (const distribution of distributions) {
+    const asset = assets.get(distribution.asset_id);
+    if (!asset) {
+      throw new Error(
+        `Native Pool distribution ${distribution.id} has unknown asset ${distribution.asset_id}`,
+      );
+    }
+    const amount = parseAtoms(
+      distribution.distribution_amount,
+      asset.balance_decimals,
+      asset.symbol,
+    );
+    await addFee(dailySupplySideRevenue, asset.symbol, amount, POOL_YIELD_TO_LPS);
+  }
+  dailyRevenue.subtract(dailySupplySideRevenue, POOL_YIELD_TO_LPS);
+
   return {
     dailyFees,
     dailyUserFees: dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue: 0, // protocol keeps 100% of maker and taker fees
+    dailySupplySideRevenue,
   };
 };
 
@@ -160,9 +288,12 @@ const methodology = {
   Fees:
     "Maker and taker trading fees on Native Core CLOB fills. Each side pays independently, so both legs are counted. Taken from GET /api/v3/stats/window over the hour. Assets without a CoinGecko id are converted through the venue USDC/USDT last price.",
   UserFees: "Same as fees — traders pay both the maker and taker legs.",
-  Revenue: "Native keeps 100% of maker and taker fees. Nothing is paid to LPs.",
-  ProtocolRevenue: "Native keeps 100% of maker and taker fees. Nothing is paid to LPs.",
-  SupplySideRevenue: "Always zero. Native Core does not share trading fees with the supply side.",
+  Revenue:
+    "Maker and taker fees Native retains after subtracting Native Pool yield distributed to LPs. Revenue can be negative in a distribution hour because Pool payouts include extra rewards as well as fee-funded yield.",
+  ProtocolRevenue:
+    "Maker and taker fees Native retains after subtracting Native Pool yield distributed to LPs. Revenue can be negative in a distribution hour because Pool payouts include extra rewards as well as fee-funded yield.",
+  SupplySideRevenue:
+    "Native Pool yield paid to LPs, from POST /api/v3/earn distributions. This includes fee-funded yield and extra rewards.",
 };
 
 const breakdownMethodology = {
@@ -177,10 +308,16 @@ const breakdownMethodology = {
   Revenue: {
     [MAKER_TO_TREASURY]: "Maker fees kept by Native.",
     [TAKER_TO_TREASURY]: "Taker fees kept by Native.",
+    [POOL_YIELD_TO_LPS]: "Native Pool yield paid to LPs, deducted from retained fees.",
   },
   ProtocolRevenue: {
     [MAKER_TO_TREASURY]: "Maker fees kept by Native.",
     [TAKER_TO_TREASURY]: "Taker fees kept by Native.",
+    [POOL_YIELD_TO_LPS]: "Native Pool yield paid to LPs, deducted from retained fees.",
+  },
+  SupplySideRevenue: {
+    [POOL_YIELD_TO_LPS]:
+      "Yield Native Pool distributes to LPs after each distribution, including fee-funded yield and extra rewards.",
   },
 };
 
@@ -191,6 +328,8 @@ const adapter: SimpleAdapter = {
   chains: [CHAIN.NATIVE_CORE],
   // Public /stats coverage is a 35-day rolling window; Native Core itself launched 2026-05-19.
   start: "2026-07-30",
+  // Pool distributions are sparse and can include extra rewards, so a payout may exceed CLOB fees in an hour.
+  allowNegativeValue: true,
   methodology,
   breakdownMethodology,
 };

--- a/fees/native-core/index.ts
+++ b/fees/native-core/index.ts
@@ -12,6 +12,7 @@ import { fetchURLAutoHandleRateLimit, httpPost } from "../../utils/fetchURL";
 const STATS_WINDOW_URL = "https://api-ui.native.org/api/v3/stats/window";
 const TICKERS_URL = "https://api-ui.native.org/api/v3/cg/tickers";
 const EARN_URL = "https://api-ui.native.org/api/v3/earn";
+const REGISTRY_URL = "https://api-ui.native.org/api/v3/core/registry";
 const HOUR = 3600;
 const USD_QUOTES = new Set(["USDC", "USDT"]);
 
@@ -21,26 +22,12 @@ const MAKER_TO_TREASURY = "Maker Fees To Treasury";
 const TAKER_TO_TREASURY = "Taker Fees To Treasury";
 const POOL_YIELD_TO_LPS = "Native Pool Yield To LPs";
 
-// CoinGecko slugs for assets DefiLlama already prices. Everything else is
-// converted through a USDC/USDT CLOB last price from /cg/tickers.
-const CG_IDS: Record<string, string> = {
-  USDC: "usd-coin",
-  USDT: "tether",
-  ETH: "ethereum",
-  BNB: "binancecoin",
-  BTC: "bitcoin",
-  WBTC: "wrapped-bitcoin",
-  cbBTC: "coinbase-wrapped-btc",
-  USDE: "ethena-usde",
-  wstETH: "wrapped-steth",
-  SOL: "solana",
-  PAXG: "pax-gold",
-  XAUt: "tether-gold",
-  CASHCAT: "cash-cat"
-};
-
 type FeeRow = {
+  asset_id: number;
   symbol: string;
+  decimals: number;
+  maker_atoms: string;
+  taker_atoms: string;
   maker: string;
   taker: string;
 };
@@ -85,6 +72,33 @@ type DistributionPage = {
   next_before_id: number | null;
 };
 
+type RegistryUnderlying = {
+  assetId: number;
+  symbol: string;
+  nativeSymbol: string;
+  address: string;
+  decimals: number;
+  enabled: boolean;
+};
+
+type RegistryChain = {
+  chainKey: string;
+  underlyings: RegistryUnderlying[];
+};
+
+type RegistryResponse = {
+  data?: { chains?: RegistryChain[] };
+};
+
+type CoreAssetToken = {
+  token: string;
+  decimals: number;
+};
+
+type CoreAssetTokens = {
+  byAssetId: Map<number, CoreAssetToken>;
+};
+
 function hourWindow(endTimestamp: number): { from: number; to: number } {
   // FetchOptions.startTimestamp is (end - window - 1s). Flooring that would
   // request the previous hour; Native rejects any from/to not on an hour mark.
@@ -100,7 +114,7 @@ function parseAmount(raw: string, symbol: string, side: string): number {
   return amount;
 }
 
-function parseAtoms(raw: string, decimals: number, symbol: string): number {
+function parseAtomAmount(raw: string, decimals: number, symbol: string): bigint {
   let atoms: bigint;
   try {
     atoms = BigInt(raw);
@@ -114,21 +128,33 @@ function parseAtoms(raw: string, decimals: number, symbol: string): number {
       `Native Pool distribution for ${symbol} has invalid amount or decimals`,
     );
   }
-
-  const scale = 10n ** BigInt(decimals);
-  const wholeAmount = atoms / scale;
-  if (wholeAmount > BigInt(Number.MAX_SAFE_INTEGER)) {
-    throw new Error(
-      `Native Pool distribution for ${symbol} cannot be represented safely: ${raw}`,
-    );
-  }
-  const amount =
-    Number(wholeAmount) + Number(atoms % scale) / Number(scale);
-  return amount;
+  return atoms;
 }
 
-let venuePrices: Map<string, VenuePrice> | undefined;
+function rescaleAtoms(
+  raw: string,
+  fromDecimals: number,
+  toDecimals: number,
+  symbol: string,
+): bigint {
+  const atoms = parseAtomAmount(raw, fromDecimals, symbol);
+  const decimalDifference = toDecimals - fromDecimals;
+  if (decimalDifference >= 0) {
+    return atoms * 10n ** BigInt(decimalDifference);
+  }
+
+  const scale = 10n ** BigInt(-decimalDifference);
+  if (atoms % scale !== 0n) {
+    throw new Error(
+      `Native Pool distribution for ${symbol} cannot be represented with ${toDecimals} decimals`,
+    );
+  }
+  return atoms / scale;
+}
+
 let poolAssets: Map<number, PoolAsset> | undefined;
+let coreAssetTokens: CoreAssetTokens | undefined;
+let venuePrices: Map<string, VenuePrice> | undefined;
 
 async function getVenuePrices(): Promise<Map<string, VenuePrice>> {
   if (venuePrices) return venuePrices;
@@ -175,6 +201,33 @@ async function getPoolAssets(): Promise<Map<number, PoolAsset>> {
   return poolAssets;
 }
 
+async function getCoreAssetTokens(): Promise<CoreAssetTokens> {
+  if (coreAssetTokens) return coreAssetTokens;
+
+  const registry: RegistryResponse = await fetchURLAutoHandleRateLimit(REGISTRY_URL);
+  const byAssetId = new Map<number, CoreAssetToken>();
+
+  for (const chain of registry.data?.chains ?? []) {
+    for (const underlying of chain.underlyings ?? []) {
+      if (!underlying.enabled || !underlying.address) continue;
+      const asset = {
+        token: `${chain.chainKey}:${underlying.address}`,
+        decimals: underlying.decimals,
+      };
+      // An asset may be bridged to several chains. Use the enabled
+      // representation with the most decimals so Core's balance atoms can be
+      // represented exactly; the same choice serves fees and Pool payouts.
+      const existing = byAssetId.get(underlying.assetId);
+      if (!existing || asset.decimals > existing.decimals) {
+        byAssetId.set(underlying.assetId, asset);
+      }
+    }
+  }
+
+  coreAssetTokens = { byAssetId };
+  return coreAssetTokens;
+}
+
 async function getPoolDistributions(
   fromMilliseconds: number,
   toMilliseconds: number,
@@ -211,25 +264,58 @@ async function getPoolDistributions(
 
 async function addFee(
   balances: Balances,
-  symbol: string,
-  amount: number,
+  fee: FeeRow,
+  rawAmount: string,
+  rawAtoms: string,
   label: string,
 ): Promise<void> {
+  const amount = parseAmount(rawAmount, fee.symbol, "fee");
   if (amount === 0) return;
 
-  const cgId = CG_IDS[symbol];
-  if (cgId) {
-    balances.addCGToken(cgId, amount, label);
+  const asset = (await getCoreAssetTokens()).byAssetId.get(fee.asset_id);
+  if (asset) {
+    balances.addTokenVannila(
+      asset.token,
+      rescaleAtoms(rawAtoms, fee.decimals, asset.decimals, fee.symbol),
+      label,
+    );
     return;
   }
 
-  const venue = (await getVenuePrices()).get(symbol);
+  // CLOB-only synthetic assets (for example MUon) have no canonical token in
+  // the registry, so use their direct USD-quoted CLOB market as a fallback.
+  const venue = (await getVenuePrices()).get(fee.symbol);
   if (!venue) {
     throw new Error(
-      `Native Core fee asset ${symbol} has no CoinGecko id and no USDC/USDT CLOB price`,
+      `Native Core fee asset ${fee.symbol} has no Core registry token or USDC/USDT CLOB price`,
     );
   }
   balances.addCGToken(venue.cgId, amount * venue.price, label);
+}
+
+async function addPoolDistribution(
+  balances: Balances,
+  asset: PoolAsset,
+  distribution: PoolDistribution,
+): Promise<void> {
+  const registryAsset = (await getCoreAssetTokens()).byAssetId.get(asset.asset_id);
+  if (!registryAsset) {
+    throw new Error(
+      `Native Pool distribution ${distribution.id} has no Core registry token for ${asset.symbol}`,
+    );
+  }
+  // Pool balances and the registry's EVM token may use different decimals.
+  // Rescaling atoms changes only units, while retaining the same asset token.
+  balances.addTokenVannila(
+    registryAsset.token,
+    rescaleAtoms(
+      distribution.distribution_amount,
+      asset.balance_decimals,
+      registryAsset.decimals,
+      asset.symbol,
+    ),
+    POOL_YIELD_TO_LPS,
+  );
 }
 
 const fetch: FetchV2 = async (options: FetchOptions) => {
@@ -249,12 +335,10 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances();
 
   for (const row of snap.fees ?? []) {
-    const maker = parseAmount(row.maker, row.symbol, "maker");
-    const taker = parseAmount(row.taker, row.symbol, "taker");
-    await addFee(dailyFees, row.symbol, maker, MAKER_FEES);
-    await addFee(dailyFees, row.symbol, taker, TAKER_FEES);
-    await addFee(dailyRevenue, row.symbol, maker, MAKER_TO_TREASURY);
-    await addFee(dailyRevenue, row.symbol, taker, TAKER_TO_TREASURY);
+    await addFee(dailyFees, row, row.maker, row.maker_atoms, MAKER_FEES);
+    await addFee(dailyFees, row, row.taker, row.taker_atoms, TAKER_FEES);
+    await addFee(dailyRevenue, row, row.maker, row.maker_atoms, MAKER_TO_TREASURY);
+    await addFee(dailyRevenue, row, row.taker, row.taker_atoms, TAKER_TO_TREASURY);
   }
 
   const assets = await getPoolAssets();
@@ -266,12 +350,7 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
         `Native Pool distribution ${distribution.id} has unknown asset ${distribution.asset_id}`,
       );
     }
-    const amount = parseAtoms(
-      distribution.distribution_amount,
-      asset.balance_decimals,
-      asset.symbol,
-    );
-    await addFee(dailySupplySideRevenue, asset.symbol, amount, POOL_YIELD_TO_LPS);
+    await addPoolDistribution(dailySupplySideRevenue, asset, distribution);
   }
   dailyRevenue.subtract(dailySupplySideRevenue, POOL_YIELD_TO_LPS);
 
@@ -286,7 +365,7 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
 
 const methodology = {
   Fees:
-    "Maker and taker trading fees on Native Core CLOB fills. Each side pays independently, so both legs are counted. Taken from GET /api/v3/stats/window over the hour. Assets without a CoinGecko id are converted through the venue USDC/USDT last price.",
+    "Maker and taker trading fees on Native Core CLOB fills. Each side pays independently, so both legs are counted. Taken from GET /api/v3/stats/window over the hour. Settlement assets are recorded under their Native Core registry token; CLOB-only synthetic assets without a canonical token are valued from their USDC/USDT market.",
   UserFees: "Same as fees — traders pay both the maker and taker legs.",
   Revenue:
     "Maker and taker fees Native retains after subtracting Native Pool yield distributed to LPs. Revenue can be negative in a distribution hour because Pool payouts include extra rewards as well as fee-funded yield.",


### PR DESCRIPTION
## Summary
- Track Native Pool distributions as `dailySupplySideRevenue` on the Native Core fees adapter. Maker and taker CLOB fees stay in `dailyFees`; LP yield is deducted from `dailyRevenue` / `dailyProtocolRevenue`.
- Map each settlement asset through `GET /api/v3/core/registry` (`chain:token`) so fees and LP payouts stay on the same asset. New registry listings do not need an adapter PR. Assets that haven't opened up for deposit/withdraw on Core, and therefore have no registry token in the registry API (for example, MUon), still use the USDC/USDT market price for reference.
- Revenue can be negative in a distribution hour because Pool payouts include extra rewards as well as fee-funded yield (`allowNegativeValue`).
- Retry Native earn rate-limit responses and reuse distribution pages in-process so hourly backfills do not re-paginate the same list.

## Test plan
- [x] `npm test -- fees native-core 2026-09-08` (7 Sep UTC): fees $27.50k, supply-side $2.25k, revenue $25.25k. Pool payout at 02:00 UTC.
- [x] `npm test -- fees native-core 2026-09-07` (6 Sep UTC): fees $18.39k, supply-side $2.15k, revenue $16.24k. Pool payout at 02:00 UTC.
- [x] `npm test -- fees native-core` (rolling 24h ending 8 Sep 06:00 UTC): fees $21.17k, supply-side $2.24k, revenue $18.93k. Latest payout at 03:00 UTC on 8 Sep.
- [x] Confirm Fees = Revenue + SupplySide on each day, and that QQQB stays a BSC token balance rather than a USDT conversion.
- [x] `npm run ts-check` and `npm run ts-check-cli`.

## Useful links
- Website: https://native.org
- Twitter: https://x.com/native_fi
- Native Pool: https://app.native.org/native-pool
- Pool distributions: https://app.native.org/native-pool/distributions
- Docs: https://docs.native.org/native-dev/build-with-native/native-core-pool