### PR TITLE
fix(helpers): the singular token param never reaches the indexer

### DIFF
--- a/helpers/token.ts
+++ b/helpers/token.ts
@@ -131,6 +131,11 @@ type AddTokensReceivedParams = {
  */
 export async function addTokensReceived(params: AddTokensReceivedParams) {
 
+  // The indexer path reads `tokens`, so the singular `token` has to be widened
+  // before it rather than in the log fallback below: without this the filter is
+  // absent and every transfer into the target is counted at its own price.
+  if (!params.tokens && params.token) params.tokens = [params.token]
+
   if (!params.skipIndexer) {
     for (let i = 0; i < 2; i++) {
       // retry 2 times if failed
@@ -163,7 +168,6 @@ export async function addTokensReceived(params: AddTokensReceivedParams) {
     }
   }
 
-  if (!tokens && token) tokens = [token]
 
 
   if (targets?.length) {


### PR DESCRIPTION
`addTokensReceived` tries `_addTokensReceivedIndexer` first, and widens the singular `token` into `tokens` only afterwards, inside the log fallback. The indexer function destructures `tokens` and never `token`, so a caller that passed the singular one reaches `sdk.indexer.getTokenTransfers` with `tokens` undefined: the query carries no token filter and every transfer into the target comes back. Attribution then uses each row's own token, so the extra ones are counted at their own prices rather than dropped.

Its own SDK would have taken it — `indexer.js` does `if (token) tokens = [token]`. It never arrives.

This is already known inside the repository. `fees/dextools.ts`, from #9160, carries the workaround and the reason: *"`_addTokensReceivedIndexer` only forwards `tokens`, so `token` alone silently drops the filter on the indexer fast path and would sweep in every token received (USDC, USDT, ...), not just DEXT."* One adapter routed around it; the rest still pass the singular form.

**44 call sites across 34 files** pass `token:` with no `tokens:` and no `skipIndexer: true`. `fees/convex.ts` shows the shape at its clearest: the calls at lines 136 and 154 share a target and a sender filter and differ only by the dropped token, so on the indexer path they are the same query, and both results are added.

Widening moves above the indexer attempt. One file, one line.

## Tests

`npx tsc --noEmit` exits 0. `LLAMA_INDEXER_*` is unset locally, so a local run takes the log fallback and cannot show this; the harness replaces `getTokenTransfers` with a recorder and reads the argument the helper builds, compiling both revisions straight out of git:

    origin/master   tokens sent to the indexer: undefined
    the branch      tokens sent to the indexer: ["0xfb7b4564402e5500db5bb6d63ae671302777c75a"]

`fetchTokenList` sits behind the same attempt and is left alone: no adapter passes it without `tokens`.
