### PR TITLE
launchlab: count platform and creator fees; StonkFun launchpad revenue and volume

### DIFF
--- a/dexs/stonkfun.ts
+++ b/dexs/stonkfun.ts
@@ -56,6 +56,7 @@ const adapter: Adapter = {
   version: 1,
   dependencies: [Dependencies.DUNE],
   isExpensiveAdapter: true,
+  doublecounted: true, // LaunchLab reports the same bonding curve trades.
   methodology: {
     Volume: "Quote-token value of every buy and sell on the Raydium LaunchLab bonding curves configured by StonkFun, denominated in each pool's quote token (SOL, ZEC, wBTC, xStocks, STONK, ...).",
   },

--- a/dexs/stonkfun.ts
+++ b/dexs/stonkfun.ts
@@ -1,0 +1,67 @@
+import { CHAIN } from "../helpers/chains";
+import { queryDuneSql } from "../helpers/dune";
+import { Adapter, Dependencies, FetchOptions } from "../adapters/types";
+
+// Receives the platform fee of every StonkFun launch on Raydium LaunchLab. Other platform configs
+// carry the StonkFun name in their metadata but pay themselves, so the wallet is the identity here.
+const PLATFORM_FEE_WALLET = "AvVCE7Ue49iZjYzkkHz6ZhVyvY6NLHw67vB8eQaffVPz";
+
+type Row = { quote_mint: string; volume: string };
+
+const fetch = async (options: FetchOptions) => {
+  const rows = (await queryDuneSql(
+    options,
+    `
+    WITH stonkfun_configs AS (
+      SELECT account_platform_config AS config
+      FROM raydium_solana.raydium_launchpad_call_create_platform_config
+      WHERE account_platform_fee_wallet = '${PLATFORM_FEE_WALLET}'
+    ),
+    launchpad_pools AS (
+      SELECT p.pool_state, p.quote_mint
+      FROM (
+        -- StonkFun's first platform config dates from here, so nothing older can be one of its pools
+        SELECT account_pool_state AS pool_state, account_quote_mint AS quote_mint, account_platform_config AS config
+        FROM raydium_solana.raydium_launchpad_call_initialize
+        WHERE call_block_time >= DATE '2026-08-21'
+        UNION ALL
+        SELECT account_pool_state, account_quote_mint, account_platform_config
+        FROM raydium_solana.raydium_launchpad_call_initialize_v2
+        WHERE call_block_time >= DATE '2026-08-21'
+        UNION ALL
+        SELECT account_pool_state, account_quote_mint, account_platform_config
+        FROM raydium_solana.raydium_launchpad_call_initialize_with_token_2022
+        WHERE call_block_time >= DATE '2026-08-21'
+      ) p
+      JOIN stonkfun_configs c ON c.config = p.config
+    )
+    SELECT
+      l.quote_mint AS quote_mint,
+      CAST(SUM(CASE WHEN t.trade_direction LIKE '%Buy%' THEN t.amount_in ELSE t.amount_out END) AS VARCHAR) AS volume
+    FROM raydium_solana.raydium_launchpad_evt_tradeevent t
+    JOIN launchpad_pools l ON l.pool_state = t.pool_state
+    WHERE t.evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND t.evt_block_time <  from_unixtime(${options.endTimestamp})
+    GROUP BY l.quote_mint
+  `
+  )) as Row[];
+
+  const dailyVolume = options.createBalances();
+  rows.forEach(({ quote_mint, volume }) => dailyVolume.add(quote_mint, volume));
+
+  return { dailyVolume };
+};
+
+const adapter: Adapter = {
+  version: 1,
+  dependencies: [Dependencies.DUNE],
+  isExpensiveAdapter: true,
+  methodology: {
+    Volume: "Quote-token value of every buy and sell on the Raydium LaunchLab bonding curves configured by StonkFun, denominated in each pool's quote token (SOL, ZEC, wBTC, xStocks, STONK, ...).",
+  },
+  adapter: {
+    [CHAIN.SOLANA]: { fetch, start: "2026-08-21" },
+  },
+};
+
+export default adapter;

--- a/fees/launchlab/index.ts
+++ b/fees/launchlab/index.ts
@@ -6,8 +6,12 @@ import { FetchOptions } from "../../adapters/types";
 interface IData {
     quote_mint: string;
     protocol_fee: string;
+    platform_fee: string;
+    creator_fee: string;
 }
 
+// every trade deducts protocol + platform + creator fee from the input amount (1.3% in total on
+// the default config), so the three are additive and only the protocol cut belongs to Raydium
 const fetch = async (options: FetchOptions) => {
     // fees are charged in the pool's quote token, which is no longer always SOL (USD1, USDC, BONK, xStocks...)
     const data: IData[] = await queryDuneSql(options, `
@@ -23,7 +27,9 @@ const fetch = async (options: FetchOptions) => {
         )
         SELECT
             p.quote_mint AS quote_mint,
-            CAST(SUM(t.protocol_fee) AS VARCHAR) AS protocol_fee
+            CAST(SUM(t.protocol_fee) AS VARCHAR) AS protocol_fee,
+            CAST(SUM(t.platform_fee) AS VARCHAR) AS platform_fee,
+            CAST(SUM(t.creator_fee) AS VARCHAR) AS creator_fee
         FROM
             raydium_solana.raydium_launchpad_evt_tradeevent t
             JOIN pools p ON p.pool_state = t.pool_state
@@ -33,15 +39,25 @@ const fetch = async (options: FetchOptions) => {
         GROUP BY 1
     `)
     const dailyFees = options.createBalances()
-    data.forEach(({ quote_mint, protocol_fee }) => dailyFees.add(quote_mint, protocol_fee))
-    const dailyHoldersRevenue = dailyFees.clone(0.25) // 25% of is burned
-    const dailyProtocolRevenue = dailyFees.clone(0.75) // 75% of fees go to the protocol
+    const dailyRevenue = options.createBalances()
+    const dailySupplySideRevenue = options.createBalances()
+    data.forEach(({ quote_mint, protocol_fee, platform_fee, creator_fee }) => {
+        dailyFees.add(quote_mint, protocol_fee, 'Protocol Fee')
+        dailyFees.add(quote_mint, platform_fee, 'Launch Platform Fee')
+        dailyFees.add(quote_mint, creator_fee, 'Token Creator Fee')
+        dailyRevenue.add(quote_mint, protocol_fee, 'Protocol Fee')
+        dailySupplySideRevenue.add(quote_mint, platform_fee, 'Launch Platform Fee')
+        dailySupplySideRevenue.add(quote_mint, creator_fee, 'Token Creator Fee')
+    })
+    const dailyHoldersRevenue = dailyRevenue.clone(0.25) // 25% of the protocol fee is burned
+    const dailyProtocolRevenue = dailyRevenue.clone(0.75) // 75% goes to the protocol
 
     return {
         dailyFees,
-        dailyRevenue: dailyFees,
+        dailyRevenue,
         dailyProtocolRevenue,
-        dailyHoldersRevenue
+        dailyHoldersRevenue,
+        dailySupplySideRevenue,
     }
 };
 
@@ -53,11 +69,26 @@ const adapter: SimpleAdapter = {
     version: 1,
     isExpensiveAdapter: true,
     methodology: {
-        Fees: 'Protocol fee taken on every trade, denominated in each pool\'s quote token.',
-        Revenue: '0.25% burned + 0.75% to protocol of 1% platform fees',
-        ProtocolRevenue: '0.75% of platform fees go to the protocol.',
-        HoldersRevenue: '0.25% of platform fees are burned.',
-    }
+        Fees: 'All fees deducted from trades on the bonding curves: Raydium\'s protocol fee, the launch platform\'s fee and the token creator\'s fee, denominated in each pool\'s quote token.',
+        Revenue: 'Raydium\'s protocol fee only. Platform and creator fees are passed on to the third parties that launched the token.',
+        ProtocolRevenue: '75% of the protocol fee.',
+        HoldersRevenue: '25% of the protocol fee is used to buy back and burn RAY.',
+        SupplySideRevenue: 'Fees paid out to the launch platform (e.g. StonkFun, LetsBonk) and to the token creator.',
+    },
+    breakdownMethodology: {
+        Fees: {
+            'Protocol Fee': 'Raydium\'s cut of each trade (0.25% on the default config).',
+            'Launch Platform Fee': 'Fee taken by the front-end that configured the launch, set per platform config (1% on the default config).',
+            'Token Creator Fee': 'Fee taken by the wallet that created the token.',
+        },
+        Revenue: {
+            'Protocol Fee': 'Raydium\'s cut of each trade.',
+        },
+        SupplySideRevenue: {
+            'Launch Platform Fee': 'Paid to the launch platform, claimed via claim_platform_fee.',
+            'Token Creator Fee': 'Paid to the token creator, claimed via claim_creator_fee.',
+        },
+    },
 }
 
 export default adapter

