### PR TITLE
fix (dinari): track v2 order processor after 2026-06-07 pause

### DIFF
--- a/dexs/dinari/index.ts
+++ b/dexs/dinari/index.ts
@@ -1,75 +1,103 @@
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
+
 // https://github.com/dinaricrypto/sbt-contracts
 // https://github.com/dinaricrypto/sbt-contracts/blob/main/releases/v1.0.0/order_processor.json
-// https://github.com/dinaricrypto/sbt-contracts/blob/50f7cb5f0613c03fad42e7ece78e56d2992d03ba/src/orders/OrderProcessor.sol#L652
+// v2: https://arbiscan.io/address/0xf60f689ec22fC2D485b3C734eFE58538cCc28766
+const V2_PROCESSOR = "0xf60f689ec22fC2D485b3C734eFE58538cCc28766";
+const V2_START_TS = 1780790400; // 2026-06-07 — legacy OrderProcessors paused
+
 const config: Record<string, { processor: string; start: string }> = {
-    [CHAIN.ETHEREUM]: { processor: "0xA8a48C202AF4E73ad19513D37158A872A4ac79Cb", start: "2024-05-22" },
-    [CHAIN.ARBITRUM]: { processor: "0xFA922457873F750244D93679df0d810881E4131D", start: "2024-05-22" },
-    [CHAIN.BASE]: { processor: "0x63FF43009f9ba3584aF2Ddfc3D5FE2cb8AE539c0", start: "2024-06-07" },
-    [CHAIN.PLUME]: { processor: "0xc1571FEbBb6F8b62eDD0E4694714A382885d6bAB", start: "2025-04-22" },
+  [CHAIN.ETHEREUM]: { processor: "0xA8a48C202AF4E73ad19513D37158A872A4ac79Cb", start: "2024-05-22" },
+  [CHAIN.ARBITRUM]: { processor: "0xFA922457873F750244D93679df0d810881E4131D", start: "2024-05-22" },
+  [CHAIN.BASE]: { processor: "0x63FF43009f9ba3584aF2Ddfc3D5FE2cb8AE539c0", start: "2024-06-07" },
+  [CHAIN.PLUME]: { processor: "0xc1571FEbBb6F8b62eDD0E4694714A382885d6bAB", start: "2025-04-22" },
 };
 
