### PR TITLE
Mark prism-dex fees and volume as sunset

### DIFF
--- a/factory/uniV3.ts
+++ b/factory/uniV3.ts
@@ -231,7 +231,7 @@ const configs: Record<string, Record<string, any>> = {
     [CHAIN.XRPL_EVM]: { factory: '0x678100B9095848FCD4AE6C79A7D29c11815D07fe', revenueRatio: 0, protocolRevenueRatio: 0, holdersRevenueRatio: 0 },
   },
   "prism-dex": {
-    [CHAIN.MEGAETH]: { factory: '0x1adb8f973373505bb206e0e5d87af8fb1f5514ef', userFeesRatio: 1, revenueRatio: 0.25, protocolRevenueRatio: 0.25, start: '2026-02-09' },
+    [CHAIN.MEGAETH]: { factory: '0x1adb8f973373505bb206e0e5d87af8fb1f5514ef', userFeesRatio: 1, revenueRatio: 0.25, protocolRevenueRatio: 0.25, start: '2026-02-09', deadFrom: '2026-09-09' },
   },
   "parity-dex-cl": {
     [CHAIN.MONAD]: { factory: '0x2A6CE23C5017aF1b07B9c4E4014442aDE18Bd404', start: '2026-02-11' },


### PR DESCRIPTION
## Summary
- Prism DEX is shutting down. Adds `deadFrom: 2026-09-09` on the MegaETH `prism-dex` factory config so fees and volume stop updating.
- Same pattern as `kura-v3` in this file.
- Historical fees/volume should stay. Methodology is unchanged.

Companion TVL sunset: https://github.com/DefiLlama/DefiLlama-Adapters/pull/20961

## Test plan
- [ ] Confirm `deadFrom` on the chain config is enough for the server to skip collection
- [ ] Confirm historical MegaETH fees and DEX volume remain on https://defillama.com/protocol/prism-dex