--- a/fees/stonkfun.ts
+++ b/fees/stonkfun.ts
@@ -9,6 +9,11 @@ const LOCK_PROGRAM = "LockrWmn6K5twhz3y9w1dQERbmgSaRkfnTeTKbpofwE";
 const OPERATOR = "5CEbueQnq1Ym2uSSx2xXds3jQAqT1BDnkA59RZobSPAG";
 
 const STONK = "6GmAFSYs4gk3FDao5FzzySQpPZaWsa4rUJHacpMpUNgx";
+
+// Receives the platform fee of every StonkFun launch on Raydium LaunchLab. Other platform configs
+// carry the StonkFun name in their metadata but pay themselves, so the wallet is the identity here.
+// ponytail: a config that changes its fee wallet later would need update_platform_config too.
+const PLATFORM_FEE_WALLET = "AvVCE7Ue49iZjYzkkHz6ZhVyvY6NLHw67vB8eQaffVPz";
 const JUPITER = "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4";
 
 type Row = { mint: string; raw_amount: string; kind: string };
@@ -65,6 +70,31 @@ const fetch = async (options: FetchOptions) => {
     ),
     buybacks AS (
       SELECT mint, amount FROM buyback_legs WHERE leg = 1
+    ),
+    -- Launches start on a LaunchLab bonding curve, which charges StonkFun's 1% platform fee in the
+    -- pool's quote token on every trade before the token graduates to the locked position above.
+    stonkfun_configs AS (
+      SELECT account_platform_config AS config
+      FROM raydium_solana.raydium_launchpad_call_create_platform_config
+      WHERE account_platform_fee_wallet = '${PLATFORM_FEE_WALLET}'
+    ),
+    launchpad_pools AS (
+      SELECT p.pool_state, p.quote_mint
+      FROM (
+        -- StonkFun's first platform config dates from here, so nothing older can be one of its pools
+        SELECT account_pool_state AS pool_state, account_quote_mint AS quote_mint, account_platform_config AS config
+        FROM raydium_solana.raydium_launchpad_call_initialize
+        WHERE call_block_time >= DATE '2026-08-21'
+        UNION ALL
+        SELECT account_pool_state, account_quote_mint, account_platform_config
+        FROM raydium_solana.raydium_launchpad_call_initialize_v2
+        WHERE call_block_time >= DATE '2026-08-21'
+        UNION ALL
+        SELECT account_pool_state, account_quote_mint, account_platform_config
+        FROM raydium_solana.raydium_launchpad_call_initialize_with_token_2022
+        WHERE call_block_time >= DATE '2026-08-21'
+      ) p
+      JOIN stonkfun_configs c ON c.config = p.config
     )
     SELECT 'fee' AS kind, h.mint AS mint, CAST(SUM(h.amount) AS VARCHAR) AS raw_amount
     FROM harvests h JOIN quote_mints q ON q.mint = h.mint
