### PR TITLE
[add] Bubble Curve - add volume, fees, and revenue adapters on Shido

### DIFF
--- a/dexs/bubble-curve.ts
+++ b/dexs/bubble-curve.ts
@@ -15,14 +15,12 @@ const GRADUATED = "event Graduated(address indexed token, address indexed pool, 
 const SHIDO = ADDRESSES.shido.WSHIDO;
 
 const feeBreakdown = {
-  "Bonding Curve Protocol Trading Fees": "Protocol trading fees emitted by the production factory's Trade events, accrued when each trade executes.",
-  "Bonding Curve Creator Trading Fees": "Creator trading fees emitted by Trade events, accrued to token creators regardless of when claimed.",
+  "Bonding Curve Trading Fees": "Protocol and creator trading fees emitted by the production factory's Trade events, accrued when each trade executes regardless of when claimed.",
   "Graduation Fees": "The graduationFee emitted by Graduated, deducted from the curve's native reserve before DEX liquidity is created.",
 };
 
 const userFeeBreakdown = {
-  "Bonding Curve Protocol Trading Fees": "Protocol trading fees directly paid by bonding-curve traders.",
-  "Bonding Curve Creator Trading Fees": "Creator trading fees directly paid by bonding-curve traders.",
+  "Bonding Curve Trading Fees": "Protocol and creator trading fees directly paid by bonding-curve traders.",
 };
 
 const revenueBreakdown = {
@@ -48,24 +46,13 @@ const fetch = async (options: FetchOptions) => {
 
     dailyFees.add(
       SHIDO,
-      trade.protocolFee,
-      "Bonding Curve Protocol Trading Fees"
+      trade.protocolFee + trade.creatorFee,
+      "Bonding Curve Trading Fees"
     );
     dailyUserFees.add(
       SHIDO,
-      trade.protocolFee,
-      "Bonding Curve Protocol Trading Fees"
-    );
-
-    dailyFees.add(
-      SHIDO,
-      trade.creatorFee,
-      "Bonding Curve Creator Trading Fees"
-    );
-    dailyUserFees.add(
-      SHIDO,
-      trade.creatorFee,
-      "Bonding Curve Creator Trading Fees"
+      trade.protocolFee + trade.creatorFee,
+      "Bonding Curve Trading Fees"
     );
 
     dailyRevenue.add(
@@ -104,7 +91,7 @@ const fetch = async (options: FetchOptions) => {
     dailyFees,
     dailyUserFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue.clone(),
+    dailyProtocolRevenue: dailyRevenue,
     dailySupplySideRevenue,
   };
 };
@@ -120,7 +107,7 @@ const adapter: SimpleAdapter = {
     Fees: "Actual protocol and creator trading fees from Trade, plus the graduationFee from Graduated. Accrual basis in native SHIDO, valued using its 1:1 WSHIDO wrapper. No fixed fee-rate estimates, claim double-counting, gas fees or post-graduation fees.",
     UserFees: "Protocol and creator trading fees directly paid by bonding-curve traders. Graduation fees are excluded because they are deducted from the curve reserve before migration rather than charged directly to an end-user.",
     Revenue: "Protocol trading fees plus graduation fees, excluding the creator trading-fee share and all post-graduation revenue.",
-    ProtocolRevenue: "Same as Revenue: fees allocated to the protocol when accrued at the factory. Subsequent treasury spending or announced buybacks are not measured by this adapter.",
+    ProtocolRevenue: "Same as Revenue (protocol trading fees + graduation fees): fees allocated to the protocol when accrued at the factory. Subsequent treasury spending or announced buybacks are not measured by this adapter.",
     SupplySideRevenue: "Creator trading fees accrued by Trade events. This is creator income, not LP fees or revenue of holders of the Bubble Protocol token.",
   },
   breakdownMethodology: {

--- a/dexs/bubble-curve.ts
+++ b/dexs/bubble-curve.ts
@@ -19,6 +19,12 @@ const feeBreakdown = {
   "Bonding Curve Creator Trading Fees": "Creator trading fees emitted by Trade events, accrued to token creators regardless of when claimed.",
   "Graduation Fees": "The graduationFee emitted by Graduated, deducted from the curve's native reserve before DEX liquidity is created.",
 };
+
+const userFeeBreakdown = {
+  "Bonding Curve Protocol Trading Fees": "Protocol trading fees directly paid by bonding-curve traders.",
+  "Bonding Curve Creator Trading Fees": "Creator trading fees directly paid by bonding-curve traders.",
+};
+
 const revenueBreakdown = {
   "Bonding Curve Trading Fees To Protocol": "Only the protocolFee component of Trade events, excluding creator fees.",
   "Graduation Fees To Protocol": "The full graduationFee component of Graduated events, accrued to the protocol.",
@@ -27,26 +33,68 @@ const revenueBreakdown = {
 const fetch = async (options: FetchOptions) => {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
+  const dailyUserFees = options.createBalances();
   const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
   // Use the caller's window. Do not reset fromBlock to deployment here:
   // that would recount history on every hourly pull.
   const trades = await options.getLogs({ target: FACTORY, eventAbi: TRADE });
+
   for (const trade of trades) {
     // Buy: grossUsed (refund excluded). Sell: grossShidoOut (before fees).
     // Count only the SHIDO side, once; neither subtract nor add fees again.
     dailyVolume.add(SHIDO, trade.nativeAmount);
-    dailyFees.add(SHIDO, trade.protocolFee, "Bonding Curve Protocol Trading Fees");
-    dailyFees.add(SHIDO, trade.creatorFee, "Bonding Curve Creator Trading Fees");
-    dailyRevenue.add(SHIDO, trade.protocolFee, "Bonding Curve Trading Fees To Protocol");
-    dailySupplySideRevenue.add(SHIDO, trade.creatorFee, "Bonding Curve Trading Fees To Creators");
+
+    dailyFees.add(
+      SHIDO,
+      trade.protocolFee,
+      "Bonding Curve Protocol Trading Fees"
+    );
+    dailyUserFees.add(
+      SHIDO,
+      trade.protocolFee,
+      "Bonding Curve Protocol Trading Fees"
+    );
+
+    dailyFees.add(
+      SHIDO,
+      trade.creatorFee,
+      "Bonding Curve Creator Trading Fees"
+    );
+    dailyUserFees.add(
+      SHIDO,
+      trade.creatorFee,
+      "Bonding Curve Creator Trading Fees"
+    );
+
+    dailyRevenue.add(
+      SHIDO,
+      trade.protocolFee,
+      "Bonding Curve Trading Fees To Protocol"
+    );
+
+    dailySupplySideRevenue.add(
+      SHIDO,
+      trade.creatorFee,
+      "Bonding Curve Trading Fees To Creators"
+    );
   }
 
-  const graduations = await options.getLogs({ target: FACTORY, eventAbi: GRADUATED });
+  const graduations = await options.getLogs({
+    target: FACTORY,
+    eventAbi: GRADUATED,
+  });
+
   for (const graduation of graduations) {
+    // Graduation fee is deducted from the curve reserve rather than
+    // charged directly to an end-user, so it is not a UserFee.
     dailyFees.add(SHIDO, graduation.graduationFee, "Graduation Fees");
-    dailyRevenue.add(SHIDO, graduation.graduationFee, "Graduation Fees To Protocol");
+    dailyRevenue.add(
+      SHIDO,
+      graduation.graduationFee,
+      "Graduation Fees To Protocol"
+    );
   }
 
   // Claims only settle previously accrued fees; never count them again.
@@ -54,7 +102,7 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyVolume,
     dailyFees,
-    dailyUserFees: dailyFees.clone(),
+    dailyUserFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue.clone(),
     dailySupplySideRevenue,
@@ -70,14 +118,14 @@ const adapter: SimpleAdapter = {
   methodology: {
     Volume: "Gross native SHIDO notional from Trade.nativeAmount on the production v2 bonding-curve factory, counting one side of each buy/sell. Buy refunds are excluded. No legacy-factory activity, BubbleSwap/router activity, post-graduation Shido DEX trading, LP activity or graduation liquidity is counted.",
     Fees: "Actual protocol and creator trading fees from Trade, plus the graduationFee from Graduated. Accrual basis in native SHIDO, valued using its 1:1 WSHIDO wrapper. No fixed fee-rate estimates, claim double-counting, gas fees or post-graduation fees.",
-    UserFees: "Same as Fees: bonding-curve trading fees and the graduation charge borne by the curve reserve before migration. The latter is not an additional payment by the final buyer.",
+    UserFees: "Protocol and creator trading fees directly paid by bonding-curve traders. Graduation fees are excluded because they are deducted from the curve reserve before migration rather than charged directly to an end-user.",
     Revenue: "Protocol trading fees plus graduation fees, excluding the creator trading-fee share and all post-graduation revenue.",
     ProtocolRevenue: "Same as Revenue: fees allocated to the protocol when accrued at the factory. Subsequent treasury spending or announced buybacks are not measured by this adapter.",
     SupplySideRevenue: "Creator trading fees accrued by Trade events. This is creator income, not LP fees or revenue of holders of the Bubble Protocol token.",
   },
   breakdownMethodology: {
     Fees: feeBreakdown,
-    UserFees: feeBreakdown,
+    UserFees: userFeeBreakdown,
     Revenue: revenueBreakdown,
     ProtocolRevenue: revenueBreakdown,
     SupplySideRevenue: {

--- a/dexs/bubble-curve.ts
+++ b/dexs/bubble-curve.ts
@@ -1,0 +1,89 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+
+// https://curve.bubbleswap.io/faq
+// Public ABI: https://curve.bubbleswap.io/dev
+// Production v2 only; deployed at Shido block 41608398 on 2026-08-31.
+// All bonding curves emit here, not at the launched token or DEX pool addresses.
+const FACTORY = "0xe8EFF935F46600640d2d0F55C2b8E65565007fB1";
+const TRADE = "event Trade(address indexed token, address indexed trader, bool indexed isBuy, uint256 nativeAmount, uint256 tokenAmount, uint256 protocolFee, uint256 creatorFee, uint256 postTradeReserve, uint256 postTradePriceX18)";
+const GRADUATED = "event Graduated(address indexed token, address indexed pool, uint256 indexed lpTokenId, address beneficiary, uint256 lockUntil, uint256 graduationFee, uint256 nativeLiquidity, uint256 tokenLiquidity, uint256 burnedTokenRemainder)";
+
+// Events are native SHIDO amounts in wei. WSHIDO wraps native SHIDO 1:1,
+// with the same 18 decimals, and has a supported DefiLlama price mapping.
+const SHIDO = ADDRESSES.shido.WSHIDO;
+
+const feeBreakdown = {
+  "Bonding Curve Protocol Trading Fees": "Protocol trading fees emitted by the production factory's Trade events, accrued when each trade executes.",
+  "Bonding Curve Creator Trading Fees": "Creator trading fees emitted by Trade events, accrued to token creators regardless of when claimed.",
+  "Graduation Fees": "The graduationFee emitted by Graduated, deducted from the curve's native reserve before DEX liquidity is created.",
+};
+const revenueBreakdown = {
+  "Bonding Curve Trading Fees To Protocol": "Only the protocolFee component of Trade events, excluding creator fees.",
+  "Graduation Fees To Protocol": "The full graduationFee component of Graduated events, accrued to the protocol.",
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+
+  // Use the caller's window. Do not reset fromBlock to deployment here:
+  // that would recount history on every hourly pull.
+  const trades = await options.getLogs({ target: FACTORY, eventAbi: TRADE });
+  for (const trade of trades) {
+    // Buy: grossUsed (refund excluded). Sell: grossShidoOut (before fees).
+    // Count only the SHIDO side, once; neither subtract nor add fees again.
+    dailyVolume.add(SHIDO, trade.nativeAmount);
+    dailyFees.add(SHIDO, trade.protocolFee, "Bonding Curve Protocol Trading Fees");
+    dailyFees.add(SHIDO, trade.creatorFee, "Bonding Curve Creator Trading Fees");
+    dailyRevenue.add(SHIDO, trade.protocolFee, "Bonding Curve Trading Fees To Protocol");
+    dailySupplySideRevenue.add(SHIDO, trade.creatorFee, "Bonding Curve Trading Fees To Creators");
+  }
+
+  const graduations = await options.getLogs({ target: FACTORY, eventAbi: GRADUATED });
+  for (const graduation of graduations) {
+    dailyFees.add(SHIDO, graduation.graduationFee, "Graduation Fees");
+    dailyRevenue.add(SHIDO, graduation.graduationFee, "Graduation Fees To Protocol");
+  }
+
+  // Claims only settle previously accrued fees; never count them again.
+  // No legacy factory, router, DEX Swap, LP-fee or liquidity-movement events.
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees.clone(),
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue.clone(),
+    dailySupplySideRevenue,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.SHIDO],
+  start: "2026-08-31",
+  fetch,
+  methodology: {
+    Volume: "Gross native SHIDO notional from Trade.nativeAmount on the production v2 bonding-curve factory, counting one side of each buy/sell. Buy refunds are excluded. No legacy-factory activity, BubbleSwap/router activity, post-graduation Shido DEX trading, LP activity or graduation liquidity is counted.",
+    Fees: "Actual protocol and creator trading fees from Trade, plus the graduationFee from Graduated. Accrual basis in native SHIDO, valued using its 1:1 WSHIDO wrapper. No fixed fee-rate estimates, claim double-counting, gas fees or post-graduation fees.",
+    UserFees: "Same as Fees: bonding-curve trading fees and the graduation charge borne by the curve reserve before migration. The latter is not an additional payment by the final buyer.",
+    Revenue: "Protocol trading fees plus graduation fees, excluding the creator trading-fee share and all post-graduation revenue.",
+    ProtocolRevenue: "Same as Revenue: fees allocated to the protocol when accrued at the factory. Subsequent treasury spending or announced buybacks are not measured by this adapter.",
+    SupplySideRevenue: "Creator trading fees accrued by Trade events. This is creator income, not LP fees or revenue of holders of the Bubble Protocol token.",
+  },
+  breakdownMethodology: {
+    Fees: feeBreakdown,
+    UserFees: feeBreakdown,
+    Revenue: revenueBreakdown,
+    ProtocolRevenue: revenueBreakdown,
+    SupplySideRevenue: {
+      "Bonding Curve Trading Fees To Creators": "The creatorFee component emitted for every bonding-curve trade, whether already claimed or still claimable.",
+    },
+  },
+};
+
+export default adapter;

--- a/fees/bubble-curve.ts
+++ b/fees/bubble-curve.ts
@@ -1,0 +1,1 @@
+export { default } from "../dexs/bubble-curve";

--- a/fees/bubble-curve.ts
+++ b/fees/bubble-curve.ts
@@ -1,1 +1,0 @@
-export { default } from "../dexs/bubble-curve";


### PR DESCRIPTION
### Description

Adds `dexs/bubble-curve.ts` and `fees/bubble-curve.ts` for Bubble Curve's production v2 bonding-curve factory on Shido.

Metrics are calculated directly from the factory's `Trade` and `Graduated` events. The adapters track bonding-curve volume, protocol trading fees, creator trading fees, graduation fees, protocol revenue, and creator supply-side revenue.

User fees consist only of protocol and creator trading fees directly paid by bonding-curve traders. Graduation fees are excluded from user fees because they are deducted from the curve's native reserve before DEX liquidity is created rather than charged as an additional payment to the final buyer.

Post-graduation Shido DEX volume, LP fees, BubbleSwap/router activity, and legacy factory activity are excluded.

### Name (to be shown on DefiLlama):

Bubble Curve

### Twitter Link:

https://x.com/bubble_protocol

### List of audit links if any:

None

### Website Link:

https://curve.bubbleswap.io/

### Logo (High resolution, will be shown with rounded borders):

https://images.mavnode.io/bubble/branding/bpl.png

### Current TVL:

Not included in this submission.

### Treasury Addresses (if the protocol has treasury):

Protocol fees accrue in the production factory:

`0xe8EFF935F46600640d2d0F55C2b8E65565007fB1`

### Chain:

Shido

### Coingecko ID:

N/A

### Coinmarketcap ID:

N/A

### Short Description (to be shown on DefiLlama):

Permissionless token launchpad on Shido with native-SHIDO bonding-curve trading and graduation to Shido DEX.

### Token address and ticker if any:

None specific to Bubble Curve.

### Category:

Launchpad

### Oracle Provider(s):

None for bonding-curve execution.

### Implementation Details:

Bubble Curve uses reserve-based bonding-curve pricing.

The DefiLlama adapters read native SHIDO volume and actual fee amounts directly from the production v2 factory's on-chain `Trade` and `Graduated` events.

`Trade.nativeAmount` is used for bonding-curve volume. `Trade.protocolFee` and `Trade.creatorFee` are used for trading fees. `Graduated.graduationFee` is used for the graduation fee.

Protocol and creator trading fees are reported as user fees because they are directly paid by bonding-curve traders. Graduation fees are included in total fees and protocol revenue but excluded from user fees because they are deducted from the curve reserve during graduation.

Creator trading fees are reported as supply-side revenue. Claims only settle previously accrued fees and are not counted again.

### Documentation/Proof:

https://curve.bubbleswap.io/faq

https://curve.bubbleswap.io/dev

### forkedFrom:

No

### methodology:

This is not a TVL submission.

**Volume:** Gross native SHIDO notional from bonding-curve `Trade` events, counting the SHIDO side of each buy or sell once.

**Fees:** Protocol trading fees, creator trading fees, and graduation fees.

**User Fees:** Protocol and creator trading fees directly paid by bonding-curve traders. Graduation fees are excluded because they are deducted from the curve reserve before migration rather than charged directly to an end-user.

**Protocol Revenue:** Protocol trading fees plus graduation fees.

**Supply-Side Revenue:** Creator trading fees accrued from `Trade` events.

Post-graduation Shido DEX activity, LP fees, BubbleSwap/router activity, legacy factory activity, gas fees, and fee claims are excluded.

### Github org/user (Optional, if your code is open source, we can track activity):

N/A

### Does this project have a referral program?

No
