### PR TITLE
lista-dao: count validator commission once; read slisBNB commission from RewardsCompounded

### DIFF
--- a/fees/lista-lisusd/index.ts
+++ b/fees/lista-lisusd/index.ts
@@ -52,12 +52,14 @@ const usdt = ADDRESSES.bsc.USDT;
 const LISUSD_POOL_SET = "0x37DB1AE9B24055D1F9fE973Aea40B7EB2995D0Bf";
 const RATE_SCALE = 10n ** 27n;
 
-// Validator / node-operation rewards (BNB-denominated), counted once, when they land in the
-// ListaDAOCredit Safe (SafeReceived). The validator commission first accrues as stListaDAO shares
-// minted daily to the validator operator (0x7766…), the operator undelegates and claims the BNB
-// monthly and forwards it to the ops multisig, which deposits it into this Safe. Counting the daily
-// share mints as well double-counted the commission (the two legs are the same money, accrual vs.
-// realised), so only the Safe receipt is booked.
+// Validator / node-operation revenue (BNB). Lista operates several BSC validators (operators
+// 0x7766…, 0x5f04…, 0x5b2b…). Each operator's commission accrues as StakeCredit shares, is
+// undelegated and claimed monthly and forwarded to the ops multisig (0x1d60…8f66); the ops multisig
+// then deposits the DAO's share into this ListaDAOCredit Safe, which forwards it to the DAO
+// collection wallet (0x0970…) a few days later. The Safe receipt (SafeReceived) is therefore the
+// amount the DAO actually books as validator revenue, and it is counted once here. The previous
+// extra leg (daily stListaDAO share mints to 0x7766…) covered only one of the validators, valued
+// shares 1:1 as BNB, and double-counted the commission already contained in the Safe deposit.
 const listaDAOCredit = "0x0D92Ac7a4590874a493eB62b37D3Ea3390966B13";
 
 // Liquidation profit: Moolah / broker liquidations settle their USDT profit to this receiver

--- a/fees/lista-lisusd/index.ts
+++ b/fees/lista-lisusd/index.ts
@@ -52,16 +52,13 @@ const usdt = ADDRESSES.bsc.USDT;
 const LISUSD_POOL_SET = "0x37DB1AE9B24055D1F9fE973Aea40B7EB2995D0Bf";
 const RATE_SCALE = 10n ** 27n;
 
-// Validator / node-operation rewards (BNB-denominated). Track both paths:
-// 1. ListaDAOCredit SafeReceived — historical revenue before the migration.
-// 2. stListaDAO mints to the reward collector — current revenue flow.
+// Validator / node-operation rewards (BNB-denominated), counted once, when they land in the
+// ListaDAOCredit Safe (SafeReceived). The validator commission first accrues as stListaDAO shares
+// minted daily to the validator operator (0x7766…), the operator undelegates and claims the BNB
+// monthly and forwards it to the ops multisig, which deposits it into this Safe. Counting the daily
+// share mints as well double-counted the commission (the two legs are the same money, accrual vs.
+// realised), so only the Safe receipt is booked.
 const listaDAOCredit = "0x0D92Ac7a4590874a493eB62b37D3Ea3390966B13";
-const stListaDAO = "0xc096e7781c95a2fc6feb1efe776b570270b3965d";
-const validatorRewardCollector =
-  "0x0000000000000000000000007766a5ee8294343bf6c8dcf3aa4b6d856606703a";
-// One-off startup funding mint — not revenue, excluded.
-const VALIDATOR_STARTUP_TX =
-  "0x0a6b673be9105a33756f4c6a6213ad4712c027c6ea001a9717f1a0b13fcdc343";
 
 // Liquidation profit: Moolah / broker liquidations settle their USDT profit to this receiver
 const liquidatorProfitReceiver =
@@ -195,15 +192,6 @@ const fetch = async (options: FetchOptions) => {
     target: listaDAOCredit,
     eventAbi: "event SafeReceived(address indexed sender, uint256 value)",
   });
