### PR TITLE
jupiter-lend: wait for the day to finish indexing before reading the fluid dune view

### DIFF
--- a/fees/jupiter-lend/index.ts
+++ b/fees/jupiter-lend/index.ts
@@ -2,6 +2,7 @@ import { Dependencies, FetchOptions, FetchResultV2, SimpleAdapter } from "../../
 import { CHAIN } from "../../helpers/chains";
 import { JUPITER_METRICS, jupBuybackRatioFromRevenue } from "../jupiter";
 import { queryDuneSql } from "../../helpers/dune";
+import { assertDuneSolanaIndexed } from "../../helpers/duneSolanaDex";
 
 // Jupiter Lend runs on Fluid infra as two instances tagged by `instance_name`
 // in the Dune MV: the main Jupiter markets and the isolated Ethena (USDe) market
@@ -19,6 +20,7 @@ const isEthenaInstance = (row: any) => String(row.instance_name || '').toLowerCa
 const sumUsd = (rows: any[], key: string) => rows.reduce((sum, row) => sum + (row[key] || 0), 0);
 
 const fetch = async (options: FetchOptions): Promise<FetchResultV2> => {
+  assertDuneSolanaIndexed(options)
 
   // const sql = getSqlFromFile("helpers/queries/jupiter-lend.sql", {
   //   start: options.startTimestamp,


### PR DESCRIPTION
Fixes #9347.

`fees/jupiter-lend` reads the Fluid materialized view with no wait, so a run that lands while the MV
is mid-refresh gets *some* rows for the day, passes the `data.length === 0` check just below, and
stores the partial as the day's number. 09-06 was stored as **$20,334 against a 10-day mean of
$134,201**: 15.2% of a normal day; and nothing has published since.

This is the guard #9221 added to the six solana Dune adapters for the same reason ("wait for the day
to finish indexing, published volume is truncated by 13-37%"). `fees/jupiter-lend` was not in that
sweep. Its siblings all published complete days through 09-07; this one did not.

## verification

```
# a day that ended less than 10h ago is now refused instead of read half-baked
$ npx ts-node cli/testAdapter.ts fees jupiter-lend 2026-09-09
End timestamp is less than 10 hours ago, skipping fetch due to dune indexing delay
  2026-09-08T23:59:59.000Z 2026-09-08T21:11:38.095Z

# an older day passes the guard and goes on to the dune call as before
$ npx ts-node cli/testAdapter.ts fees jupiter-lend 2026-09-06
Error: DUNE_API_KEYS environment variable is not set
```

`npx tsc --noEmit` is clean.

Being explicit about what I could not check: I have no Dune key, so I cannot execute the query
itself; the second run above gets as far as the key and stops. The change is the same one-line
guard already merged for six adapters, so there is no new logic to get wrong, but the 10-hour
threshold is inherited rather than measured against *this* source. If the Fluid MV refreshes later
than that, the wait needs to be longer for this adapter, and only the runner logs would show it.