@@ -73,6 +103,13 @@ const fetch = async (options: FetchOptions) => {
     SELECT 'buyback' AS kind, b.mint AS mint, CAST(SUM(b.amount) AS VARCHAR) AS raw_amount
     FROM buybacks b JOIN quote_mints q ON q.mint = b.mint
     GROUP BY b.mint
+    UNION ALL
+    SELECT 'platform_fee' AS kind, l.quote_mint AS mint, CAST(SUM(t.platform_fee) AS VARCHAR) AS raw_amount
+    FROM raydium_solana.raydium_launchpad_evt_tradeevent t
+    JOIN launchpad_pools l ON l.pool_state = t.pool_state
+    WHERE t.evt_block_time >= from_unixtime(${options.startTimestamp})
+      AND t.evt_block_time <  from_unixtime(${options.endTimestamp})
+    GROUP BY l.quote_mint
   `
   )) as Row[];
 
@@ -85,6 +122,9 @@ const fetch = async (options: FetchOptions) => {
     if (amount === 0n) continue;
     if (row.kind === "buyback") {
       dailyHoldersRevenue.add(row.mint, amount, "STONK Buyback And Burn");
+    } else if (row.kind === "platform_fee") {
+      dailyFees.add(row.mint, amount, "Launch Curve Platform Fee");
+      dailyRevenue.add(row.mint, amount, "Launch Curve Platform Fee");
     } else {
       dailyFees.add(row.mint, amount, "Locked LP Trading Fees");
       dailyRevenue.add(row.mint, amount, "Locked LP Trading Fees");
@@ -97,18 +137,21 @@ const fetch = async (options: FetchOptions) => {
 };
 
 const methodology = {
-  Fees: "StonkFun's share of trading fees from the locked Raydium CLMM positions behind each launch, read on-chain as the quote-token transfers Raydium's Burn & Earn program pays to the platform's operator wallet.",
-  Revenue: "Same as fees (StonkFun's share of the locked Raydium CLMM positions behind each launch). Every dollar counted was harvested into the treasury.",
+  Fees: "StonkFun's 1% platform fee on every trade against the Raydium LaunchLab bonding curves it configures, plus its share of trading fees from the locked Raydium CLMM positions behind each graduated launch.",
+  Revenue: "Same as fees. The platform fee accrues to StonkFun's fee wallet and the locked-position fees are harvested into the treasury.",
   HoldersRevenue:
     "Quote assets spent buying STONK on Jupiter, identified on-chain as swaps that returned STONK to the operator wallet. Measured at the amount spent, not the value of the tokens later burned.",
 };
 
 const breakdownMethodology = {
   Fees: {
+    "Launch Curve Platform Fee":
+      "1% of every LaunchLab bonding curve trade, charged in the pool's quote token and claimable by StonkFun's fee wallet.",
     "Locked LP Trading Fees":
       "Quote-token fees harvested from the permanently locked launch positions.",
   },
   Revenue: {
+    "Launch Curve Platform Fee": "Platform fee accrued to StonkFun.",
     "Locked LP Trading Fees": "Quote-token fees retained by the protocol.",
   },
   HoldersRevenue: {


### PR DESCRIPTION
### LaunchLab: fees were 5x understated

A LaunchLab trade deducts `protocol_fee` + `platform_fee` + `creator_fee` from the input, and the three are additive: on a sample buy, `amount_in - delta(real_quote) = 278,608 = 53,580 + 214,313 + 10,715` (0.25% + 1% + 0.05% on the default config). The adapter summed only `protocol_fee`, so 2026-09-07 reported $53.6k against ~$277k of real fees.

Now counts all three. Revenue stays Raydium's protocol fee (25% burn / 75% protocol); platform and creator fees become `SupplySideRevenue`, the same split `fees/zapzy` already uses reporting these fees from the platform side. 2026-09-06: $326k fees, $64.9k revenue, $262k supply side (was $64.9k / $64.9k / none).

Needs a refill from 2025-04-15, platform fees have existed since launch.

### StonkFun: 1% platform fee and curve volume

StonkFun (`stonkfun.xyz`) has run LaunchLab platform configs at a 1% platform fee since 2026-08-21, and that is now most of its income. `fees/stonkfun.ts` read only the Burn & Earn locked-CLMM fees, so 2026-09-06 reported $177k against $1.09M ($253k platform fee + $836k locked LP).

Configs are matched on `account_platform_fee_wallet = AvVCE7Ue49iZjYzkkHz6ZhVyvY6NLHw67vB8eQaffVPz`, not on the name in the config metadata: 17 configs carry "StonkFun" on-chain but the 14 created 2026-09-06/07 each pay a different wallet. The pool scan is floored at their first config date, without it the query costs ~9 Dune credits a day.

`dexs/stonkfun.ts` adds their bonding curve volume, quote-token value per trade: $25.19M on 2026-09-06. Left unflagged as discussed, so the LaunchLab entry in `factory/duneSolanaDex.ts` needs delisting or a `doublecounted` flag, that entry reports $17.15M for the same day.

### Notes

- Refills: launchlab fees from 2025-04-15, stonkfun from 2026-08-21.
- StonkFun needs a dexs record for protocol 8450.
- About 40 of 205 daily quote mints have no coins.llama.fi price (small pump.fun coins) and count as $0 on both adapters.