-const events = {
-    OrderFill: "event OrderFill(uint256 indexed id, address indexed paymentToken, address indexed assetToken, address requester, uint256 assetAmount, uint256 paymentAmount, uint256 feesTaken, bool sell)",
-};
+const ORDER_FILL =
+  "event OrderFill(uint256 indexed id, address indexed paymentToken, address indexed assetToken, address requester, uint256 assetAmount, uint256 paymentAmount, uint256 feesTaken, bool sell)";
+
+const REQUEST_TOPICS = [
+  "0xbd045500f2277c3a6864bc1421e90d6eeb36bb9d1d92c2b7d16cb1d942c90fa3",
+  "0xa56a3770fc4f301b41d7919ce30551c6449d44c0954dfc8a8d5e8bb2001588ee",
+];
+const SETTLED_TOPIC = "0x4907bbdd27eecc3fd5b0202f215bb36933e3601de096474cb7afb6f5c0b4aeb1";
+
+const word = (data: string, i: number) => BigInt(`0x${data.slice(2 + i * 64, 2 + (i + 1) * 64)}`);
 
 const fetch = async (options: FetchOptions) => {
-    const { createBalances, getLogs } = options;
-    const { processor } = config[options.chain];
+  const { processor } = config[options.chain];
+  const dailyFees = options.createBalances();
+  const dailyVolume = options.createBalances();
 
-    const dailyFees = createBalances();
-    const dailyVolume = createBalances();
+  if (options.startTimestamp < V2_START_TS) {
+    const logs = await options.getLogs({ target: processor, eventAbi: ORDER_FILL });
+    for (const log of logs as any[]) {
+      dailyVolume.add(log.paymentToken, log.paymentAmount);
+      dailyFees.add(log.paymentToken, log.feesTaken, METRIC.TRADING_FEES);
+    }
+  }
 
-    const orderFilledLogs = await getLogs({
-        target: processor,
-        eventAbi: events.OrderFill,
-    });
+  if (options.endTimestamp > V2_START_TS) {
+    const [req0, req1, settled] = await Promise.all([
+      options.getLogs({ target: V2_PROCESSOR, topics: [REQUEST_TOPICS[0]], entireLog: true }),
+      options.getLogs({ target: V2_PROCESSOR, topics: [REQUEST_TOPICS[1]], entireLog: true }),
+      options.getLogs({ target: V2_PROCESSOR, topics: [SETTLED_TOPIC], entireLog: true }),
+    ]);
 
-    orderFilledLogs.forEach((log: any) => {
-        dailyVolume.add(log.paymentToken, log.paymentAmount);
-        dailyFees.add(log.paymentToken, log.feesTaken, METRIC.TRADING_FEES);
-    });
+    for (const log of [...req0, ...req1] as any[]) {
+      const paymentQty = word(log.data, 4); // buys; sells are 0 here
+      const fee = word(log.data, 5);
+      if (paymentQty > 0n) dailyVolume.addUSDValue(Number(paymentQty) / 1e18);
+      if (fee > 0n) dailyFees.addUSDValue(Number(fee) / 1e18, METRIC.TRADING_FEES);
+    }
 
-    return {
-        dailyVolume,
-        dailyFees,
-        dailyUserFees: dailyFees,
-        dailyRevenue: dailyFees,
-        dailyProtocolRevenue: dailyFees,
-    };
+    for (const log of settled as any[]) {
+      const usd = Number(word(log.data, 0)) / 1e18;
+      if (usd >= 1) dailyVolume.addUSDValue(usd);
+    }
+  }
+
+  return {
+    dailyVolume,
+    dailyFees,
+    dailyUserFees: dailyFees.clone(),
+    dailyRevenue: dailyFees.clone(),
+    dailyProtocolRevenue: dailyFees.clone(),
+  };
 };
 
 const methodology = {
-    Fees: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).",
-    UserFees: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are paid by users.",
-    Revenue: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are revenue.",
-    ProtocolRevenue: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) goes to the protocol.",
+  Fees: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).",
+  UserFees: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are paid by users.",
+  Revenue: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are revenue.",
+  ProtocolRevenue: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) goes to the protocol.",
+  Volume: "Payment-token notional of dShare orders.",
 };
 
 const breakdownMethodology = {
-    Fees: {
-        [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).",
-    },
-    UserFees: {
-        [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are paid by users.",
-    },
-    Revenue: {
-        [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are revenue.",
-    },
-    ProtocolRevenue: {
-        [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) goes to the protocol.",
-    },
+  Fees: {
+    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).",
+  },
+  UserFees: {
+    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are paid by users.",
+  },
+  Revenue: {
+    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are revenue.",
+  },
+  ProtocolRevenue: {
+    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) goes to the protocol.",
+  },
 };
 
 const adapter: Adapter = {
-    version: 2,
-    pullHourly: true,
-    adapter: config,
-    fetch,
-    methodology,
-    breakdownMethodology,
+  version: 2,
+  pullHourly: true,
+  adapter: config,
+  fetch,
+  methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/dexs/dinari/index.ts
+++ b/dexs/dinari/index.ts
@@ -1,61 +1,71 @@
+import { ethers } from "ethers";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
 
+// Legacy (v1) OrderProcessors — open source:
 // https://github.com/dinaricrypto/sbt-contracts
 // https://github.com/dinaricrypto/sbt-contracts/blob/main/releases/v1.0.0/order_processor.json
-// v2: https://arbiscan.io/address/0xf60f689ec22fC2D485b3C734eFE58538cCc28766
 const V2_PROCESSOR = "0xf60f689ec22fC2D485b3C734eFE58538cCc28766";
-const V2_START_TS = 1780790400; // 2026-06-07 — legacy OrderProcessors paused
+const V2_START_TS = 1780790400; // 2026-06-07
 
 const config: Record<string, { processor: string; start: string }> = {
-  [CHAIN.ETHEREUM]: { processor: "0xA8a48C202AF4E73ad19513D37158A872A4ac79Cb", start: "2024-05-22" },
-  [CHAIN.ARBITRUM]: { processor: "0xFA922457873F750244D93679df0d810881E4131D", start: "2024-05-22" },
-  [CHAIN.BASE]: { processor: "0x63FF43009f9ba3584aF2Ddfc3D5FE2cb8AE539c0", start: "2024-06-07" },
-  [CHAIN.PLUME]: { processor: "0xc1571FEbBb6F8b62eDD0E4694714A382885d6bAB", start: "2025-04-22" },
-};
+    [CHAIN.ETHEREUM]: { processor: "0xA8a48C202AF4E73ad19513D37158A872A4ac79Cb", start: "2024-05-22" },
+    [CHAIN.ARBITRUM]: { processor: "0xFA922457873F750244D93679df0d810881E4131D", start: "2024-05-22" },
+    [CHAIN.BASE]: { processor: "0x63FF43009f9ba3584aF2Ddfc3D5FE2cb8AE539c0", start: "2024-06-07" },
+    [CHAIN.PLUME]: { processor: "0xc1571FEbBb6F8b62eDD0E4694714A382885d6bAB", start: "2025-04-22" },
+   };
 
