### PR TITLE
[fix] americafun - derive revenue instead of discarding contradictory upstream days

### DIFF
--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -26,15 +26,12 @@ const fetch = async (options: FetchOptions) => {
 
   const feesUsd = parseFloat(data.dailyFees) || 0
   const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
-  const dailySupplySideRevenueUsd = parseFloat(data.dailySupplySideRevenue)
-  // defillama.america.fun/api/v1/fees reports exact-zero supply side alongside populated
-  // meteoraFee and inflated revenue on 13 historical days (issue #9277, PR #9310).
-  // The LP remainder and staker split are unknown; default the residual to treasury
-  // conservatively instead of fabricating an unverified staker payout.
-  const deriveRevenue = dailySupplySideRevenueUsd === 0 && feesUsd > 0
-  const protocolRevenueUsd = deriveRevenue ? feesUsd - meteoraFeeUsd : parseFloat(data.dailyProtocolRevenue) || 0
-  const holdersRevenueUsd = deriveRevenue ? 0 : parseFloat(data.dailyHoldersRevenue) || 0
-  const lpFeeUsd = deriveRevenue ? 0 : (dailySupplySideRevenueUsd || 0) - meteoraFeeUsd
+  const supplySideUsd = parseFloat(data.dailySupplySideRevenue)
+  // upstream returns supply side 0 with inflated revenue on some days (#9277); rebuild the split from the two fields that stay consistent
+  const rebuildSplit = supplySideUsd === 0
+  const protocolRevenueUsd = rebuildSplit ? feesUsd - meteoraFeeUsd : parseFloat(data.dailyProtocolRevenue) || 0
+  const holdersRevenueUsd = rebuildSplit ? 0 : parseFloat(data.dailyHoldersRevenue) || 0
+  const lpFeeUsd = rebuildSplit ? 0 : (supplySideUsd || 0) - meteoraFeeUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")

--- a/fees/americafun.ts
+++ b/fees/americafun.ts
@@ -25,10 +25,16 @@ const fetch = async (options: FetchOptions) => {
   const dailySupplySideRevenue = options.createBalances()
 
   const feesUsd = parseFloat(data.dailyFees) || 0
-  const protocolRevenueUsd = parseFloat(data.dailyProtocolRevenue) || 0
-  const holdersRevenueUsd = parseFloat(data.dailyHoldersRevenue) || 0
   const meteoraFeeUsd = parseFloat(data.meteoraFee) || 0
-  const lpFeeUsd = (parseFloat(data.dailySupplySideRevenue) || 0) - meteoraFeeUsd
+  const dailySupplySideRevenueUsd = parseFloat(data.dailySupplySideRevenue)
+  // defillama.america.fun/api/v1/fees reports exact-zero supply side alongside populated
+  // meteoraFee and inflated revenue on 13 historical days (issue #9277, PR #9310).
+  // The LP remainder and staker split are unknown; default the residual to treasury
+  // conservatively instead of fabricating an unverified staker payout.
+  const deriveRevenue = dailySupplySideRevenueUsd === 0 && feesUsd > 0
+  const protocolRevenueUsd = deriveRevenue ? feesUsd - meteoraFeeUsd : parseFloat(data.dailyProtocolRevenue) || 0
+  const holdersRevenueUsd = deriveRevenue ? 0 : parseFloat(data.dailyHoldersRevenue) || 0
+  const lpFeeUsd = deriveRevenue ? 0 : (dailySupplySideRevenueUsd || 0) - meteoraFeeUsd
 
   if (feesUsd > 0) dailyFees.addUSDValue(feesUsd, "Swap Fees")
   if (protocolRevenueUsd > 0) dailyProtocolRevenue.addUSDValue(protocolRevenueUsd, "Swap Fees To Treasury")


### PR DESCRIPTION
Follow-up to #9310 (closed, not merged) - not reopening it, this is a different approach per bheluga's request on that thread. Context: #9277 (closed alongside #9310).

`fees/americafun.ts` relays `defillama.america.fun`'s own `/api/v1/fees` breakdown. #9310 found the endpoint's own numbers self-contradict on 13 historical days and threw instead of publishing those days. bheluga on that thread:

> "Hmm some of your concern makes sense, but the main issue here is that by throwing error we would lose actual fee values for those days. IMO the right solution would be to derive fees from supply side revenue and revenue. WDYT?"

## What the live data actually supports

Re-pulled the endpoint for the full history today. The literal `supplySide = fees - revenue` derivation doesn't survive contact with the data, because `dailyRevenue` is *also* corrupted on these days, not just `dailySupplySideRevenue`:

| date | dailyFees | dailyRevenue | dailySupplySideRevenue | meteoraFee |
|---|---|---|---|---|
| 2026-05-17 | 306.45 | 24222.29 | 0.00 | 61.29 |
| 2026-06-13 | 938.36 | 15906.64 | 0.00 | 187.67 |

`revenue - fees` there is deeply negative if you try to derive supply side from it. What *is* consistent across all 141 days checked, including every bad one: `meteoraFee` is `dailyFees * 0.2` within rounding (0.200003 on 08-30, 0.199807 on 09-04, exact everywhere else) - it reads as a client-computed fixed fraction of `dailyFees`, not an independently corrupted measurement, so it (and `dailyFees` itself) survive whatever breaks `dailyRevenue`/`dailySupplySideRevenue`.

So the derivation goes the other direction from the literal suggestion: keep `dailyFees` and `meteoraFee`, rebuild everything else from those two instead of trusting the broken `dailyRevenue`/`dailyProtocolRevenue`/`dailyHoldersRevenue`/`dailySupplySideRevenue` fields on a detected day.

```ts
const rebuildSplit = supplySideUsd === 0
const protocolRevenueUsd = rebuildSplit ? feesUsd - meteoraFeeUsd : parseFloat(data.dailyProtocolRevenue) || 0
const holdersRevenueUsd = rebuildSplit ? 0 : parseFloat(data.dailyHoldersRevenue) || 0
const lpFeeUsd = rebuildSplit ? 0 : (supplySideUsd || 0) - meteoraFeeUsd
```

`SupplySideRevenue` on a rebuilt day = `meteoraFee` only (no LP-remainder fabricated - it isn't recoverable). `Revenue` = `fees - meteoraFee`, attributed entirely to treasury/`ProtocolRevenue`, none to `HoldersRevenue`. That means the published `Revenue` on a derived day is an **upper bound** (nothing is fabricated for stakers or LPs, but the true treasury/staker split for that specific day is unknown - averaged across healthy days the protocol:staker split ranges 94:6 to 70:30 day to day, so there's no stable ratio to fall back on instead). If you'd rather the unknown residual default to `SupplySideRevenue`/LPs instead of treasury, that's a one-line flip (`protocolRevenueUsd = 0`, add `lpFeeUsd = feesUsd - meteoraFeeUsd` in the `rebuildSplit` branch) - happy to send that instead if you prefer.

`Fees = Revenue + SupplySideRevenue` holds by construction on every rebuilt day (`(fees - meteora) + meteora = fees`, arithmetically exact, no tolerance needed).

## A day the original 13-day list missed

Sweeping the full history (not just the 13 dates from #9277) turned up a 14th contradiction: **2026-05-05** has `dailyFees=0`, `dailySupplySideRevenue=0`, `meteoraFee=0`, but `dailyRevenue=21914.87` - fees of zero next to revenue of $21.9k, the single largest identity violation across the adapter's whole history. A first pass at this fix gated the rebuild on `feesUsd > 0`, which let this exact day through unmodified. Fixed: the signal is just `supplySideUsd === 0`, no fees condition - on a genuinely quiet day (fees=revenue=supply=0) this still fires but produces byte-identical zeros, so it doesn't touch anything that wasn't already zero.

## Out of scope, flagging for awareness

Six other days (07-01, 07-03, 06-01, 06-07, 08-24, 08-25) have `meteoraFee > dailySupplySideRevenue` (not `dailySupplySideRevenue == 0`, just smaller than its own Meteora component), which makes the *existing, unmodified* `lpFeeUsd` clamp (`if (lpFeeUsd > 0)`) silently drop the LP bucket and under-report `SupplySideRevenue` relative to the API's own total by up to ~20% on the worst of those (07-03: published rev+supply is 19.6% over fees). This PR doesn't touch that path - confirmed byte-identical adapter output on those days before/after this change - flagging it as a possible follow-up, not fixing it here to keep this PR scoped to the #9277 contradiction.

## Verification

Live, today, against the real endpoint - repo's own CLI, no mocking:

- All 14 contradiction days (13 from #9277 + 2026-05-05): no throw, `Daily fees == Daily revenue + Daily supply side revenue` exactly on every one (e.g. 2026-05-17: 306 = 245 + 61; 2026-08-31: 0.14 = 0.11 + 0.03; 2026-05-06: 0 = 0 + 0).
- 8 healthy days (including the two lpFee-clamp anomaly days above), diffed byte-for-byte between this branch and unmodified `origin/master` in a separate worktree: identical output in every case, confirming the rebuild path never fires where it shouldn't and normal-day arithmetic is untouched.
- `npx tsc --project tsconfig.json --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
