### PR TITLE
lista-lisusd: add Launchpool Income and Voting Rewards

### DIFF
--- a/fees/lista-lisusd/index.ts
+++ b/fees/lista-lisusd/index.ts
@@ -52,12 +52,14 @@ const usdt = ADDRESSES.bsc.USDT;
 const LISUSD_POOL_SET = "0x37DB1AE9B24055D1F9fE973Aea40B7EB2995D0Bf";
 const RATE_SCALE = 10n ** 27n;
 
-// Validator / node-operation rewards (BNB-denominated), counted once, when they land in the
-// ListaDAOCredit Safe (SafeReceived). The validator commission first accrues as stListaDAO shares
-// minted daily to the validator operator (0x7766…), the operator undelegates and claims the BNB
-// monthly and forwards it to the ops multisig, which deposits it into this Safe. Counting the daily
-// share mints as well double-counted the commission (the two legs are the same money, accrual vs.
-// realised), so only the Safe receipt is booked.
+// Validator / node-operation revenue (BNB). Lista operates several BSC validators (operators
+// 0x7766…, 0x5f04…, 0x5b2b…). Each operator's commission accrues as StakeCredit shares, is
+// undelegated and claimed monthly and forwarded to the ops multisig (0x1d60…8f66); the ops multisig
+// then deposits the DAO's share into this ListaDAOCredit Safe, which forwards it to the DAO
+// collection wallet (0x0970…) a few days later. The Safe receipt (SafeReceived) is therefore the
+// amount the DAO actually books as validator revenue, and it is counted once here. The previous
+// extra leg (daily stListaDAO share mints to 0x7766…) covered only one of the validators, valued
+// shares 1:1 as BNB, and double-counted the commission already contained in the Safe deposit.
 const listaDAOCredit = "0x0D92Ac7a4590874a493eB62b37D3Ea3390966B13";
 
 // Liquidation profit: Moolah / broker liquidations settle their USDT profit to this receiver

--- a/fees/lista-lisusd/index.ts
+++ b/fees/lista-lisusd/index.ts
@@ -11,6 +11,7 @@ import { CHAIN } from "../../helpers/chains";
  * @treasury
  * https://bscscan.com/address/0x8d388136d578dcd791d081c6042284ced6d9b0c6#tokentxns
  * https://bscscan.com/address/0x34b504a5cf0ff41f8a480580533b6dda687fa3da#tokentxns
+ * https://bscscan.com/address/0x09702ea135d9d707dd51f530864f2b9220aad87b (DAO collection wallet / Ops Safe)
  */
 
 const newTreasuryActivationTime = 1727222400 //2024-09-25;
@@ -23,6 +24,9 @@ const newTreasury =
 // after the payout recipient migrated off the old treasury.
 const opsSafe =
   "0x00000000000000000000000009702ea135d9d707dd51f530864f2b9220aad87b";
+// Same Ops Safe, unpadded — it is also the DAO collection wallet for native BNB income (Gnosis Safe,
+// emits SafeReceived) and the receiver() of the voting-reward buyback contract.
+const daoCollectionWallet = "0x09702Ea135d9D707DD51f530864f2B9220aAD87B";
 const zeroAddress =
   "0x0000000000000000000000000000000000000000000000000000000000000000";
 const transferHash =
@@ -33,6 +37,25 @@ const SnBnbYieldConverterStrategy =
   "0x0000000000000000000000006f28fec449dbd2056b76ac666350af8773e03873";
 const CeETHVault = "0xA230805C28121cc97B348f8209c79BEBEa3839C0";
 const HayJoin = "0x4C798F81de7736620Cd8e6510158b1fE758e22F7";
+
+// Auto Launchpool income (native BNB). The clisBNB launchpool reward distributors forward the DAO's
+// share of each launchpool round to the DAO collection wallet (SafeReceived). Only these two senders
+// are counted: the same Safe also receives the validator revenue forwarded from the ListaDAOCredit
+// Safe (0x0D92…), which is already booked as Validator Rewards on 0x0D92's own SafeReceived, so it
+// must not be counted a second time here.
+const launchpoolDistributors = new Set([
+  "0x81a62b329cc8939494d8613f614171a9955a46e8", // ClisBNBLaunchPoolDistributor
+  "0x8b7d334d243b74d63c4b963893267a0f5240f990", // ClisBNBLaunchPoolDistributorPendle
+]);
+
+// Voting rewards (USDT). Bribes / gauge-voting incentives earned by the DAO's veCAKE / veTHE
+// positions are collected by the ops bribe wallet (0x85ce…) and pushed into this VotingReward
+// buyback contract, where the bot swaps them to USDT and the contract forwards the USDT to its
+// receiver() — the DAO collection wallet — in the same tx (BoughtBack). That forwarded USDT is the
+// realised income; the intermediate swap legs (router -> contract) are the same money and are not
+// counted.
+const votingRewardBuyback =
+  "0x000000000000000000000000098a0c419915bffa99983abee5d960c193cc9bfb";
 
 // token
 const lista = "0xFceB31A79F71AC9CBDCF853519c1b12D379EdC46";
