### PR TITLE
growth(adapter): add AlphaPilot Hyperliquid builder metrics

### DIFF
--- a/factory/hyperliquid.ts
+++ b/factory/hyperliquid.ts
@@ -30,6 +30,17 @@ const superxConfig: BuilderConfig = {
 // factory export. The DefiLlama dimension framework picks the appropriate
 // fields (volume vs fees) based on each protocol's metadata adapter type.
 const builderConfigs: Record<string, BuilderConfig> = {
+  "alphapilot": {
+    // AlphaPilot builder; daily fills: https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/0xbe8d82c64d33fbb3324ddd7ba6c3efda1a0776a1/20260908.csv.lz4
+    addresses: ["0xbe8d82c64d33fbb3324ddd7ba6c3efda1a0776a1"],
+    methodology: {
+      Volume: "Notional volume of Hyperliquid trades routed through AlphaPilot's builder code.",
+      Fees: "Builder code fees paid on Hyperliquid trades routed through AlphaPilot; excludes Hyperliquid exchange trading fees.",
+      Revenue: "Builder code fees collected by AlphaPilot from Hyperliquid trades.",
+      ProtocolRevenue: "Builder code fees collected by AlphaPilot from Hyperliquid trades.",
+    },
+    breakdownFees: true,
+  },
   "whale-ag": {
     addresses: ["0xfa4a0d1ca5288478f2c515d5574d53631e7fa711"],
     start: "2026-04-23",


### PR DESCRIPTION
Add AlphaPilot to the existing Hyperliquid builder factory so its routed trading volume and builder fee receipts can be tracked. This adds one configuration entry in `factory/hyperliquid.ts`; it reuses the shared helper, breakdown methodology and `doublecounted: true` attribution to Hyperliquid.

## Listing information

- **Name:** AlphaPilot
- **Website:** https://www.alphapilot.tech/
- **Twitter:** https://x.com/AlphaPilotHQ
- **Documentation:** https://www.alphapilot.tech/docs
- **Logo:** https://www.alphapilot.tech/logo.png (512 × 512 PNG)
- **Short description:** AI-assisted DEX strategy creation, backtesting and Hyperliquid execution.
- **Chain:** Hyperliquid (HyperCore execution; this submission is not a HyperEVM contract).
- **Category:** Derivatives / Hyperliquid trading frontend. Uses the established Hyperliquid factory's `dexs` and `fees` routes.
- **Current TVL / TVL methodology:** Not submitted; this adapter measures routed fills and builder fees, not deposits or TVL.
- **Builder fee recipient:** `0xbe8d82c64d33fbb3324ddd7ba6c3efda1a0776a1`. Verified against AlphaPilot's production builder configuration before submission. This is a builder recipient, not a claim about a separate treasury contract.
- **Audit links:** No AlphaPilot audit report supplied with this submission.
- **CoinGecko ID / CoinMarketCap ID / token address and ticker:** Not supplied; no AlphaPilot token is needed for these metrics.
- **Oracle / implementation:** This integration submits trades to Hyperliquid; it does not deploy a separate oracle. The adapter reads official Hyperliquid fill exports rather than querying an AlphaPilot price oracle. Hyperliquid reference: https://hyperliquid.gitbook.io/hyperliquid-docs/trading/builder-codes
- **forkedFrom:** This application integrates Hyperliquid execution; no protocol fork is being submitted.
- **Open-source code tracking:** Not requested for AlphaPilot's proprietary application.
- **Referral program:** Yes, https://www.alphapilot.tech/referral. This adapter reports builder receipts, not accounting profit after any subsequent referral payouts or operating costs.

## Source and methodology

Official daily source, with the lowercase builder address and UTC date:
https://stats-data.hyperliquid.xyz/Mainnet/builder_fills/0xbe8d82c64d33fbb3324ddd7ba6c3efda1a0776a1/20260908.csv.lz4

For 2026-09-08, an independent decimal aggregation of the official CSV finds **5 fills, $73.770441 notional volume and $0.073768 builder fees**. The fee-to-volume ratio is approximately 0.1%, consistent with the per-fill values in this sample. These are one day's values, not cumulative activity or a fixed rate assumption; the helper sums each fill's actual `builder_fee` and `px * sz`.

Fees exclude Hyperliquid's own exchange trading fees. Builder receipts already included in Hyperliquid totals remain marked double-counted by the shared helper. No synthetic fee split or fixed fee percentage is introduced. Historical fee-rate changes have not been reconstructed because the source provides actual charged amounts. Cumulative builder rewards, account-specific UI values and routed notional are different measurements and should not be compared as the same metric.

An actual no-trade day can have zero activity, but an unavailable export is not evidence of zero: the shared helper throws on unavailable files. The exact first active date is not established, so this entry omits `start` as instructed in AGENTS.md. The shared helper consequently uses its existing 2025-08-01 default; this is not an AlphaPilot launch-date claim. Maintainer/indexer confirmation is needed before bulk backfill begins.

No existing AlphaPilot slug or builder address was found across the factory, dexs, fees and aggregator-derivatives directories, or in open/closed AlphaPilot PR searches. This is a new listing, so there is no prior AlphaPilot adapter series to refill.

## Validation

- `pnpm run ts-check` — passed.
- `pnpm run ts-check-cli` — passed.
- `pnpm run build` — passed; `alphapilot` resolves through the shared factory under both `fees` and `dexs`, including fee breakdown methodology.
- `DEBUG_BREAKDOWN_FEES=true pnpm test fees alphapilot 2026-09-09` — passed for UTC 2026-09-08; fee label `Hyperliquid Builder Code Fees` is $0.0738 at displayed precision, matching the independently aggregated source.
- `DEBUG_BREAKDOWN_FEES=true pnpm test fees alphapilot 2026-09-06` — passed for UTC 2026-09-05; displayed volume $154 and builder fees $0.1545.
- `pnpm test dexs alphapilot 2026-09-02` — passed for UTC 2026-09-01; displayed volume $594 and builder fees $0.5943.
- `git diff --check` — passed.

Some initial local attempts failed with a TLS connection error before downloading the source; successful runs used the local network proxy. No network workaround or dependency change is included in the patch.

**Server-side follow-up after merge:** please wire the new listing's volume and fee dimensions to `alphapilot` in defillama-server and confirm the appropriate frontend classification/history start. This PR does not change server metadata.

Prepared by Codex, an AI assistant, on behalf of AlphaPilot with the owner's authorization. Maintainer edits are enabled.