-  const validatorRewardsStListaDAO = (
-    await options.getLogs({
-      target: stListaDAO,
-      topics: [transferHash, zeroAddress, validatorRewardCollector],
-    })
-  ).filter(
-    (log: any) =>
-      (log.transactionHash ?? "").toLowerCase() !== VALIDATOR_STARTUP_TX,
-  );
   // LP staking rewards
   const lpStakeRewardsFromHash =
     "0x00000000000000000000000062dfec5c9518fe2e0ba483833d1bad94ecf68153";
@@ -271,9 +259,6 @@ const fetch = async (options: FetchOptions) => {
   [...validatorRewardsListaDAOCredit].forEach((log) => {
     dailyFees.add(bnb, Number(log.value), VALIDATOR_REWARDS);
   });
-  [...validatorRewardsStListaDAO].forEach((log) => {
-    dailyFees.add(bnb, Number(log.data), VALIDATOR_REWARDS);
-  });
   [...lpStakingListaRewards].forEach((log) => {
     dailyFees.add(lista, Number(log.data), LP_STAKING_REWARDS);
   });
@@ -329,7 +314,7 @@ const LISUSD_BREAKDOWN = {
   [PSM_CONVERT_FEE]: 'PSM (USDT) conversion fee',
   [USDT_STAKING_PROFIT]: 'Profit from USDT staking via VenusAdapter',
   [VALIDATOR_REWARDS]:
-    'BNB validator / node-operation rewards (ListaDAOCredit SafeReceived historically; stListaDAO minted to the reward collector currently)',
+    'BNB validator commission, booked once when it is deposited into the ListaDAOCredit Safe (SafeReceived)',
   [LP_STAKING_REWARDS]: 'CAKE / LISTA rewards from PancakeSwap LP staking',
   [FREEZE_LISTA]: 'Frozen (burned) LISTA deducted from revenue',
 };

--- a/fees/lista-slisbnb/index.ts
+++ b/fees/lista-slisbnb/index.ts
@@ -14,8 +14,10 @@ import { CHAIN } from "../../helpers/chains";
 const ListaStakeManagerAddress = "0x1adB950d8bB3dA4bE104211D5AB038628e477fE6";
 
 // ListaStakeManager.compoundRewards() runs once a day: it books the BSC staking rewards earned by the
-// pool, keeps synFee of them as the protocol commission (minted as slisBNB to revenuePool) and emits
-// RewardsCompounded(_amount) with that commission in BNB.
+// pool (totalProfit), takes fee = max(totalProfit * synFee, totalDelegated * annualRate / 365) as the
+// protocol commission (minted as slisBNB to revenuePool) and emits RewardsCompounded(fee) in BNB.
+// Revenue below is that exact fee; gross rewards are derived as fee / synFee, which is exact whenever
+// the profit-based branch binds (every day in Aug-2026).
 //
 // The commission is read from this event rather than inferred from the slisBNB exchange-rate move,
 // because the rate also rises for two reasons that are not staking rewards and carry no fee:

--- a/fees/lista-slisbnb/index.ts
+++ b/fees/lista-slisbnb/index.ts
@@ -13,50 +13,45 @@ import { CHAIN } from "../../helpers/chains";
 
 const ListaStakeManagerAddress = "0x1adB950d8bB3dA4bE104211D5AB038628e477fE6";
 
-// token
-const slisBNB = "0xb0b84d294e0c75a6abe60171b70edeb2efd14a1b";
+// ListaStakeManager.compoundRewards() runs once a day: it books the BSC staking rewards earned by the
+// pool, keeps synFee of them as the protocol commission (minted as slisBNB to revenuePool) and emits
+// RewardsCompounded(_amount) with that commission in BNB.
+//
+// The commission is read from this event rather than inferred from the slisBNB exchange-rate move,
+// because the rate also rises for two reasons that are not staking rewards and carry no fee:
+// (1) the validator-commission refund that RefundCommission deposits and compoundRewards burns back to
+//     holders day by day, and
+// (2) rewards accrued on shares awaiting withdrawal, which ClaimUndelegatedFrom leaves with the
+//     remaining holders.
+// Inferring from the rate overstated Revenue by ~3.5% in Aug-2026 versus the fee actually minted.
+const REWARDS_COMPOUNDED = "event RewardsCompounded(uint256 _amount)";
 
 const fetch = async (options: FetchOptions) => {
-  const slilsBnbSupplyBefore = await options.fromApi.call({
-    target: slisBNB,
-    abi: 'uint256:totalSupply',
-  });
-
-  const slisBnbSupplyAfter = await options.toApi.call({
-    target: slisBNB,
-    abi: 'uint256:totalSupply',
-  });
-
-  const pooledBnbBefore = await options.fromApi.call({
+  const logs = await options.getLogs({
     target: ListaStakeManagerAddress,
-    abi: 'uint256:getTotalPooledBnb',
+    eventAbi: REWARDS_COMPOUNDED,
   });
-
-  const pooledBnbAfter = await options.toApi.call({
-    target: ListaStakeManagerAddress,
-    abi: 'uint256:getTotalPooledBnb',
-  });
-
-  // staking rewards distributed post revenue cut
-  const supplySideRewards = (pooledBnbAfter / slisBnbSupplyAfter - pooledBnbBefore / slilsBnbSupplyBefore) * (slisBnbSupplyAfter / 1e18);
 
   // Commission rate is configurable on-chain (ListaStakeManager.synFee, 1e10 precision).
-  // Read it live instead of hardcoding, so Fees/Revenue always track the current rate.
   const synFee = await options.toApi.call({
     target: ListaStakeManagerAddress,
     abi: 'uint256:synFee',
   });
   const commissionRate = Number(synFee) / 1e10;
-  const supplyRate = 1 - commissionRate;
-  if (supplyRate <= 0) throw new Error(`Invalid synFee (commission >= 100%): ${synFee}`);
+  if (commissionRate <= 0 || commissionRate >= 1) throw new Error(`Invalid synFee: ${synFee}`);
 
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addCGToken("binancecoin", supplySideRewards / supplyRate, 'BNB Staking Rewards');
-  dailySupplySideRevenue.addCGToken("binancecoin", supplySideRewards, 'BNB Staking Rewards To Stakers');
+  for (const log of logs) {
+    const commission = Number(log._amount) / 1e18; // BNB kept by the protocol in this compound run
+    const rewards = commission / commissionRate; // total staking rewards compounded in this run
+    dailyFees.addCGToken("binancecoin", rewards, 'BNB Staking Rewards');
+    dailyRevenue.addCGToken("binancecoin", commission, 'BNB Staking Rewards Commission');
+    dailySupplySideRevenue.addCGToken("binancecoin", rewards - commission, 'BNB Staking Rewards To Stakers');
+  }
 
-  const dailyRevenue = dailyFees.clone(commissionRate, 'BNB Staking Rewards Commission');
   const dailyHoldersRevenue = dailyRevenue.clone(0.3, 'Token Buy Back'); // 30% of commission buys back LISTA
   const dailyProtocolRevenue = dailyRevenue.clone(0.7, 'BNB Staking Rewards Commission'); // 70% to treasury
 
@@ -70,7 +65,7 @@ const fetch = async (options: FetchOptions) => {
 };
 const methodology = {
   Fees: 'Total yields from staked BNB.',
-  Revenue: 'Lista DAO charges a commission on the staking yields (rate read on-chain from ListaStakeManager.synFee, 1e10 precision).',
+  Revenue: 'Lista DAO charges a commission (ListaStakeManager.synFee) on the staking yields, read from the daily RewardsCompounded event, i.e. the commission actually minted to revenuePool.',
   ProtocolRevenue: '70% of the commission is retained by the treasury.',
   HoldersRevenue: '30% of the commission is used to buy back LISTA.',
   SupplySideRevenue: 'Stakers earn the staking rewards net of the commission.',
@@ -89,7 +84,7 @@ const adapter: SimpleAdapter = {
       'BNB Staking Rewards': 'Total BNB staking rewards collected by running BSC validators.',
     },
     Revenue: {
-      'BNB Staking Rewards Commission': 'Commission charged on staking rewards (synFee, read on-chain).',
+      'BNB Staking Rewards Commission': 'Commission actually taken on each compoundRewards run (RewardsCompounded._amount).',
     },
     ProtocolRevenue: {
       'BNB Staking Rewards Commission': '70% of the commission is retained by the treasury.',


### PR DESCRIPTION
## Summary

Two accounting fixes for Lista DAO, both verified against Lista's internal revenue accounting (lista-cron) by recomputing both methods on-chain for August 2026.

### 1. `fees/lista-lisusd` — validator commission was counted twice

The adapter added two legs under **Validator Rewards**:

- daily `stListaDAO` mints to the validator operator `0x7766…03a` (commission accrual, minted by the system tx at 00:00 UTC), and
- `SafeReceived` on the ListaDAOCredit Safe `0x0D92…B13`.

On-chain these overlap. Lista operates three BSC validators (operators `0x7766…03a`, `0x5f04…1ae4`, `0x5b2b…3f96`). Each operator's commission accrues as StakeCredit shares; every month all three undelegate, and after the ~7-day unbonding period claim the BNB from StakeHub on the same day and forward it to the ops multisig `0x1d60…8f66` the same or next day (Jun / Jul / Aug 2026: 43.90 + 39.67 + 40.24, 46.19 + 42.03 + 43.96, 44.63 + 34.19 + 36.49 BNB). The ops multisig then deposits roughly half of the pooled commission into the ListaDAOCredit Safe (62.36 / 67.65 / 52.09 BNB; the remainder stays in the ops multisig), and the Safe forwards exactly that amount to the DAO collection wallet `0x0970…87B` one to four days later (06-16, 07-21, 08-14).

So the `SafeReceived` leg is the amount the DAO actually books as validator revenue, and the mint leg was (a) a second count of commission already inside that deposit, (b) only one of the three validators, and (c) valued 1:1 as BNB although the share price is ~1.011. The adapter comment assumed the `SafeReceived` path had stopped; it has not.

Fix: book validator revenue once, on the Safe receipt. The mint leg (and the startup-tx exclusion that only existed for it) is removed. This is also how Lista's internal accounting books it.

| month | before (mints + SafeReceived) | after (SafeReceived) | Lista internal accounting |
|---|---|---|---|
| 2026-06 | 106.25 BNB | 62.36 | 62.36 |
| 2026-07 | 107.75 | 67.65 | 67.65 |
| 2026-08 | 134.66 | 52.09 | 52.09 |

### 2. `fees/lista-slisbnb` — commission read from `RewardsCompounded` instead of inferred from the exchange rate

The adapter inferred total staking rewards from the daily change in the slisBNB exchange rate and took `synFee` of it. The exchange rate also rises for two reasons that are **not** staking rewards and on which the protocol takes no fee:

- the validator-commission refund (`RefundCommission`) that is deposited to the StakeManager and burned back to holders day by day inside `compoundRewards`;
- rewards accrued on shares awaiting withdrawal, which `ClaimUndelegatedFrom` leaves with the remaining holders.

In August 2026 this overstated Revenue by 4.56 BNB (+3.55%): inferred 133.14 BNB vs 128.53 BNB actually minted to `revenuePool` (3.36 BNB from the refund, 1.25 BNB from withdrawal-lag redistribution).

Fix: read `RewardsCompounded(_amount)` — in `ListaStakeManager.compoundRewards()` `_amount` is `fee = max(totalProfit × synFee, totalDelegated × annualRate / 365)`, the commission actually minted to `revenuePool` (verified per tx against `getTotalPooledBnb` deltas: exactly 15.00% of profit on all 31 August days). Fees = `_amount / synFee`, Revenue = `_amount`, SupplySide = the difference. Holders / protocol split unchanged (30 / 70).

Daily check with `cli/testAdapter.ts` (USD at DefiLlama's BNB price):

| day (UTC) | before | after | Lista internal (fee minted to revenuePool) |
|---|---|---|---|
| 2026-08-12 | $2,897 | $2,811 | 4.6106 BNB ≈ $2,811 |
| 2026-08-19 | $3,401 | $3,307 | 5.2744 BNB ≈ $3,307 |

Validator Rewards on 2026-08-13 (the day of the Safe deposit): before $32,268 (52.09 BNB deposit + that day's share mint), after $30,758 = 52.0907 BNB at the hourly BNB price; 2026-08-19: before $1,745 (mint only), after 0.

## Test

```
npx ts-node --transpile-only cli/testAdapter.ts fees lista-lisusd 2026-08-14
npx ts-node --transpile-only cli/testAdapter.ts fees lista-slisbnb 2026-08-13
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