@@ -84,6 +107,8 @@ const VALIDATOR_REWARDS = "Validator Rewards";
 const LP_STAKING_REWARDS = "LP Staking Rewards";
 const FREEZE_LISTA = "Freeze LISTA";
 const LSR_SAVINGS_COST = "sLisUSD Savings Cost";
+const LAUNCHPOOL_INCOME = "Launchpool Income";
+const VOTING_REWARDS = "Voting Rewards";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -194,6 +219,20 @@ const fetch = async (options: FetchOptions) => {
     target: listaDAOCredit,
     eventAbi: "event SafeReceived(address indexed sender, uint256 value)",
   });
+
+  // Auto Launchpool income: native BNB from the launchpool distributors into the DAO collection wallet
+  const launchpoolIncome = (
+    await options.getLogs({
+      target: daoCollectionWallet,
+      eventAbi: "event SafeReceived(address indexed sender, uint256 value)",
+    })
+  ).filter((log: any) => launchpoolDistributors.has(String(log.sender).toLowerCase()));
+
+  // Voting rewards: USDT forwarded by the buyback contract to the DAO collection wallet
+  const votingRewards = await options.getLogs({
+    target: usdt,
+    topics: [transferHash, votingRewardBuyback, opsSafe],
+  });
   // LP staking rewards
   const lpStakeRewardsFromHash =
     "0x00000000000000000000000062dfec5c9518fe2e0ba483833d1bad94ecf68153";
@@ -261,6 +300,12 @@ const fetch = async (options: FetchOptions) => {
   [...validatorRewardsListaDAOCredit].forEach((log) => {
     dailyFees.add(bnb, Number(log.value), VALIDATOR_REWARDS);
   });
+  [...launchpoolIncome].forEach((log) => {
+    dailyFees.add(bnb, Number(log.value), LAUNCHPOOL_INCOME);
+  });
+  [...votingRewards].forEach((log) => {
+    dailyFees.add(usdt, Number(log.data), VOTING_REWARDS);
+  });
   [...lpStakingListaRewards].forEach((log) => {
     dailyFees.add(lista, Number(log.data), LP_STAKING_REWARDS);
   });
@@ -318,6 +363,10 @@ const LISUSD_BREAKDOWN = {
   [VALIDATOR_REWARDS]:
     'BNB validator commission, booked once when it is deposited into the ListaDAOCredit Safe (SafeReceived)',
   [LP_STAKING_REWARDS]: 'CAKE / LISTA rewards from PancakeSwap LP staking',
+  [LAUNCHPOOL_INCOME]:
+    'BNB share of clisBNB launchpool rewards forwarded by the launchpool distributors to the DAO collection wallet (SafeReceived)',
+  [VOTING_REWARDS]:
+    'veCAKE / veTHE gauge-voting bribes, counted as the USDT the voting-reward buyback contract forwards to the DAO collection wallet after swapping',
   [FREEZE_LISTA]: 'Frozen (burned) LISTA deducted from revenue',
 };
 
@@ -342,7 +391,7 @@ const adapter: SimpleAdapter = {
     },
   },
   methodology: {
-    Fees: 'All protocol income collected by Lista DAO on BSC (staking profits, borrow interest, liquidation profit, and PSM/veLista/LP/validator fees), net of frozen LISTA.',
+    Fees: 'All protocol income collected by Lista DAO on BSC (staking profits, borrow interest, liquidation profit, PSM/veLista/LP/validator fees, launchpool income and voting rewards), net of frozen LISTA.',
     Revenue: 'Collected income kept by the protocol, net of the sLisUSD savings interest paid out to sLisUSD depositors.',
     ProtocolRevenue: 'Collected income kept by the protocol treasury, net of the sLisUSD savings interest.',
     SupplySideRevenue: 'Interest earned by third-party sLisUSD depositors in the savings pool (LisUSDPoolSet), measured as the duty-rate accrual over the period (totalSupply * change in getRate index).',

--- a/fees/lista-lisusd/index.ts
+++ b/fees/lista-lisusd/index.ts
@@ -52,16 +52,13 @@ const usdt = ADDRESSES.bsc.USDT;
 const LISUSD_POOL_SET = "0x37DB1AE9B24055D1F9fE973Aea40B7EB2995D0Bf";
 const RATE_SCALE = 10n ** 27n;
 
-// Validator / node-operation rewards (BNB-denominated). Track both paths:
-// 1. ListaDAOCredit SafeReceived — historical revenue before the migration.
-// 2. stListaDAO mints to the reward collector — current revenue flow.
+// Validator / node-operation rewards (BNB-denominated), counted once, when they land in the
+// ListaDAOCredit Safe (SafeReceived). The validator commission first accrues as stListaDAO shares
+// minted daily to the validator operator (0x7766…), the operator undelegates and claims the BNB
+// monthly and forwards it to the ops multisig, which deposits it into this Safe. Counting the daily
+// share mints as well double-counted the commission (the two legs are the same money, accrual vs.
+// realised), so only the Safe receipt is booked.
 const listaDAOCredit = "0x0D92Ac7a4590874a493eB62b37D3Ea3390966B13";
-const stListaDAO = "0xc096e7781c95a2fc6feb1efe776b570270b3965d";
-const validatorRewardCollector =
-  "0x0000000000000000000000007766a5ee8294343bf6c8dcf3aa4b6d856606703a";
-// One-off startup funding mint — not revenue, excluded.
-const VALIDATOR_STARTUP_TX =
-  "0x0a6b673be9105a33756f4c6a6213ad4712c027c6ea001a9717f1a0b13fcdc343";
 
 // Liquidation profit: Moolah / broker liquidations settle their USDT profit to this receiver
 const liquidatorProfitReceiver =
@@ -195,15 +192,6 @@ const fetch = async (options: FetchOptions) => {
     target: listaDAOCredit,
     eventAbi: "event SafeReceived(address indexed sender, uint256 value)",
   });