+// ---- v1 events -----------------------------------------------------------------------
 const ORDER_FILL =
   "event OrderFill(uint256 indexed id, address indexed paymentToken, address indexed assetToken, address requester, uint256 assetAmount, uint256 paymentAmount, uint256 feesTaken, bool sell)";
 
-const REQUEST_TOPICS = [
-  "0xbd045500f2277c3a6864bc1421e90d6eeb36bb9d1d92c2b7d16cb1d942c90fa3",
-  "0xa56a3770fc4f301b41d7919ce30551c6449d44c0954dfc8a8d5e8bb2001588ee",
-];
-const SETTLED_TOPIC = "0x4907bbdd27eecc3fd5b0202f215bb36933e3601de096474cb7afb6f5c0b4aeb1";
+// ---- v2 events -----------------------------------------------------------------------
+const ORDER_REQUESTED =
+  "event OrderRequested(address indexed requester, address indexed assetToken, address indexed paymentToken, address recipient, uint8 orderType, uint8 side, uint256 assetAmount, uint256 paymentAmount, uint256 fee, string externalId, uint256 timestamp)";
+const MANAGED_ORDER_REQUESTED =
+  "event ManagedOrderRequested(address indexed requester, address indexed assetToken, address indexed paymentToken, address recipient, uint8 orderType, uint8 side, uint256 assetAmount, uint256 paymentAmount, uint256 fee, string externalId, uint256 timestamp)";
 
