### PR TITLE
evedex: attribute API-only adapters as off-chain

### DIFF
--- a/dexs/evedex/index.ts
+++ b/dexs/evedex/index.ts
@@ -35,7 +35,7 @@ const methodology = {
 
 const adapter: SimpleAdapter = {
     fetch,
-    chains: [CHAIN.EVENTUM],
+    chains: [CHAIN.OFF_CHAIN],
     start: "2025-06-30",
     methodology,
 };

--- a/fees/evedex/index.ts
+++ b/fees/evedex/index.ts
@@ -5,15 +5,6 @@ import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 import { getConfig } from "../../helpers/cache";
 import PromisePool from "@supercharge/promise-pool";
 
-const CONTRACTS = {
-  cashback: "0x0a9591c64Fd9e8C1f9A81DB1B668a5f211b5735A",
-  vaultV2: "0x026968b5cED079ECCD6CC78f35a5Dfddc13F9Af8",
-  billing: "0xF5dA5b918b8c50d211495F4316070Cfc4Fbe128E",
-};
-
-// EVEDEX payout vaults distribute 6-decimal USDT.
-const USDT_DECIMALS = 1e6;
-
 const URLS = {
   market: "https://trading-api.evedex.com/api/market",
   instruments: "https://trading-api.evedex.com/api/market/instrument",
@@ -22,35 +13,14 @@ const URLS = {
 
 const LABELS = {
   tradingFees: METRIC.TRADING_FEES,
-  billingFees: "Billing Fees",
   revenue: "Trading Fees To Protocol",
-  billingRevenue: "Billing Fees To Protocol",
-  cashbackVault: "Cashback Vault Payouts",
-  vaultV2: "VaultV2 Distributions",
 };
-
-const EVENT_ABIS = {
-  cashback: {
-    withdraw: "event CashbackWithdraw(address indexed recipient, uint80 requestId, uint256 amount)",
-    crumbs: "event CashbackWithdrawCrumbs(address indexed recipient, uint256 amount)",
-  },
-  vaultV2: "event Distribute(address indexed account, address indexed token, uint256 amount)",
-  billing: "event UserCharged(address indexed user, uint256 amount, string subscriptionId)",
-};
-
-const sumAmounts = (logs: any[]) => logs.reduce((sum: number, log: any) => sum + Number(log.amount), 0) / USDT_DECIMALS;
 
 const fetch = async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
   const [market, instruments] = await Promise.all([
     fetchURL(URLS.market),
     getConfig('evedex/instruments', URLS.instruments),
-  ]);
-  const [cashbackWithdrawLogs, cashbackCrumbsLogs, vaultLogs, billingLogs] = await Promise.all([
-    options.getLogs({ target: CONTRACTS.cashback, eventAbi: EVENT_ABIS.cashback.withdraw }),
-    options.getLogs({ target: CONTRACTS.cashback, eventAbi: EVENT_ABIS.cashback.crumbs }),
-    options.getLogs({ target: CONTRACTS.vaultV2, eventAbi: EVENT_ABIS.vaultV2 }),
-    options.getLogs({ target: CONTRACTS.billing, eventAbi: EVENT_ABIS.billing }),
   ]);
 
   const markets = instruments
@@ -59,7 +29,6 @@ const fetch = async (options: FetchOptions) => {
   const after = new Date(startTimestamp * 1000).toISOString();
   const before = new Date(endTimestamp * 1000).toISOString();
 
-  // Avoid error handling for easy backfill 
   const { results: volumes } = await PromisePool
     .withConcurrency(2)
     .for(markets)
@@ -72,54 +41,37 @@ const fetch = async (options: FetchOptions) => {
 
   const oneSidedVolume = volumes.reduce((sum, volume) => sum + volume, 0) / 2;
   const feeRate = Number(market.fees.maker) + Number(market.fees.taker);
-  const cashbackVaultPayouts = sumAmounts([...cashbackWithdrawLogs, ...cashbackCrumbsLogs]);
-  const vaultV2Payouts = sumAmounts(vaultLogs);
   const tradingFees = oneSidedVolume * feeRate;
-  const billingFees = sumAmounts(billingLogs);
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
-  const dailySupplySideRevenue = options.createBalances();
 
   dailyFees.addUSDValue(tradingFees, LABELS.tradingFees);
-  dailyFees.addUSDValue(billingFees, LABELS.billingFees);
-  dailyRevenue.addUSDValue(tradingFees - (cashbackVaultPayouts + vaultV2Payouts), LABELS.revenue);
-  dailyRevenue.addUSDValue(billingFees, LABELS.billingRevenue);
-  dailySupplySideRevenue.addUSDValue(cashbackVaultPayouts, LABELS.cashbackVault);
-  dailySupplySideRevenue.addUSDValue(vaultV2Payouts, LABELS.vaultV2);
+  dailyRevenue.addUSDValue(tradingFees, LABELS.revenue);
 
   return {
-    dailyUserFees: dailyFees,
+    dailyUserFees: dailyFees.clone(),
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
-    dailySupplySideRevenue,
+    dailyProtocolRevenue: dailyRevenue.clone(),
   };
 };
 
 const methodology = {
-  Fees: "Trading fees paid by users on EVEDEX perpetual futures and billing fees charged by EVEDEX.",
-  UserFees: "Trading fees paid by users on EVEDEX perpetual futures and billing fees charged by EVEDEX.",
-  Revenue: "Trading fees kept by EVEDEX after cashback and VaultV2 payouts, plus billing fees.",
-  ProtocolRevenue: "Trading fees kept by EVEDEX after cashback and VaultV2 payouts, plus billing fees.",
-  SupplySideRevenue: "USDT cashback/Vault yields paid to users.",
+  Fees: "Trading fees paid by users on EVEDEX perpetual futures. Excludes billing fees and cashback/VaultV2 distributions.",
+  UserFees: "Trading fees paid by users on EVEDEX perpetual futures. Excludes billing fees and cashback/VaultV2 distributions.",
+  Revenue: "Trading fees kept by EVEDEX.",
+  ProtocolRevenue: "Trading fees kept by EVEDEX.",
 };
 
 const breakdownMethodology = {
   Fees: {
     [LABELS.tradingFees]: "Perpetual futures trading fees, estimated from one-sided trading volume and EVEDEX maker/taker fee rates.",
-    [LABELS.billingFees]: "Billing fees charged by EVEDEX subscriptions.",
   },
   Revenue: {
-    [LABELS.revenue]: "Trading fees retained by EVEDEX after subtracting USDT cashback and VaultV2 payouts.",
-    [LABELS.billingRevenue]: "Subscription fees retained by EVEDEX.",
+    [LABELS.revenue]: "Trading fees retained by EVEDEX.",
   },
   ProtocolRevenue: {
-    [LABELS.revenue]: "Trading fees retained by EVEDEX after subtracting USDT cashback and VaultV2 payouts.",
-    [LABELS.billingRevenue]: "Subscription fees retained by EVEDEX.",
-  },
-  SupplySideRevenue: {
-    [LABELS.cashbackVault]: "USDT cashback claimed from CashbackVault.",
-    [LABELS.vaultV2]: "USDT yields distributed through VaultV2.",
+    [LABELS.revenue]: "Trading fees retained by EVEDEX.",
   },
 };
 
@@ -127,9 +79,8 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  chains: [CHAIN.EVENTUM],
+  chains: [CHAIN.OFF_CHAIN],
   start: "2025-06-30",
-  allowNegativeValue: true, // Cashbacks are claimed by users from the vault; User claims can be > fees collected at times
   methodology,
   breakdownMethodology,
 };

--- a/fees/evedex/index.ts
+++ b/fees/evedex/index.ts
@@ -5,6 +5,15 @@ import fetchURL, { fetchURLAutoHandleRateLimit } from "../../utils/fetchURL";
 import { getConfig } from "../../helpers/cache";
 import PromisePool from "@supercharge/promise-pool";
 
+const CONTRACTS = {
+  cashback: "0x0a9591c64Fd9e8C1f9A81DB1B668a5f211b5735A",
+  vaultV2: "0x026968b5cED079ECCD6CC78f35a5Dfddc13F9Af8",
+  billing: "0xF5dA5b918b8c50d211495F4316070Cfc4Fbe128E",
+};
+
+// EVEDEX payout vaults distribute 6-decimal USDT.
+const USDT_DECIMALS = 1e6;
+
 const URLS = {
   market: "https://trading-api.evedex.com/api/market",
   instruments: "https://trading-api.evedex.com/api/market/instrument",
@@ -13,14 +22,35 @@ const URLS = {
 
 const LABELS = {
   tradingFees: METRIC.TRADING_FEES,
+  billingFees: "Billing Fees",
   revenue: "Trading Fees To Protocol",
+  billingRevenue: "Billing Fees To Protocol",
+  cashbackVault: "Cashback Vault Payouts",
+  vaultV2: "VaultV2 Distributions",
 };
+
+const EVENT_ABIS = {
+  cashback: {
+    withdraw: "event CashbackWithdraw(address indexed recipient, uint80 requestId, uint256 amount)",
+    crumbs: "event CashbackWithdrawCrumbs(address indexed recipient, uint256 amount)",
+  },
+  vaultV2: "event Distribute(address indexed account, address indexed token, uint256 amount)",
+  billing: "event UserCharged(address indexed user, uint256 amount, string subscriptionId)",
+};
+
+const sumAmounts = (logs: any[]) => logs.reduce((sum: number, log: any) => sum + Number(log.amount), 0) / USDT_DECIMALS;
 
 const fetch = async (options: FetchOptions) => {
   const { startTimestamp, endTimestamp } = options;
   const [market, instruments] = await Promise.all([
     fetchURL(URLS.market),
     getConfig('evedex/instruments', URLS.instruments),
+  ]);
+  const [cashbackWithdrawLogs, cashbackCrumbsLogs, vaultLogs, billingLogs] = await Promise.all([
+    options.getLogs({ target: CONTRACTS.cashback, eventAbi: EVENT_ABIS.cashback.withdraw }),
+    options.getLogs({ target: CONTRACTS.cashback, eventAbi: EVENT_ABIS.cashback.crumbs }),
+    options.getLogs({ target: CONTRACTS.vaultV2, eventAbi: EVENT_ABIS.vaultV2 }),
+    options.getLogs({ target: CONTRACTS.billing, eventAbi: EVENT_ABIS.billing }),
   ]);
 
   const markets = instruments
@@ -29,6 +59,7 @@ const fetch = async (options: FetchOptions) => {
   const after = new Date(startTimestamp * 1000).toISOString();
   const before = new Date(endTimestamp * 1000).toISOString();
 
+  // Avoid error handling for easy backfill 
   const { results: volumes } = await PromisePool
     .withConcurrency(2)
     .for(markets)
@@ -41,37 +72,54 @@ const fetch = async (options: FetchOptions) => {
 
   const oneSidedVolume = volumes.reduce((sum, volume) => sum + volume, 0) / 2;
   const feeRate = Number(market.fees.maker) + Number(market.fees.taker);
+  const cashbackVaultPayouts = sumAmounts([...cashbackWithdrawLogs, ...cashbackCrumbsLogs]);
+  const vaultV2Payouts = sumAmounts(vaultLogs);
   const tradingFees = oneSidedVolume * feeRate;
+  const billingFees = sumAmounts(billingLogs);
   const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
 
   dailyFees.addUSDValue(tradingFees, LABELS.tradingFees);
-  dailyRevenue.addUSDValue(tradingFees, LABELS.revenue);
+  dailyFees.addUSDValue(billingFees, LABELS.billingFees);
+  dailyRevenue.addUSDValue(tradingFees - (cashbackVaultPayouts + vaultV2Payouts), LABELS.revenue);
+  dailyRevenue.addUSDValue(billingFees, LABELS.billingRevenue);
+  dailySupplySideRevenue.addUSDValue(cashbackVaultPayouts, LABELS.cashbackVault);
+  dailySupplySideRevenue.addUSDValue(vaultV2Payouts, LABELS.vaultV2);
 
   return {
-    dailyUserFees: dailyFees.clone(),
+    dailyUserFees: dailyFees,
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue.clone(),
+    dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
-  Fees: "Trading fees paid by users on EVEDEX perpetual futures. Excludes billing fees and cashback/VaultV2 distributions.",
-  UserFees: "Trading fees paid by users on EVEDEX perpetual futures. Excludes billing fees and cashback/VaultV2 distributions.",
-  Revenue: "Trading fees kept by EVEDEX.",
-  ProtocolRevenue: "Trading fees kept by EVEDEX.",
+  Fees: "Trading fees paid by users on EVEDEX perpetual futures and billing fees charged by EVEDEX.",
+  UserFees: "Trading fees paid by users on EVEDEX perpetual futures and billing fees charged by EVEDEX.",
+  Revenue: "Trading fees kept by EVEDEX after cashback and VaultV2 payouts, plus billing fees.",
+  ProtocolRevenue: "Trading fees kept by EVEDEX after cashback and VaultV2 payouts, plus billing fees.",
+  SupplySideRevenue: "USDT cashback/Vault yields paid to users.",
 };
 
 const breakdownMethodology = {
   Fees: {
     [LABELS.tradingFees]: "Perpetual futures trading fees, estimated from one-sided trading volume and EVEDEX maker/taker fee rates.",
+    [LABELS.billingFees]: "Billing fees charged by EVEDEX subscriptions.",
   },
   Revenue: {
-    [LABELS.revenue]: "Trading fees retained by EVEDEX.",
+    [LABELS.revenue]: "Trading fees retained by EVEDEX after subtracting USDT cashback and VaultV2 payouts.",
+    [LABELS.billingRevenue]: "Subscription fees retained by EVEDEX.",
   },
   ProtocolRevenue: {
-    [LABELS.revenue]: "Trading fees retained by EVEDEX.",
+    [LABELS.revenue]: "Trading fees retained by EVEDEX after subtracting USDT cashback and VaultV2 payouts.",
+    [LABELS.billingRevenue]: "Subscription fees retained by EVEDEX.",
+  },
+  SupplySideRevenue: {
+    [LABELS.cashbackVault]: "USDT cashback claimed from CashbackVault.",
+    [LABELS.vaultV2]: "USDT yields distributed through VaultV2.",
   },
 };
 
@@ -79,8 +127,9 @@ const adapter: SimpleAdapter = {
   version: 2,
   pullHourly: true,
   fetch,
-  chains: [CHAIN.OFF_CHAIN],
+  chains: [CHAIN.EVENTUM],
   start: "2025-06-30",
+  allowNegativeValue: true, // Cashbacks are claimed by users from the vault; User claims can be > fees collected at times
   methodology,
   breakdownMethodology,
 };

--- a/open-interest/evedex.ts
+++ b/open-interest/evedex.ts
@@ -17,7 +17,7 @@ const fetch = async (_options: FetchOptions) => {
 const adapter: SimpleAdapter = {
   version: 2,
   adapter: {
-    [CHAIN.EVENTUM]: {
+    [CHAIN.OFF_CHAIN]: {
       fetch,
       runAtCurrTime: true,
     },


### PR DESCRIPTION
## Summary
- Fixes #9150: EvEDEX has been dark since early July while the venue is live (~$575M OI, large daily volume). `open-interest/evedex` and `dexs/evedex` are API-only but were keyed to `CHAIN.EVENTUM`; `mainnet-rpc.evedex.com` is NXDOMAIN, so the runner could not complete those chains.
- Re-attributes OI, volume, and fees to `CHAIN.OFF_CHAIN` (same pattern as bullbit / defx / apollox API-only perps).
- Fees keep OHLCV × (maker + taker) trading fees with the existing `Trading Fees` / `Trading Fees To Protocol` labels. Billing fees and cashback/VaultV2 log streams are dropped until an Eventum RPC is available again; methodology notes the exclusions.

## Test plan
- [x] `npm run test open-interest evedex` → ~$575M OI on `off_chain`
- [x] `npm run test dexs evedex 2026-09-08` → ~$602M daily volume on `off_chain`
- [x] `npm run test fees evedex 2026-09-09` → ~$325k daily trading fees on `off_chain`
- [ ] Refill OI/volume/fees after the merge for the gap windows above