### PR TITLE
[fix] pez-family - count only PEZ pool fees after graduation, PEZ creator fees as protocol revenue

### DIFF
--- a/fees/pez-family-v2/index.ts
+++ b/fees/pez-family-v2/index.ts
@@ -11,11 +11,10 @@ const MEME_HOOK = "0x57387759Ea3a3116330f4Bd2cae48B03091A2044";
 // verified against the Robinhood Chain RPC.
 const FACTORY_DEPLOYED_BLOCK = 55493136;
 const BPS = 10000;
-// Pez's official deployment/docs do not identify a separate platform token;
-// buybacks of launched tokens are supply-side revenue. Add a verified platform
-// token address here if Pez deploys one, so only that token's buyback is holders
-// revenue. See https://pez.family/docs.
-const PLATFORM_TOKENS = new Set<string>();
+// PEZ, the platform token launched by the Pez team through its own factory.
+// Its "creator" fees go to the team (protocol revenue) and its buybacks are
+// holders revenue. Every other launched token belongs to a third-party creator.
+const PLATFORM_TOKENS = new Set<string>(["0xa3602804e096cb73bd8344afc1ff3f3390b899c5"]);
 
 const TOKEN_LAUNCHED_EVENT =
   "event TokenLaunched(address indexed token, address indexed curve, address indexed deployer, address pairToken, uint256 launchConfigId, uint256 graduationThreshold)";
@@ -35,10 +34,14 @@ const POSITION_INFO_FUNCTION = "function positionInfo(uint256 tokenId) view retu
 const LAUNCH_FEE_POLICY_FUNCTION =
   "function getLaunchFeePolicy(address token) view returns (tuple(address protocolFeeRecipient, uint16 protocolFeeShareBps, uint16 buybackBurnBps, uint16 hookFeeBps, uint16 maxInternalPriceImpactBps))";
 