-const word = (data: string, i: number) => BigInt(`0x${data.slice(2 + i * 64, 2 + (i + 1) * 64)}`);
+const SETTLED_TOPIC = "0x4907bbdd27eecc3fd5b0202f215bb36933e3601de096474cb7afb6f5c0b4aeb1";
+const SETTLED_DATA_TYPES = ["uint256", "string", "uint256", "bytes32"];
+const abiCoder = ethers.AbiCoder.defaultAbiCoder();
+
+const USD_1E18 = 1e18;
 
 const fetch = async (options: FetchOptions) => {
-  const { processor } = config[options.chain];
   const dailyFees = options.createBalances();
   const dailyVolume = options.createBalances();
 
+  // v1: raw payment-token amounts, priced by the balances helper
   if (options.startTimestamp < V2_START_TS) {
-    const logs = await options.getLogs({ target: processor, eventAbi: ORDER_FILL });
-    for (const log of logs as any[]) {
+    const logs = await options.getLogs({ target: config[options.chain].processor, eventAbi: ORDER_FILL });
+    for (const log of logs) {
       dailyVolume.add(log.paymentToken, log.paymentAmount);
       dailyFees.add(log.paymentToken, log.feesTaken, METRIC.TRADING_FEES);
     }
   }
 
+  // v2: USD values normalised to 18 decimals on-chain
   if (options.endTimestamp > V2_START_TS) {
-    const [req0, req1, settled] = await Promise.all([
-      options.getLogs({ target: V2_PROCESSOR, topics: [REQUEST_TOPICS[0]], entireLog: true }),
-      options.getLogs({ target: V2_PROCESSOR, topics: [REQUEST_TOPICS[1]], entireLog: true }),
+    const [requested, managed, settled] = await Promise.all([
+      options.getLogs({ target: V2_PROCESSOR, eventAbi: ORDER_REQUESTED }),
+      options.getLogs({ target: V2_PROCESSOR, eventAbi: MANAGED_ORDER_REQUESTED }),
       options.getLogs({ target: V2_PROCESSOR, topics: [SETTLED_TOPIC], entireLog: true }),
     ]);
 
-    for (const log of [...req0, ...req1] as any[]) {
-      const paymentQty = word(log.data, 4); // buys; sells are 0 here
-      const fee = word(log.data, 5);
-      if (paymentQty > 0n) dailyVolume.addUSDValue(Number(paymentQty) / 1e18);
-      if (fee > 0n) dailyFees.addUSDValue(Number(fee) / 1e18, METRIC.TRADING_FEES);
+    // Buy side: payment leg is committed at request time
+    for (const log of [...requested, ...managed]) {
+      const paymentAmount = Number(log.paymentAmount) / USD_1E18;
+      const fee = Number(log.fee) / USD_1E18;
+      if (paymentAmount > 0) dailyVolume.addUSDValue(paymentAmount);
+      if (fee > 0) dailyFees.addUSDValue(fee, METRIC.TRADING_FEES);
     }
 
-    for (const log of settled as any[]) {
-      const usd = Number(word(log.data, 0)) / 1e18;
-      if (usd >= 1) dailyVolume.addUSDValue(usd);
+    // Sell side: proceeds paid out at settlement
+    for (const log of settled) {
+      const [amount] = abiCoder.decode(SETTLED_DATA_TYPES, log.data);
+      const usd = Number(amount) / USD_1E18;
+      if (usd > 0) dailyVolume.addUSDValue(usd);
     }
   }
 
@@ -68,36 +78,30 @@ const fetch = async (options: FetchOptions) => {
   };
 };
 
+const FEE_DESC = "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).";
+
 const methodology = {
-  Fees: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).",
-  UserFees: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are paid by users.",
-  Revenue: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are revenue.",
-  ProtocolRevenue: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) goes to the protocol.",
-  Volume: "Payment-token notional of dShare orders.",
+  Fees: FEE_DESC,
+  UserFees: `${FEE_DESC} All fees are paid by users.`,
+  Revenue: `${FEE_DESC} All fees are revenue.`,
+  ProtocolRevenue: `${FEE_DESC} All fees go to the protocol.`,
+  Volume: "Payment-token notional of dShare orders (buys counted at request, sells at settlement).",
 };
 
 const breakdownMethodology = {
-  Fees: {
-    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares).",
-  },
-  UserFees: {
-    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are paid by users.",
-  },
-  Revenue: {
-    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) are revenue.",
-  },
-  ProtocolRevenue: {
-    [METRIC.TRADING_FEES]: "Trading fees (flat + variable) charged on buy and sell orders of tokenized stocks (dShares) goes to the protocol.",
-  },
+  Fees: { [METRIC.TRADING_FEES]: methodology.Fees },
+  UserFees: { [METRIC.TRADING_FEES]: methodology.UserFees },
+  Revenue: { [METRIC.TRADING_FEES]: methodology.Revenue },
+  ProtocolRevenue: { [METRIC.TRADING_FEES]: methodology.ProtocolRevenue },
 };
 
 const adapter: Adapter = {
   version: 2,
   pullHourly: true,
-  adapter: config,
   fetch,
   methodology,
   breakdownMethodology,
+  adapter: config,
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary
- Fixes #9200: legacy `OrderProcessor`s were paused on 2026-06-07, so the adapter stored successful `$0` while orders moved to diamond `0xf60f689ec22fC2D485b3C734eFE58538cCc28766` (same address on eth/arb/base/plume).
- Keep legacy `OrderFill` for history; from 2026-06-07 read v2 request + settlement logs (amounts are 18-decimal USD → `addUSDValue`).
- Volume = buy `paymentQty` on requests + settlements with notional ≥ $1 (skips buy-refund dust). Fees = request fee field.

## Test plan
- [x] `npm run test dexs dinari 2026-06-05 arbitrum` — legacy still nonzero (~$242 vol)
- [x] `npm run test dexs dinari 2026-09-04 arbitrum` — ~$61.5k vol / ~$42.5 fees
- [x] `npm run test dexs dinari 2026-09-04 ethereum` — small nonzero post-migration