### PR TITLE
dodo: skip unfinished dashboard chains so healthy legs still publish

### DIFF
--- a/dexs/dodo/index.ts
+++ b/dexs/dodo/index.ts
@@ -81,30 +81,43 @@ interface IDailyResponse {
 //   };
 // }
 
+function trailingMedian(list: IDailyResponse['data']['dashboard_chain_day_data']['list'], chain: string, startOfDay: number): number {
+  const trailing = list
+    .filter((item: any) => item.timestamp < startOfDay && item.timestamp >= startOfDay - 7 * 24 * 60 * 60)
+    .map((item: any) => Number(item.volume[chain]))
+    .filter((value: number) => Number.isFinite(value))
+    .sort((a: number, b: number) => a - b)
+  return trailing.length ? trailing[Math.floor(trailing.length / 2)] : 0
+}
+
 const fetch = async (options: FetchOptions) => {
   const chain = chainConversion(options.chain)
   const dailyResponse = (await postURL(dailyEndpoint, dailyVolumePayload(chain))) as IDailyResponse
   const list = dailyResponse.data.dashboard_chain_day_data.list
   const day = list.find((item: any) => item.timestamp === options.startOfDay)
+  const median = trailingMedian(list, chain, options.startOfDay)
 
-  if (!day)
+  // the day table sometimes returns 0 / no row for a chain it has not finished
+  // aggregating yet, then backfills later (#9111/#9296). returning that 0 would
+  // cache a fake quiet day; throwing would abort Promise.all and blank every
+  // other chain. null is not stored, so siblings can still publish.
+  const skipUnfinished = () => {
+    console.error(`dodo: ${chain} looks unfinished for ${options.dateString} against a 7 day median of ${Math.round(median)}; skipping this chain so other chains can still publish`)
+    return { dailyVolume: null as any }
+  }
+
+  if (!day) {
+    // dust chains genuinely miss quiet days; a high median means lag, not quiet
+    if (median > 10000) return skipUnfinished()
     throw new Error(`dodo: dashboard_chain_day_data has no ${chain} row for ${options.dateString}`)
+  }
 
   const dailyVolume = Number(day.volume[chain])
 
   if (!Number.isFinite(dailyVolume))
     throw new Error(`dodo: ${chain} is missing from the volume object for ${options.dateString}`)
 
-  if (dailyVolume === 0) {
-    const trailing = list
-      .filter((item: any) => item.timestamp < options.startOfDay && item.timestamp >= options.startOfDay - 7 * 24 * 60 * 60)
-      .map((item: any) => Number(item.volume[chain]))
-      .filter((value: number) => Number.isFinite(value))
-      .sort((a: number, b: number) => a - b)
-    const median = trailing.length ? trailing[Math.floor(trailing.length / 2)] : 0
-    if (median > 10000)
-      throw new Error(`dodo: ${chain} reports 0 volume for ${options.dateString} against a 7 day median of ${Math.round(median)}, refusing to publish a day the dashboard has not finished aggregating`)
-  }
+  if (dailyVolume === 0 && median > 10000) return skipUnfinished()
 
   return { dailyVolume }
 }


### PR DESCRIPTION
## Summary
- Fixes #9296: when `gateway.dodoex.io` day-table rows for ethereum/bsc/arbitrum are still `0` (unfinished aggregation), the #9112 guard threw and `Promise.all` blanked the whole protocol — including polygon/avalanche/optimism, which already had real rows (~$4.4M/day).
- Keeps the guard’s intent: do **not** store a fake `$0` when volume is `0` (or the day row is missing) against a 7-day median > $10k.
- Changes the failure mode from `throw` → `dailyVolume: null` (not stored) + log, so only the unfinished chain is omitted, and siblings still publish.
- Does **not** permanently `deadFrom` eth/bsc/arb — the freeze is intermittent (e.g. 2026-09-07 published all six).

## Test plan
- [x] `npm run test dexs dodo 2026-09-05` (day 09-04) → skips eth/bsc/arb, aggregate **~$4.46M** (polygon + avax + op)
- [x] `npm run test dexs dodo 2026-09-04` (day 09-03, healthy) → all major chains, aggregate **~$9.39M**
- [x] `npm run test dexs dodo 2026-09-09` (day 09-08, frozen again) → skips eth/bsc/arb, aggregate **~$10.65M**
- [ ] Refill missing/partial days after merge once day-table cells are non-zero