+// Graduated pools trade on Uniswap v4 and their volume/fees are already counted
+// by the uniswap-v4 adapter on Robinhood Chain. This adapter covers the bonding
+// curves for every token, plus the graduated-pool fees of the PEZ token only,
+// because those accrue to the Pez team rather than to a third-party creator.
 async function fetch(options: FetchOptions) {
   const dailyVolume = options.createBalances();
   const dailyFees = options.createBalances();
-  const dailyRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
   const dailyHoldersRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
@@ -65,8 +68,11 @@ async function fetch(options: FetchOptions) {
     tokenToPairToken.set(token, pairToken);
   }
 
+  // Only platform-token pools are tracked after graduation.
   const positionIdToTokens = new Map(
-    poolGraduatedLogs.map((log) => [String(log.positionId), String(log.token).toLowerCase()])
+    poolGraduatedLogs
+      .filter((log) => PLATFORM_TOKENS.has(String(log.token).toLowerCase()))
+      .map((log) => [String(log.positionId), String(log.token).toLowerCase()])
   );
   const tokens = Array.from(curveToTokens.values()).map(({ token }) => token);
 
@@ -130,6 +136,7 @@ async function fetch(options: FetchOptions) {
       if (!curve) return;
       const policy = tokenToLaunchFeePolicy.get(curve.token);
       if (!policy) return;
+      const isPlatformToken = PLATFORM_TOKENS.has(curve.token);
 
       logs.forEach((log: any) => {
         const args = log.args ?? log;
@@ -142,21 +149,21 @@ async function fetch(options: FetchOptions) {
         const creatorBps = (BPS - protocolBps) / (BPS / (BPS - policy.buybackBurnBps));
         const buybackBps = BPS - creatorBps - protocolBps;
 
+        const creatorAmount = (fee * BigInt(creatorBps)) / BigInt(BPS);
+        const buybackAmount = (fee * BigInt(buybackBps)) / BigInt(BPS);
+
         dailyVolume.add(quoteToken, isBuy ? quoteAmount : quoteAmount + fee + tax);
         dailyFees.add(quoteToken, fee + tax, "Curve Swap Fees");
-        dailyRevenue.add(quoteToken, (fee * BigInt(protocolBps)) / BigInt(BPS), "Curve Swap Fees to Protocol");
-        dailySupplySideRevenue.add(
-          quoteToken,
-          (fee * BigInt(creatorBps)) / BigInt(BPS),
-          "Curve Swap Fees to Creators"
-        );
-        const buybackAmount = (fee * BigInt(buybackBps)) / BigInt(BPS);
-        if (PLATFORM_TOKENS.has(curve.token)) {
-          dailyHoldersRevenue.add(quoteToken, buybackAmount, METRIC.TOKEN_BUY_BACK);
+        dailyProtocolRevenue.add(quoteToken, (fee * BigInt(protocolBps)) / BigInt(BPS), "Curve Swap Fees to Protocol");
+        if (isPlatformToken) {
+          // No fixed buyback split is observable for PEZ; everything the team
+          // collects on its own token is protocol revenue.
+          dailyProtocolRevenue.add(quoteToken, creatorAmount + buybackAmount + tax, "PEZ Creator Fees");
         } else {
+          dailySupplySideRevenue.add(quoteToken, creatorAmount, "Curve Swap Fees to Creators");
           dailySupplySideRevenue.add(quoteToken, buybackAmount, "Curve Swap Fees to Meme Token Buybacks");
+          dailySupplySideRevenue.add(quoteToken, tax, "Creator Tax");
         }
-        dailySupplySideRevenue.add(quoteToken, tax, "Creator Tax");
       });
     });
   };
@@ -164,6 +171,7 @@ async function fetch(options: FetchOptions) {
   addCurveLogs(curveBuyLogs, true);
   addCurveLogs(curveSellLogs, false);
 
+  // PEZ pool only (poolIdToTokens is filtered to PLATFORM_TOKENS above).
   for (const log of poolFeeSweptLogs) {
     const token = poolIdToTokens.get(String(log.poolId).slice(0, 52).toLowerCase());
     if (!token) continue;
@@ -175,56 +183,56 @@ async function fetch(options: FetchOptions) {
       BigInt(log.protocolAmount) + BigInt(log.buybackAmount) + BigInt(log.creatorAmount),
       METRIC.SWAP_FEES
     );
-    dailyRevenue.add(pairToken, log.protocolAmount, "Token Swap Fees to Protocol");
-    dailySupplySideRevenue.add(pairToken, log.creatorAmount, "Token Swap Fees to Creators");
-    if (PLATFORM_TOKENS.has(token)) {
-      dailyHoldersRevenue.add(pairToken, log.buybackAmount, METRIC.TOKEN_BUY_BACK);
-    } else {
-      dailySupplySideRevenue.add(pairToken, log.buybackAmount, "Token Swap Fees to Meme Token Buybacks");
-    }
+    dailyProtocolRevenue.add(pairToken, log.protocolAmount, "Token Swap Fees to Protocol");
+    dailyProtocolRevenue.add(pairToken, log.creatorAmount, "PEZ Creator Fees");
+    dailyHoldersRevenue.add(pairToken, log.buybackAmount, METRIC.TOKEN_BUY_BACK);
   }
+
+  const dailyRevenue = dailyProtocolRevenue.clone();
+  dailyRevenue.addBalances(dailyHoldersRevenue);
 
   return {
     dailyVolume,
     dailyFees,
     dailyRevenue,
-    dailyProtocolRevenue: dailyRevenue,
+    dailyProtocolRevenue,
     dailyHoldersRevenue,
     dailySupplySideRevenue,
   };
 }
 
 const methodology = {
-  Volume: "Volume of all swaps on Pez's launch curves; external Uniswap v4 swaps are excluded.",
-  Fees: "Includes Pez curve trade fees, creator taxes, and graduated-pool swap fees realized through PoolFeesSwept events. Pez's current deployment has no launch fee.",
-  Revenue: "Zero under Pez's current zero-platform-fee policy; any non-zero protocol amount is read from the on-chain fee policy or PoolFeesSwept events.",
-  ProtocolRevenue: "Pez's current deployment has no protocol fee share; the adapter retains this field to detect future on-chain policy changes.",
-  HoldersRevenue: "Buyback-and-lock amounts funded from the creator's share of Pez trade fees only when the bought-back token is a verified Pez platform token.",
-  SupplySideRevenue: "Creator fee, creator tax, and launched-token buyback amounts paid from Pez trade fees. Buybacks of launched tokens are supply-side revenue; only a verified platform-token buyback is holders revenue.",
+  Volume: "Volume of all swaps on Pez's launch curves. Graduated pools trade on Uniswap v4 and are counted under the Uniswap v4 listing.",
+  Fees: "Pez curve trade fees and creator taxes on every launched token, plus the graduated Uniswap v4 pool fees of the PEZ platform token, realized through PoolFeesSwept events. Other graduated pools are counted under the Uniswap v4 listing. Pez's current deployment has no launch fee.",
+  Revenue: "Protocol revenue plus holders revenue.",
+  ProtocolRevenue: "Any protocol fee share read from the on-chain fee policy (zero under the current policy), plus the creator fees and taxes of the PEZ token, which the Pez team launched and collects on.",
+  HoldersRevenue: "PEZ buyback-and-lock amounts reported by PoolFeesSwept for the PEZ pool. No such buyback has happened on-chain so far, so this is currently zero.",
+  SupplySideRevenue: "Creator fee, creator tax, and launched-token buyback amounts paid from curve fees of third-party launched tokens.",
 };
 
 const breakdownMethodology = {
   Fees: {
     "Curve Swap Fees": "Base trade fees and creator taxes collected from swaps on Pez launch curves.",
-    [METRIC.SWAP_FEES]: "Fees collected from Uniswap v4 swaps on graduated Pez pools, realized through PoolFeesSwept events.",
+    [METRIC.SWAP_FEES]: "Fees collected from Uniswap v4 swaps on the graduated PEZ pool, realized through PoolFeesSwept events.",
   },
   Revenue: {
     "Curve Swap Fees to Protocol": "Protocol share of curve swap fees defined by each token's launch fee policy.",
-    "Token Swap Fees to Protocol": "Protocol amount emitted by PoolFeesSwept for graduated pools.",
+    "Token Swap Fees to Protocol": "Protocol amount emitted by PoolFeesSwept for the PEZ pool.",
+    "PEZ Creator Fees": "Creator share of fees and taxes on the PEZ token, collected by the Pez team.",
+    [METRIC.TOKEN_BUY_BACK]: "PEZ buyback-and-lock amounts funded from PEZ trade fees.",
   },
   ProtocolRevenue: {
     "Curve Swap Fees to Protocol": "Protocol share of curve swap fees; zero under the current Pez policy.",
     "Token Swap Fees to Protocol": "Protocol amount emitted by PoolFeesSwept; zero under the current Pez policy.",
+    "PEZ Creator Fees": "Creator share of fees and taxes on the PEZ token, collected by the Pez team.",
   },
   HoldersRevenue: {
-    [METRIC.TOKEN_BUY_BACK]: "Buyback-and-lock amounts from the creator's share of Pez trade fees.",
+    [METRIC.TOKEN_BUY_BACK]: "PEZ buyback-and-lock amounts funded from PEZ trade fees.",
   },
   SupplySideRevenue: {
-    "Curve Swap Fees to Creators": "Creator share of curve swap fees.",
-    "Curve Swap Fees to Meme Token Buybacks": "Buyback share of curve swap fees used to buy launched tokens.",
-    "Creator Tax": "Creator tax collected on curve swaps.",
-    "Token Swap Fees to Creators": "Creator amount emitted by PoolFeesSwept for graduated pools.",
-    "Token Swap Fees to Meme Token Buybacks": "Buyback amount emitted by PoolFeesSwept and used to buy launched tokens.",
+    "Curve Swap Fees to Creators": "Creator share of curve swap fees on third-party tokens.",
+    "Curve Swap Fees to Meme Token Buybacks": "Buyback share of curve swap fees used to buy third-party launched tokens.",
+    "Creator Tax": "Creator tax collected on curve swaps of third-party tokens.",
   },
 };
 


### PR DESCRIPTION
Fees were ~4x volume because the adapter counted PoolFeesSwept from every graduated Uniswap v4 pool while volume only covered the bonding curves. Those pools are already counted under the uniswap-v4 adapter on Robinhood Chain.

- Keep PoolFeesSwept only for the PEZ token pool (0xa3602804E096cb73BD8344AFc1ff3F3390B899C5), which the Pez team launched itself.
- PEZ creator fees (curve and pool) are protocol revenue. Revenue = protocol + holders.
- Other launched tokens are unchanged: curve fees, creator share and buybacks stay supply side.
- On-chain the PEZ pool has no buyback or lock so far (all 41 sweeps have buybackAmount and tokensLocked of 0), so holders revenue is currently zero.

Needs a refill from 2026-09-05.