-  const validatorRewardsStListaDAO = (
-    await options.getLogs({
-      target: stListaDAO,
-      topics: [transferHash, zeroAddress, validatorRewardCollector],
-    })
-  ).filter(
-    (log: any) =>
-      (log.transactionHash ?? "").toLowerCase() !== VALIDATOR_STARTUP_TX,
-  );
   // LP staking rewards
   const lpStakeRewardsFromHash =
     "0x00000000000000000000000062dfec5c9518fe2e0ba483833d1bad94ecf68153";
@@ -271,9 +259,6 @@ const fetch = async (options: FetchOptions) => {
   [...validatorRewardsListaDAOCredit].forEach((log) => {
     dailyFees.add(bnb, Number(log.value), VALIDATOR_REWARDS);
   });
-  [...validatorRewardsStListaDAO].forEach((log) => {
-    dailyFees.add(bnb, Number(log.data), VALIDATOR_REWARDS);
-  });
   [...lpStakingListaRewards].forEach((log) => {
     dailyFees.add(lista, Number(log.data), LP_STAKING_REWARDS);
   });
@@ -329,7 +314,7 @@ const LISUSD_BREAKDOWN = {
   [PSM_CONVERT_FEE]: 'PSM (USDT) conversion fee',
   [USDT_STAKING_PROFIT]: 'Profit from USDT staking via VenusAdapter',
   [VALIDATOR_REWARDS]:
-    'BNB validator / node-operation rewards (ListaDAOCredit SafeReceived historically; stListaDAO minted to the reward collector currently)',
+    'BNB validator commission, booked once when it is deposited into the ListaDAOCredit Safe (SafeReceived)',
   [LP_STAKING_REWARDS]: 'CAKE / LISTA rewards from PancakeSwap LP staking',
   [FREEZE_LISTA]: 'Frozen (burned) LISTA deducted from revenue',
 };

--- a/fees/lista-slisbnb/index.ts
+++ b/fees/lista-slisbnb/index.ts
@@ -14,8 +14,10 @@ import { CHAIN } from "../../helpers/chains";
 const ListaStakeManagerAddress = "0x1adB950d8bB3dA4bE104211D5AB038628e477fE6";
 
 // ListaStakeManager.compoundRewards() runs once a day: it books the BSC staking rewards earned by the
-// pool, keeps synFee of them as the protocol commission (minted as slisBNB to revenuePool) and emits
-// RewardsCompounded(_amount) with that commission in BNB.
+// pool (totalProfit), takes fee = max(totalProfit * synFee, totalDelegated * annualRate / 365) as the
+// protocol commission (minted as slisBNB to revenuePool) and emits RewardsCompounded(fee) in BNB.
+// Revenue below is that exact fee; gross rewards are derived as fee / synFee, which is exact whenever
+// the profit-based branch binds (every day in Aug-2026).
 //
 // The commission is read from this event rather than inferred from the slisBNB exchange-rate move,
 // because the rate also rises for two reasons that are not staking rewards and carry no fee:

--- a/fees/lista-slisbnb/index.ts
+++ b/fees/lista-slisbnb/index.ts
@@ -80,6 +80,7 @@ const adapter: SimpleAdapter = {
       start: '2023-08-30',
     },
   },
+  pullHourly: true,
   methodology,
   breakdownMethodology: {
     Fees: {

--- a/fees/lista-slisbnb/index.ts
+++ b/fees/lista-slisbnb/index.ts
@@ -13,50 +13,45 @@ import { CHAIN } from "../../helpers/chains";
 
 const ListaStakeManagerAddress = "0x1adB950d8bB3dA4bE104211D5AB038628e477fE6";
 
-// token
-const slisBNB = "0xb0b84d294e0c75a6abe60171b70edeb2efd14a1b";
+// ListaStakeManager.compoundRewards() runs once a day: it books the BSC staking rewards earned by the
+// pool, keeps synFee of them as the protocol commission (minted as slisBNB to revenuePool) and emits
+// RewardsCompounded(_amount) with that commission in BNB.
+//
+// The commission is read from this event rather than inferred from the slisBNB exchange-rate move,
+// because the rate also rises for two reasons that are not staking rewards and carry no fee:
+// (1) the validator-commission refund that RefundCommission deposits and compoundRewards burns back to
+//     holders day by day, and
+// (2) rewards accrued on shares awaiting withdrawal, which ClaimUndelegatedFrom leaves with the
+//     remaining holders.
+// Inferring from the rate overstated Revenue by ~3.5% in Aug-2026 versus the fee actually minted.
+const REWARDS_COMPOUNDED = "event RewardsCompounded(uint256 _amount)";
 
 const fetch = async (options: FetchOptions) => {
-  const slilsBnbSupplyBefore = await options.fromApi.call({
-    target: slisBNB,
-    abi: 'uint256:totalSupply',
-  });
-
-  const slisBnbSupplyAfter = await options.toApi.call({
-    target: slisBNB,
-    abi: 'uint256:totalSupply',
-  });
-
-  const pooledBnbBefore = await options.fromApi.call({
+  const logs = await options.getLogs({
     target: ListaStakeManagerAddress,
-    abi: 'uint256:getTotalPooledBnb',
+    eventAbi: REWARDS_COMPOUNDED,
   });
-
-  const pooledBnbAfter = await options.toApi.call({
-    target: ListaStakeManagerAddress,
-    abi: 'uint256:getTotalPooledBnb',
-  });
-
-  // staking rewards distributed post revenue cut
-  const supplySideRewards = (pooledBnbAfter / slisBnbSupplyAfter - pooledBnbBefore / slilsBnbSupplyBefore) * (slisBnbSupplyAfter / 1e18);
 
   // Commission rate is configurable on-chain (ListaStakeManager.synFee, 1e10 precision).
-  // Read it live instead of hardcoding, so Fees/Revenue always track the current rate.
   const synFee = await options.toApi.call({
     target: ListaStakeManagerAddress,
     abi: 'uint256:synFee',
   });
   const commissionRate = Number(synFee) / 1e10;
-  const supplyRate = 1 - commissionRate;
-  if (supplyRate <= 0) throw new Error(`Invalid synFee (commission >= 100%): ${synFee}`);
+  if (commissionRate <= 0 || commissionRate >= 1) throw new Error(`Invalid synFee: ${synFee}`);
 
   const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
   const dailySupplySideRevenue = options.createBalances();
 
-  dailyFees.addCGToken("binancecoin", supplySideRewards / supplyRate, 'BNB Staking Rewards');
-  dailySupplySideRevenue.addCGToken("binancecoin", supplySideRewards, 'BNB Staking Rewards To Stakers');
+  for (const log of logs) {
+    const commission = Number(log._amount) / 1e18; // BNB kept by the protocol in this compound run
+    const rewards = commission / commissionRate; // total staking rewards compounded in this run
+    dailyFees.addCGToken("binancecoin", rewards, 'BNB Staking Rewards');
+    dailyRevenue.addCGToken("binancecoin", commission, 'BNB Staking Rewards Commission');
+    dailySupplySideRevenue.addCGToken("binancecoin", rewards - commission, 'BNB Staking Rewards To Stakers');
+  }
 
-  const dailyRevenue = dailyFees.clone(commissionRate, 'BNB Staking Rewards Commission');
   const dailyHoldersRevenue = dailyRevenue.clone(0.3, 'Token Buy Back'); // 30% of commission buys back LISTA
   const dailyProtocolRevenue = dailyRevenue.clone(0.7, 'BNB Staking Rewards Commission'); // 70% to treasury
 
@@ -70,7 +65,7 @@ const fetch = async (options: FetchOptions) => {
 };
 const methodology = {
   Fees: 'Total yields from staked BNB.',
-  Revenue: 'Lista DAO charges a commission on the staking yields (rate read on-chain from ListaStakeManager.synFee, 1e10 precision).',
+  Revenue: 'Lista DAO charges a commission (ListaStakeManager.synFee) on the staking yields, read from the daily RewardsCompounded event, i.e. the commission actually minted to revenuePool.',
   ProtocolRevenue: '70% of the commission is retained by the treasury.',
   HoldersRevenue: '30% of the commission is used to buy back LISTA.',
   SupplySideRevenue: 'Stakers earn the staking rewards net of the commission.',
@@ -89,7 +84,7 @@ const adapter: SimpleAdapter = {
       'BNB Staking Rewards': 'Total BNB staking rewards collected by running BSC validators.',
     },
     Revenue: {
-      'BNB Staking Rewards Commission': 'Commission charged on staking rewards (synFee, read on-chain).',
+      'BNB Staking Rewards Commission': 'Commission actually taken on each compoundRewards run (RewardsCompounded._amount).',
     },
     ProtocolRevenue: {
       'BNB Staking Rewards Commission': '70% of the commission is retained by the treasury.',


### PR DESCRIPTION
## Summary

Adds two Lista DAO income sources that the internal accounting (lista-cron `daily_income_log`) books but `fees/lista-lisusd` did not. Both are verified as the same money as the internal figures, from on-chain data for Jun–Aug 2026.

Stacked on #9363 (same file); merge that first or this one will carry its two commits.

### Launchpool Income (BNB)

The clisBNB launchpool reward distributors (`0x81a6…46e8`, `0x8b7d…f990`) forward the DAO's share of each launchpool round as native BNB to the DAO collection wallet `0x0970…87B`, a Gnosis Safe, so each receipt is a `SafeReceived(sender, value)` log. The leg reads those logs and keeps only the two distributor senders. The same Safe also receives the validator revenue forwarded from the ListaDAOCredit Safe (`0x0D92…`, already booked as Validator Rewards on that Safe's own `SafeReceived`), which the sender whitelist excludes — no double count. In Jun–Aug 2026 these three were the only `SafeReceived` senders on `0x0970`.

| month | Launchpool Income |
|---|---|
| 2026-06 | 19.1652 BNB |
| 2026-07 | 3.7646 BNB |
| 2026-08 | 0 |

### Voting Rewards (USDT)

Gauge-voting incentives collected by the DAO's bribe wallet (`0x85ce…`) are pushed into the voting-reward buyback contract `0x098a…9bFb`; the bot swaps them to USDT and the contract forwards the USDT to its `receiver()` (`0x0970…87B`) in the same tx. The leg books that forwarded USDT (`Transfer` from `0x098a…` to `0x0970…`), which equals the internal `receiveAmount` and avoids counting the intermediate swap legs. Small: 219.96 / 105.97 / 80.83 USDT in Jun / Jul / Aug 2026 (35 txs).

### Checked and not added

- ETH withdraw fee: already inside Fees — the existing CeETHVault → treasury ETH-token leg (label ETH Staking Profit) is exactly that fee (all ETH-token transfers on that filter since 2024 sit in withdrawal txs; the staking yield arrives as wBETH). Left as is to avoid changing the historical breakdown; effectively 0 in 2026.
- DAO ops-multisig yield on its own USDT MoolahVault deposit: supply-side, estimated internally, no realisation event — not protocol revenue.

## Test

```
npx ts-node --transpile-only cli/testAdapter.ts fees lista-lisusd 2026-07-02   # Launchpool Income 3.7646 BNB (≈ $2,072)
npx ts-node --transpile-only cli/testAdapter.ts fees lista-lisusd 2026-08-26   # Voting Rewards 30.96 USDT
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
