### PR TITLE
[fix] perp open interest: report one side, not long plus short

### DIFF
--- a/dexs/avantis/index.ts
+++ b/dexs/avantis/index.ts
@@ -36,8 +36,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
 		// totalRatio is Sigma(long + short) — it matches Avantis' own totalOi exactly. Pool venue
 		// with no single-sided field, so report the average of the two sides.
 		openInterestAtEnd: openInterest ? openInterest.totalRatio / 2 : 0,
-		longOpenInterestAtEnd: openInterest ? openInterest.longTotal : 0,
-		shortOpenInterestAtEnd: openInterest ? openInterest.shortTotal : 0,
+		longOpenInterestAtEnd: openInterest ? openInterest.longTotal / 2 : 0,
+		shortOpenInterestAtEnd: openInterest ? openInterest.shortTotal / 2 : 0,
 	};
 };
 

--- a/dexs/avantis/index.ts
+++ b/dexs/avantis/index.ts
@@ -33,7 +33,9 @@ const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
 
 	return {
 		dailyVolume,
-		openInterestAtEnd: openInterest ? openInterest.totalRatio : 0,
+		// totalRatio is Sigma(long + short) — it matches Avantis' own totalOi exactly. Pool venue
+		// with no single-sided field, so report the average of the two sides.
+		openInterestAtEnd: openInterest ? openInterest.totalRatio / 2 : 0,
 		longOpenInterestAtEnd: openInterest ? openInterest.longTotal : 0,
 		shortOpenInterestAtEnd: openInterest ? openInterest.shortTotal : 0,
 	};

--- a/dexs/extended/index.ts
+++ b/dexs/extended/index.ts
@@ -45,7 +45,8 @@ const fetch = async (options: FetchOptions): Promise<FetchResultVolume> => {
   const historical: IResponse = await fetchURL(config.endpoints.historicalVolume(timestampISO))
   const dailyVolume = historical.data.reduce((a: number, b: IVolumeall) => a + Number(b.tradingVolume), 0) / 2
   const res = (await fetchURL(config.endpoints.markets)).data
-  const openInterestAtEnd = res.reduce((a: number, b: any) => a + Number(b.marketStats.openInterest || 0), 0)
+  // marketStats.openInterest sums long and short, halve it like tradingVolume above
+  const openInterestAtEnd = res.reduce((a: number, b: any) => a + Number(b.marketStats.openInterest || 0), 0) / 2
 
   return {
     dailyVolume,

--- a/dexs/fulcrom-finance-derivatives.ts
+++ b/dexs/fulcrom-finance-derivatives.ts
@@ -49,7 +49,8 @@ const fetch = async (options: FetchOptions) => {
   const dailyVolume = toUSD(BigInt(volume.margin) + BigInt(volume.liquidation));
   const longOpenInterestAtEnd = toUSD(oi.longOpenInterest);
   const shortOpenInterestAtEnd = toUSD(oi.shortOpenInterest);
-  const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
+  // pool venue with no single-sided field: average the two sides instead of summing them
+  const openInterestAtEnd = (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2;
 
   return {
     dailyVolume,

--- a/dexs/fulcrom-finance-derivatives.ts
+++ b/dexs/fulcrom-finance-derivatives.ts
@@ -47,8 +47,8 @@ const fetch = async (options: FetchOptions) => {
   const oi = dailyData.tradingStats[0];
 
   const dailyVolume = toUSD(BigInt(volume.margin) + BigInt(volume.liquidation));
-  const longOpenInterestAtEnd = toUSD(oi.longOpenInterest);
-  const shortOpenInterestAtEnd = toUSD(oi.shortOpenInterest);
+  const longOpenInterestAtEnd = toUSD(oi.longOpenInterest) / 2;
+  const shortOpenInterestAtEnd = toUSD(oi.shortOpenInterest) / 2;
   // pool venue with no single-sided field: average the two sides instead of summing them
   const openInterestAtEnd = (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2;
 

--- a/dexs/moonlander/index.ts
+++ b/dexs/moonlander/index.ts
@@ -90,8 +90,8 @@ const getOpenInterest = async ({
   });
 
   return {
-    longOpenInterestAtEnd: totalLongOIUsd,
-    shortOpenInterestAtEnd: totalShortOIUsd,
+    longOpenInterestAtEnd: totalLongOIUsd / 2,
+    shortOpenInterestAtEnd: totalShortOIUsd / 2,
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd: (totalLongOIUsd + totalShortOIUsd) / 2,
   };

--- a/dexs/moonlander/index.ts
+++ b/dexs/moonlander/index.ts
@@ -92,7 +92,8 @@ const getOpenInterest = async ({
   return {
     longOpenInterestAtEnd: totalLongOIUsd,
     shortOpenInterestAtEnd: totalShortOIUsd,
-    openInterestAtEnd: totalLongOIUsd + totalShortOIUsd,
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd: (totalLongOIUsd + totalShortOIUsd) / 2,
   };
 };
 

--- a/dexs/ostium/index.ts
+++ b/dexs/ostium/index.ts
@@ -4,13 +4,12 @@ import { queryDuneSql } from "../../helpers/dune";
 
 const fetch = async (options: FetchOptions) => {
 
-  // Bilateral OI: max(oi_long, oi_short) * 2.
+  // One-sided OI: (oi_long + oi_short) / 2.
   // Ostium is a bilateral OTC venue: every trade has a counterparty (another trader
-  // or the Liquidity Pool Vault). The vault's private hedging operations are now
-  // fully off-chain and can't be tracked directly, so trader-side notional alone
-  // understates true exposure. Taking the larger side and doubling it gives an
-  // approximation of total open exposure across both legs of the market. If/when
-  // hedging activity is reflected on-chain again, this can be revisited.
+  // or the Liquidity Pool Vault), and there is no single-sided field to read. Long and
+  // short are independent here (per-pair L/S spans 0.03-8.0), so the average of the two
+  // sides is the one-sided figure, matching how the other pool venues are reported.
+  // This replaces an earlier max(long, short) * 2 estimate of total two-legged exposure.
   const volumeRes = await queryDuneSql(options, `
     WITH orders AS (
       SELECT * FROM query_5255724
@@ -52,10 +51,9 @@ const fetch = async (options: FetchOptions) => {
     ),
     final_oi AS (
       SELECT
-        greatest(
-          sum(IF(is_buy, open_interest, 0)),
-          sum(IF(NOT is_buy, open_interest, 0))
-        ) * 2 AS open_interest
+        (
+          sum(IF(is_buy, open_interest, 0)) + sum(IF(NOT is_buy, open_interest, 0))
+        ) / 2 AS open_interest
       FROM latest_oi_per_side
     )
     SELECT 

--- a/dexs/variational-omni/index.ts
+++ b/dexs/variational-omni/index.ts
@@ -9,7 +9,12 @@ const fetch = async (_: any) => {
   const data = await fetchUrl(URL);
 
   return {
-    openInterestAtEnd: data.open_interest,
+    // Two factors. The headline open_interest counts each position from both counterparties, so
+    // it is exactly 2.0000x the sum of the per-listing long_open_interest + short_open_interest.
+    // That sum is then halved again: Variational is an RFQ/dealer venue where long != short
+    // (Sigma long $576.5M vs Sigma short $312.0M), so the one-sided figure is the average of the
+    // two sides, not either one. Net: a quarter of the published number.
+    openInterestAtEnd: Number(data.open_interest) / 4,
     dailyVolume: data?.total_volume_24h ,
   };
 };

--- a/dexs/variational-omni/index.ts
+++ b/dexs/variational-omni/index.ts
@@ -9,12 +9,12 @@ const fetch = async (_: any) => {
   const data = await fetchUrl(URL);
 
   return {
-    // Two factors. The headline open_interest counts each position from both counterparties, so
-    // it is exactly 2.0000x the sum of the per-listing long_open_interest + short_open_interest.
-    // That sum is then halved again: Variational is an RFQ/dealer venue where long != short
-    // (Sigma long $576.5M vs Sigma short $312.0M), so the one-sided figure is the average of the
-    // two sides, not either one. Net: a quarter of the published number.
-    openInterestAtEnd: Number(data.open_interest) / 4,
+    // The headline open_interest is gross both-legs: exactly 2.00000x the sum of the per-listing
+    // long_open_interest + short_open_interest (measured on two snapshots). Those per-listing
+    // sides are user exposure against the dealer, not the two legs of one contract - Variational
+    // is RFQ, and 51 of 550 markets carry longs with short exactly 0, which a two-leg field pair
+    // could not - so their sum already counts each position once. Halve once, not twice.
+    openInterestAtEnd: Number(data.open_interest) / 2,
     dailyVolume: data?.total_volume_24h ,
   };
 };

--- a/dexs/wavex-derivatives.ts
+++ b/dexs/wavex-derivatives.ts
@@ -53,10 +53,10 @@ const fetch = async (options: FetchOptions) => {
 
   return {
     longOpenInterestAtEnd: longOpenInterestAtEnd
-      ? String(longOpenInterestAtEnd * 10 ** -DECIMALS)
+      ? String((longOpenInterestAtEnd / 2) * 10 ** -DECIMALS)
       : undefined,
     shortOpenInterestAtEnd: shortOpenInterestAtEnd
-      ? String(shortOpenInterestAtEnd * 10 ** -DECIMALS)
+      ? String((shortOpenInterestAtEnd / 2) * 10 ** -DECIMALS)
       : undefined,
     openInterestAtEnd: openInterestAtEnd
       ? String(openInterestAtEnd * 10 ** -DECIMALS)

--- a/dexs/wavex-derivatives.ts
+++ b/dexs/wavex-derivatives.ts
@@ -45,7 +45,8 @@ const fetch = async (options: FetchOptions) => {
     shortOpenInterestAtEnd = Number(
       tradingStats.tradingStat.shortOpenInterest || 0
     );
-    openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd = (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2;
   }
 
   const DECIMALS = 30;

--- a/helpers/hyperliquid.ts
+++ b/helpers/hyperliquid.ts
@@ -469,12 +469,16 @@ export async function queryHyperliquidIndexerOpenInterest(options: FetchOptions)
     hip3Deployers: {},
   }
 
+  // Hyperliquid's openInterest counts both sides of each contract (measured at exactly 2x CMC's
+  // one-sided figure), so halve it here to match the one-sided convention used across perp OI.
+  const oneSided = (item: any) => (Number(item.openInterest) * Number(item.markPx)) / 2;
+
   // default perps
   const metaAndAssetCtxs = await getMetaAndAssetCtxs(options);
   if (metaAndAssetCtxs) {
     for (const item of metaAndAssetCtxs[1]) {
-      result.totalOpenInterest += Number(item.openInterest) * Number(item.markPx);
-      result.defaultPerpsOpenInterest += Number(item.openInterest) * Number(item.markPx);
+      result.totalOpenInterest += oneSided(item);
+      result.defaultPerpsOpenInterest += oneSided(item);
     }
   }
 
@@ -484,8 +488,8 @@ export async function queryHyperliquidIndexerOpenInterest(options: FetchOptions)
     if (metaAndAssetCtxsDex) {
       result.hip3Deployers[dex] = 0;
       for (const item of metaAndAssetCtxsDex[1]) {
-        result.totalOpenInterest += Number(item.openInterest) * Number(item.markPx);
-        result.hip3Deployers[dex] += Number(item.openInterest) * Number(item.markPx);
+        result.totalOpenInterest += oneSided(item);
+        result.hip3Deployers[dex] += oneSided(item);
       }
     }
   }

--- a/open-interest/apollox.ts
+++ b/open-interest/apollox.ts
@@ -68,7 +68,11 @@ const fetch = async () => {
 
   const v2DailyVolume = await fetchV2Volume();
 
-  const dailyOpenInterest = v2DailyVolume.openInterestAtEnd + v1DailyOpenInterest;
+  // Aster docs: "Both long and short open positions are counted as part of Open interest.
+  // It is calculated both ways." This bapi ticker `openInterest` is that UI figure (USD notional),
+  // so halve it for the one-sided convention. Aster's Binance-shaped /fapi/v1/openInterest is
+  // one-sided already and would be the cleaner source to switch to.
+  const dailyOpenInterest = (v2DailyVolume.openInterestAtEnd + v1DailyOpenInterest) / 2;
 
   return { openInterestAtEnd: dailyOpenInterest };
 };

--- a/open-interest/arcus-oi.ts
+++ b/open-interest/arcus-oi.ts
@@ -8,13 +8,15 @@ const fetch = async () => {
   const { markets } = await fetchURL(API);
   const openInterestAtEnd = markets
     .filter((market: any) => market.type === "PERPETUAL")
-    .reduce((sum: number, market: any) => sum + Number(market.openInterest) * Number(market.markPrice), 0);
+    .reduce((sum: number, market: any) => sum + Number(market.openInterest) * Number(market.markPrice), 0) / 2;
 
+  // /v1/markets openInterest is long+short: measured 2x fill size on HOOD-USD (9/12 lags), and
+  // CoinGecko independently carries 2.013x our halved figure across 57 markets.
   return { openInterestAtEnd };
 };
 
 const methodology = {
-  OpenInterest: "Open interest is the sum of notional open interest from Arcus's markets API.",
+  OpenInterest: "Open interest is the sum of notional open interest from Arcus's markets API, halved because that field counts both the long and the short side of each contract.",
 };
 
 const adapter: SimpleAdapter = {

--- a/open-interest/bounce-tech-oi.ts
+++ b/open-interest/bounce-tech-oi.ts
@@ -40,6 +40,8 @@ const fetch = async (options: FetchOptions) => {
 
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd.resizeBy(0.5);
+    longOpenInterestAtEnd.resizeBy(0.5);
+    shortOpenInterestAtEnd.resizeBy(0.5);
 
     return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };

--- a/open-interest/bounce-tech-oi.ts
+++ b/open-interest/bounce-tech-oi.ts
@@ -38,6 +38,9 @@ const fetch = async (options: FetchOptions) => {
         else shortOpenInterestAtEnd.add(USDC, notional);
     });
 
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd.resizeBy(0.5);
+
     return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };
 

--- a/open-interest/bulk-trade/index.ts
+++ b/open-interest/bulk-trade/index.ts
@@ -23,7 +23,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
   if (!Number.isFinite(openInterest * 2))
     throw new Error('BULK stats response has invalid open interest')
   return {
-    openInterestAtEnd: openInterest * 2,
+    // The API's one-sided figure is the headline: aggregate longs equal aggregate shorts, so
+    // reporting their sum would double-count.
+    openInterestAtEnd: openInterest,
     longOpenInterestAtEnd: openInterest,
     shortOpenInterestAtEnd: openInterest,
   }
@@ -37,7 +39,7 @@ const adapter: SimpleAdapter = {
   // Open interest is a point-in-time snapshot and must not be summed across hourly runs.
   pullHourly: false,
   methodology: {
-    OpenInterest: 'Current gross long-plus-short open interest across all BULK perpetual markets. The BULK API exposes one-sided open interest from positive positions; aggregate longs equal aggregate shorts, so the adapter reports the API value for each side and their sum as gross open interest.',
+    OpenInterest: 'Current open interest across all BULK perpetual markets, one-sided. The BULK API exposes one-sided open interest from positive positions; aggregate longs equal aggregate shorts, so the API value is reported as-is rather than summed across both sides.',
   },
 }
 

--- a/open-interest/bulk-trade/index.ts
+++ b/open-interest/bulk-trade/index.ts
@@ -22,13 +22,9 @@ async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
     throw new Error('BULK stats response has invalid open interest')
   if (!Number.isFinite(openInterest * 2))
     throw new Error('BULK stats response has invalid open interest')
-  return {
-    // The API's one-sided figure is the headline: aggregate longs equal aggregate shorts, so
-    // reporting their sum would double-count.
-    openInterestAtEnd: openInterest,
-    longOpenInterestAtEnd: openInterest / 2,
-    shortOpenInterestAtEnd: openInterest / 2,
-  }
+  // The API's one-sided figure is the headline: aggregate longs equal aggregate shorts, so
+  // their sum would double-count and a long/short split would be this number twice.
+  return { openInterestAtEnd: openInterest }
 }
 
 const adapter: SimpleAdapter = {
@@ -39,7 +35,7 @@ const adapter: SimpleAdapter = {
   // Open interest is a point-in-time snapshot and must not be summed across hourly runs.
   pullHourly: false,
   methodology: {
-    OpenInterest: 'Current open interest across all BULK perpetual markets, one-sided. The BULK API exposes one-sided open interest from positive positions; aggregate longs equal aggregate shorts, so the API value is reported as-is rather than summed across both sides.',
+    OpenInterest: 'Current open interest across all BULK perpetual markets, one-sided. The BULK API exposes one-sided open interest from positive positions; aggregate longs equal aggregate shorts, so the API value is reported as-is rather than summed across both sides. No long/short split is reported because the two sides are equal by construction.',
   },
 }
 

--- a/open-interest/bulk-trade/index.ts
+++ b/open-interest/bulk-trade/index.ts
@@ -26,8 +26,8 @@ async function fetch(options: FetchOptions): Promise<FetchResultVolume> {
     // The API's one-sided figure is the headline: aggregate longs equal aggregate shorts, so
     // reporting their sum would double-count.
     openInterestAtEnd: openInterest,
-    longOpenInterestAtEnd: openInterest,
-    shortOpenInterestAtEnd: openInterest,
+    longOpenInterestAtEnd: openInterest / 2,
+    shortOpenInterestAtEnd: openInterest / 2,
   }
 }
 

--- a/open-interest/dango-oi.ts
+++ b/open-interest/dango-oi.ts
@@ -19,8 +19,9 @@ const query = `{
 }`
 
 async function fetch(options: FetchOptions) {
-    const shortOpenInterestAtEnd = options.createBalances();
-    const longOpenInterestAtEnd = options.createBalances();
+    // The vault takes the other side of every position, so long_oi == short_oi always: one
+    // side is the one-sided total and a long/short split would report it twice.
+    const openInterestAtEnd = options.createBalances();
 
     const response = await httpPost(DANGO_GRAPH_URL, { query });
 
@@ -28,22 +29,10 @@ async function fetch(options: FetchOptions) {
     const pairStates = response.data.queryApp.wasm_smart;
 
     for (const pair of Object.keys(pairStates)) {
-        longOpenInterestAtEnd.addUSDValue(Number(pairStates[pair].long_oi) * Number(pricesMap.get(pair)));
-        shortOpenInterestAtEnd.addUSDValue(Number(pairStates[pair].short_oi) * Number(pricesMap.get(pair)));
+        openInterestAtEnd.addUSDValue(Number(pairStates[pair].long_oi) * Number(pricesMap.get(pair)));
     }
 
-    // The vault takes the other side of every position, so long_oi == short_oi always and
-    // summing them double-counts. (Contrast pool venues like GMX, where L and S are independent.)
-    const openInterestAtEnd = longOpenInterestAtEnd.clone();
-    // halved: each leg's contribution to the one-sided total
-    longOpenInterestAtEnd.resizeBy(0.5);
-    shortOpenInterestAtEnd.resizeBy(0.5);
-
-    return {
-        shortOpenInterestAtEnd,
-        longOpenInterestAtEnd,
-        openInterestAtEnd,
-    }
+    return { openInterestAtEnd }
 }
 
 const adapter: SimpleAdapter = {

--- a/open-interest/dango-oi.ts
+++ b/open-interest/dango-oi.ts
@@ -35,6 +35,9 @@ async function fetch(options: FetchOptions) {
     // The vault takes the other side of every position, so long_oi == short_oi always and
     // summing them double-counts. (Contrast pool venues like GMX, where L and S are independent.)
     const openInterestAtEnd = longOpenInterestAtEnd.clone();
+    // halved: each leg's contribution to the one-sided total
+    longOpenInterestAtEnd.resizeBy(0.5);
+    shortOpenInterestAtEnd.resizeBy(0.5);
 
     return {
         shortOpenInterestAtEnd,

--- a/open-interest/dango-oi.ts
+++ b/open-interest/dango-oi.ts
@@ -32,8 +32,9 @@ async function fetch(options: FetchOptions) {
         shortOpenInterestAtEnd.addUSDValue(Number(pairStates[pair].short_oi) * Number(pricesMap.get(pair)));
     }
 
+    // The vault takes the other side of every position, so long_oi == short_oi always and
+    // summing them double-counts. (Contrast pool venues like GMX, where L and S are independent.)
     const openInterestAtEnd = longOpenInterestAtEnd.clone();
-    openInterestAtEnd.add(shortOpenInterestAtEnd);
 
     return {
         shortOpenInterestAtEnd,

--- a/open-interest/derive-options.ts
+++ b/open-interest/derive-options.ts
@@ -15,7 +15,8 @@ async function fetch() {
 
     statsList.forEach((statsEntry: any) => {
         const currentPrice = currencyList.filter((currencyEntry: any) => statsEntry.currency === currencyEntry.currency).at(0)?.spot_price ?? 0;
-        openInterestAtEnd += (statsEntry.open_interest * currentPrice * 2);
+        // statistics.open_interest is one-sided; get_ticker's open_interest is the 2x version
+        openInterestAtEnd += (statsEntry.open_interest * currentPrice);
     });
 
     return { openInterestAtEnd }

--- a/open-interest/drake-exchange.ts
+++ b/open-interest/drake-exchange.ts
@@ -3,7 +3,7 @@
  *
  * Reads per-instrument long/short open interest directly from the PlatformManager
  * contract at the end of each period and reports:
- *   - openInterestAtEnd      = sum over instruments of (long + short)
+ *   - openInterestAtEnd      = sum over instruments of (long + short) / 2
  *   - longOpenInterestAtEnd  = sum over instruments of long OI
  *   - shortOpenInterestAtEnd = sum over instruments of short OI
  */
@@ -57,6 +57,8 @@ const fetch = async (options: FetchOptions) => {
 
     const openInterestAtEnd = longOpenInterestAtEnd.clone();
     openInterestAtEnd.addBalances(shortOpenInterestAtEnd);
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd.resizeBy(0.5);
 
     return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };
@@ -75,6 +77,6 @@ export default {
     fetch,
     methodology: {
         OpenInterest:
-            "Sum of long and short open interest across all instruments, read from contract state at the end of the period. Values are notional in AUSD (position size x oracle price).",
+            "Average of long and short open interest across all instruments, read from contract state at the end of the period. Values are notional in AUSD (position size x oracle price). Long and short are halved into one figure because there is no single-sided field to read.",
     },
 } as SimpleAdapter;

--- a/open-interest/drake-exchange.ts
+++ b/open-interest/drake-exchange.ts
@@ -59,6 +59,8 @@ const fetch = async (options: FetchOptions) => {
     openInterestAtEnd.addBalances(shortOpenInterestAtEnd);
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd.resizeBy(0.5);
+    longOpenInterestAtEnd.resizeBy(0.5);
+    shortOpenInterestAtEnd.resizeBy(0.5);
 
     return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };

--- a/open-interest/drift-trade.ts
+++ b/open-interest/drift-trade.ts
@@ -18,7 +18,8 @@ async function fetch() {
       const lastPrice = parseFloat(contract.price);
       return acc + (openInterest * lastPrice);
     }, 0);
-  const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
+  // pool venue with no single-sided field: average the two sides instead of summing them
+  const openInterestAtEnd = (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2;
 
   return {
     openInterestAtEnd,

--- a/open-interest/drift-trade.ts
+++ b/open-interest/drift-trade.ts
@@ -23,8 +23,8 @@ async function fetch() {
 
   return {
     openInterestAtEnd,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
+    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
+    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
   };
 }
 

--- a/open-interest/flashtrade-oi.ts
+++ b/open-interest/flashtrade-oi.ts
@@ -36,8 +36,8 @@ const fetch = async (options: FetchOptions) => {
   return {
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd: (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
+    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
+    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
   };
 };
 

--- a/open-interest/flashtrade-oi.ts
+++ b/open-interest/flashtrade-oi.ts
@@ -34,7 +34,8 @@ const fetch = async (options: FetchOptions) => {
   }
 
   return {
-    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd: (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2,
     longOpenInterestAtEnd,
     shortOpenInterestAtEnd,
   };

--- a/open-interest/gains-network.ts
+++ b/open-interest/gains-network.ts
@@ -71,6 +71,9 @@ const fetch = async (options: FetchOptions) => {
     });
   });
 
+  // pool venue with no single-sided field: average the two sides instead of summing them
+  openInterestAtEnd.resizeBy(0.5);
+
   return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };
 

--- a/open-interest/gains-network.ts
+++ b/open-interest/gains-network.ts
@@ -73,6 +73,8 @@ const fetch = async (options: FetchOptions) => {
 
   // pool venue with no single-sided field: average the two sides instead of summing them
   openInterestAtEnd.resizeBy(0.5);
+  longOpenInterestAtEnd.resizeBy(0.5);
+  shortOpenInterestAtEnd.resizeBy(0.5);
 
   return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };

--- a/open-interest/gmtrade-oi.ts
+++ b/open-interest/gmtrade-oi.ts
@@ -19,7 +19,8 @@ const fetch = async (_a: any) => {
   return {
     longOpenInterestAtEnd,
     shortOpenInterestAtEnd,
-    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd: (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2,
   }
 }
 

--- a/open-interest/gmtrade-oi.ts
+++ b/open-interest/gmtrade-oi.ts
@@ -17,8 +17,8 @@ const fetch = async (_a: any) => {
   }
 
   return {
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
+    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
+    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd: (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2,
   }

--- a/open-interest/gmx-v2-gmx-v2-trade.ts
+++ b/open-interest/gmx-v2-gmx-v2-trade.ts
@@ -22,7 +22,10 @@ const fetchOpenInterest = async (options: FetchOptions) => {
   const marketInfos = res.marketInfos || [];
   const longOI = marketInfos.reduce((acc: number, m: any) => acc + Number(m.longOpenInterestUsd), 0);
   const shortOI = marketInfos.reduce((acc: number, m: any) => acc + Number(m.shortOpenInterestUsd), 0);
-  return longOI + shortOI
+  // Pool venue with no single-sided field: long and short face the pool independently
+  // (per-market L/S spans 0.59-2.47), so report the average of the two sides to stay on the
+  // one-sided convention rather than their sum.
+  return (longOI + shortOI) / 2
 }
 
 const fetch = async (options: FetchOptions) => {

--- a/open-interest/gum-oi.ts
+++ b/open-interest/gum-oi.ts
@@ -7,7 +7,8 @@ const GUM_API_URL = "https://gum-api.jup.net/fe/mainnet-beta/perps/markets";
 export async function fetch(_options: FetchOptions) {
     const response = await fetchURL(GUM_API_URL);
 
-    const openInterestAtEnd = response.reduce((acc, curr) => acc + curr.openInterest, 0);
+    // openInterest is USD notional and double-sided (long+short), so halve it
+    const openInterestAtEnd = response.reduce((acc, curr) => acc + curr.openInterest, 0) / 2;
 
     return {
         openInterestAtEnd,

--- a/open-interest/hertzflow.ts
+++ b/open-interest/hertzflow.ts
@@ -68,8 +68,8 @@ const fetch = async (options: FetchOptions) => {
   return {
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd: usd30((longOpenInterest + shortOpenInterest) / 2n),
-    longOpenInterestAtEnd: usd30(longOpenInterest),
-    shortOpenInterestAtEnd: usd30(shortOpenInterest),
+    longOpenInterestAtEnd: usd30(longOpenInterest / 2n),
+    shortOpenInterestAtEnd: usd30(shortOpenInterest / 2n),
   }
 }
 

--- a/open-interest/hertzflow.ts
+++ b/open-interest/hertzflow.ts
@@ -66,7 +66,8 @@ const fetch = async (options: FetchOptions) => {
   })
 
   return {
-    openInterestAtEnd: usd30(longOpenInterest + shortOpenInterest),
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd: usd30((longOpenInterest + shortOpenInterest) / 2n),
     longOpenInterestAtEnd: usd30(longOpenInterest),
     shortOpenInterestAtEnd: usd30(shortOpenInterest),
   }

--- a/open-interest/hotstuff-oi.ts
+++ b/open-interest/hotstuff-oi.ts
@@ -15,7 +15,9 @@ async function fetch(options: FetchOptions) {
     })
 
     for (const market of marketsInfo) {
-        openInterestAtEnd.addUSDValue(Number(market.open_interest) * Number(market.mark_price) * 2);
+        // no * 2: open_interest is the per-market one-sided field, same shape as every other
+        // orderbook venue we measured (lighter, dydx, hibachi all read one-sided here)
+        openInterestAtEnd.addUSDValue(Number(market.open_interest) * Number(market.mark_price));
     }
 
     return {

--- a/open-interest/hyperliquid-perp-oi.ts
+++ b/open-interest/hyperliquid-perp-oi.ts
@@ -17,7 +17,8 @@ const fetch = async (options: FetchOptions) => {
 
     for (const item of oi_data.chart_data) {
       if (item.time === full_date_string) {
-        openInterestAtEnd += item.open_interest;
+        // same double-sided convention as the API, halved to stay continuous with the indexer branch
+        openInterestAtEnd += item.open_interest / 2;
       }
     }
 

--- a/open-interest/jupiter-perpetual-oi.ts
+++ b/open-interest/jupiter-perpetual-oi.ts
@@ -48,6 +48,8 @@ const fetch = async (options: FetchOptions) => {
   openInterestAtEnd.add(shortOpenInterestAtEnd);
   // pool venue with no single-sided field: average the two sides instead of summing them
   openInterestAtEnd.resizeBy(0.5);
+  longOpenInterestAtEnd.resizeBy(0.5);
+  shortOpenInterestAtEnd.resizeBy(0.5);
 
   return {
     longOpenInterestAtEnd,

--- a/open-interest/jupiter-perpetual-oi.ts
+++ b/open-interest/jupiter-perpetual-oi.ts
@@ -46,6 +46,8 @@ const fetch = async (options: FetchOptions) => {
 
   const openInterestAtEnd = longOpenInterestAtEnd.clone();
   openInterestAtEnd.add(shortOpenInterestAtEnd);
+  // pool venue with no single-sided field: average the two sides instead of summing them
+  openInterestAtEnd.resizeBy(0.5);
 
   return {
     longOpenInterestAtEnd,

--- a/open-interest/kiloex.ts
+++ b/open-interest/kiloex.ts
@@ -64,7 +64,8 @@ const fetch = async (options: FetchOptions) => {
   const shortOpenInterestSum = shortOis.reduce((sum: bigint, oi: bigint) => sum + BigInt(oi), 0n);
 
   return {
-    openInterestAtEnd: formatOI(longOpenInterestSum + shortOpenInterestSum),
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd: formatOI((longOpenInterestSum + shortOpenInterestSum) / 2n),
     longOpenInterestAtEnd: formatOI(longOpenInterestSum),
     shortOpenInterestAtEnd: formatOI(shortOpenInterestSum),
   };

--- a/open-interest/kiloex.ts
+++ b/open-interest/kiloex.ts
@@ -66,8 +66,8 @@ const fetch = async (options: FetchOptions) => {
   return {
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd: formatOI((longOpenInterestSum + shortOpenInterestSum) / 2n),
-    longOpenInterestAtEnd: formatOI(longOpenInterestSum),
-    shortOpenInterestAtEnd: formatOI(shortOpenInterestSum),
+    longOpenInterestAtEnd: formatOI(longOpenInterestSum / 2n),
+    shortOpenInterestAtEnd: formatOI(shortOpenInterestSum / 2n),
   };
 };
 

--- a/open-interest/leverup-oi.ts
+++ b/open-interest/leverup-oi.ts
@@ -56,7 +56,8 @@ async function fetch(options: FetchOptions) {
   });
 
   return {
-    openInterestAtEnd: longOpenInterest + shortOpenInterest,
+    // long == short exactly (LP is the counterparty on both legs), so the sum double-counts
+    openInterestAtEnd: longOpenInterest,
     longOpenInterestAtEnd: longOpenInterest,
     shortOpenInterestAtEnd: shortOpenInterest,
   };

--- a/open-interest/leverup-oi.ts
+++ b/open-interest/leverup-oi.ts
@@ -22,9 +22,10 @@ async function fetch(options: FetchOptions) {
       abi: oiAbi,
     });
     return {
-      openInterestAtEnd: Number(oi.totalUsd) / 1e18,
-      longOpenInterestAtEnd: Number(oi.longUsd) / 1e18,
-      shortOpenInterestAtEnd: Number(oi.shortUsd) / 1e18,
+      // totalUsd is longUsd + shortUsd; average the sides so the breakdown sums to the total
+      openInterestAtEnd: Number(oi.totalUsd) / 1e18 / 2,
+      longOpenInterestAtEnd: Number(oi.longUsd) / 1e18 / 2,
+      shortOpenInterestAtEnd: Number(oi.shortUsd) / 1e18 / 2,
     };
   }
 

--- a/open-interest/leverup-oi.ts
+++ b/open-interest/leverup-oi.ts
@@ -21,12 +21,9 @@ async function fetch(options: FetchOptions) {
       target: LEVERUP_DIAMOND,
       abi: oiAbi,
     });
-    return {
-      // totalUsd is longUsd + shortUsd; average the sides so the breakdown sums to the total
-      openInterestAtEnd: Number(oi.totalUsd) / 1e18 / 2,
-      longOpenInterestAtEnd: Number(oi.longUsd) / 1e18 / 2,
-      shortOpenInterestAtEnd: Number(oi.shortUsd) / 1e18 / 2,
-    };
+    // longUsd == shortUsd (the LP is the counterparty on both legs), so totalUsd double-counts
+    // and a long/short split would report the same number twice.
+    return { openInterestAtEnd: Number(oi.totalUsd) / 1e18 / 2 };
   }
 
   // Pre-V2 days: original method, so existing history is reproduced unchanged.
@@ -44,24 +41,16 @@ async function fetch(options: FetchOptions) {
   });
 
   let longOpenInterest = 0;
-  let shortOpenInterest = 0;
 
   marketInfos.forEach((info: any) => {
     const lQty = parseFloat(info.longQty);
-    const sQty = parseFloat(info.shortQty);
     const lPrice = parseFloat(info.lpLongAvgPrice);
-    const sPrice = parseFloat(info.lpShortAvgPrice);
 
     longOpenInterest += (lQty * lPrice) / 1e28;
-    shortOpenInterest += (sQty * sPrice) / 1e28;
   });
 
-  return {
-    // long == short exactly (LP is the counterparty on both legs), so the sum double-counts
-    openInterestAtEnd: longOpenInterest,
-    longOpenInterestAtEnd: longOpenInterest,
-    shortOpenInterestAtEnd: shortOpenInterest,
-  };
+  // long == short exactly (LP is the counterparty on both legs), so the sum double-counts
+  return { openInterestAtEnd: longOpenInterest };
 }
 
 const adapter: SimpleAdapter = {

--- a/open-interest/lighter-rh-oi.ts
+++ b/open-interest/lighter-rh-oi.ts
@@ -16,7 +16,8 @@ const fetch = async (options: FetchOptions) => {
   const data = await fetchURL(`${api}/orderBookDetails`);
   const markets = data.order_book_details;
   markets.forEach((market: any) => {
-    openInterestAtEnd += (Number(market.open_interest || 0) * Number(market.last_trade_price || 0) * 2); // * 2 because of double sided OI
+    // Lighter's open_interest is already one-sided (verified against trade deltas: moves 1:1 with fill size)
+    openInterestAtEnd += (Number(market.open_interest || 0) * Number(market.last_trade_price || 0));
   });
 
   return { openInterestAtEnd };

--- a/open-interest/lighter-v2.ts
+++ b/open-interest/lighter-v2.ts
@@ -16,7 +16,8 @@ const fetch = async (options: FetchOptions) => {
   const data = await fetchURL(`${api}/orderBookDetails`);
   const markets = data.order_book_details;
   markets.forEach((market: any) => {
-    openInterestAtEnd += (Number(market.open_interest || 0) * Number(market.last_trade_price || 0) * 2); // * 2 because of double sided OI
+    // Lighter's open_interest is already one-sided (verified against trade deltas: moves 1:1 with fill size)
+    openInterestAtEnd += (Number(market.open_interest || 0) * Number(market.last_trade_price || 0));
   });
 
   return { openInterestAtEnd };

--- a/open-interest/lyra-v2.ts
+++ b/open-interest/lyra-v2.ts
@@ -15,7 +15,8 @@ async function fetch() {
 
     statsList.forEach((statsEntry: any) => {
         const currentPrice = currencyList.filter((currencyEntry: any) => statsEntry.currency === currencyEntry.currency).at(0)?.spot_price ?? 0;
-        openInterestAtEnd += (statsEntry.open_interest * currentPrice * 2);
+        // statistics.open_interest is one-sided; get_ticker's open_interest is the 2x version
+        openInterestAtEnd += (statsEntry.open_interest * currentPrice);
     });
 
     return { openInterestAtEnd }

--- a/open-interest/mux-protocol-oi.ts
+++ b/open-interest/mux-protocol-oi.ts
@@ -155,6 +155,9 @@ const fetch = async (options: FetchOptions) => {
     }
   }
 
+  // pool venue with no single-sided field: average the two sides instead of summing them
+  openInterestAtEnd.resizeBy(0.5);
+
   return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };
 

--- a/open-interest/mux-protocol-oi.ts
+++ b/open-interest/mux-protocol-oi.ts
@@ -157,6 +157,8 @@ const fetch = async (options: FetchOptions) => {
 
   // pool venue with no single-sided field: average the two sides instead of summing them
   openInterestAtEnd.resizeBy(0.5);
+  longOpenInterestAtEnd.resizeBy(0.5);
+  shortOpenInterestAtEnd.resizeBy(0.5);
 
   return { openInterestAtEnd, longOpenInterestAtEnd, shortOpenInterestAtEnd };
 };

--- a/open-interest/nado.ts
+++ b/open-interest/nado.ts
@@ -49,7 +49,8 @@ const sumAllProductOpenInterests = (open_interests: IData): number => {
   for (const v of Object.values(open_interests)) {
     sum += parseInt(v);
   }
-  return sum / 1e18;
+  // Nado reports long+short summed OI, halve it for the one-sided convention
+  return sum / 1e18 / 2;
 };
 
 const fetch = async (options: FetchOptions) => {

--- a/open-interest/ondo-perps.ts
+++ b/open-interest/ondo-perps.ts
@@ -13,13 +13,14 @@ type OpenInterestItem = {
 
 const fetch = async (_options: FetchOptions) => {
   const response = await fetchURL(API);
-  const openInterestAtEnd = response.result.reduce((acc: number, market: OpenInterestItem) => acc + Number(market.notionalValue), 0)
+  // notionalValue is long+short summed, halve it for the one-sided convention
+  const openInterestAtEnd = response.result.reduce((acc: number, market: OpenInterestItem) => acc + Number(market.notionalValue), 0) / 2
   return { openInterestAtEnd }
 }
 
 const methodology = {
   OpenInterest:
-    "Open interest is the sum of notionalValue from Ondo Perps's open interest API.",
+    "Open interest is the sum of notionalValue from Ondo Perps's open interest API, halved because that field sums long and short.",
 };
 
 const adapter: SimpleAdapter = {

--- a/open-interest/pacifica-oi.ts
+++ b/open-interest/pacifica-oi.ts
@@ -4,7 +4,8 @@ import fetchURL from "../utils/fetchURL";
 const fetch = async (_a: any) => {
   const { data } = await fetchURL('https://api.pacifica.fi/api/v1/info/prices')
 
-  const oi = data.reduce((a: number, b: { open_interest: string, mark: string }) => a + (Number(b.open_interest) * Number(b.mark)), 0)
+  // open_interest is double-sided (long+short), same engine convention as the doubled klines
+  const oi = data.reduce((a: number, b: { open_interest: string, mark: string }) => a + (Number(b.open_interest) * Number(b.mark)), 0) / 2
 
   return {
     openInterestAtEnd: oi,

--- a/open-interest/perpl.ts
+++ b/open-interest/perpl.ts
@@ -19,8 +19,9 @@ const fetch = async (options: FetchOptions) => {
     permitFailure: true,
   });
 
-  let longOpenInterestAtEnd = 0;
-  let shortOpenInterestAtEnd = 0;
+  // Matched book: longOpenInterestLNS == shortOpenInterestLNS exactly, so one side is the
+  // one-sided total and a long/short split would report it twice.
+  let openInterestAtEnd = 0;
 
   for (const info of results) {
     if (!info) continue;
@@ -28,19 +29,10 @@ const fetch = async (options: FetchOptions) => {
     const lotDecimals = Number(info.lotDecimals);
     const markPrice = Number(info.markPNS) / 10 ** priceDecimals;
     const longOI = Number(info.longOpenInterestLNS) / 10 ** lotDecimals;
-    const shortOI = Number(info.shortOpenInterestLNS) / 10 ** lotDecimals;
-    longOpenInterestAtEnd += longOI * markPrice;
-    shortOpenInterestAtEnd += shortOI * markPrice;
+    openInterestAtEnd += longOI * markPrice;
   }
-  // Matched book: longOpenInterestLNS == shortOpenInterestLNS exactly, so their sum double-counts.
-  // The halved sides are each leg's contribution to that one-sided total.
-  const openInterestAtEnd = longOpenInterestAtEnd;
 
-  return {
-    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
-    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
-    openInterestAtEnd,
-  };
+  return { openInterestAtEnd };
 };
 
 const adapter: SimpleAdapter = {

--- a/open-interest/perpl.ts
+++ b/open-interest/perpl.ts
@@ -32,7 +32,8 @@ const fetch = async (options: FetchOptions) => {
     longOpenInterestAtEnd += longOI * markPrice;
     shortOpenInterestAtEnd += shortOI * markPrice;
   }
-  const openInterestAtEnd = longOpenInterestAtEnd + shortOpenInterestAtEnd;
+  // Matched book: longOpenInterestLNS == shortOpenInterestLNS exactly, so their sum double-counts.
+  const openInterestAtEnd = longOpenInterestAtEnd;
 
   return { longOpenInterestAtEnd, shortOpenInterestAtEnd, openInterestAtEnd };
 };

--- a/open-interest/perpl.ts
+++ b/open-interest/perpl.ts
@@ -33,9 +33,14 @@ const fetch = async (options: FetchOptions) => {
     shortOpenInterestAtEnd += shortOI * markPrice;
   }
   // Matched book: longOpenInterestLNS == shortOpenInterestLNS exactly, so their sum double-counts.
+  // The halved sides are each leg's contribution to that one-sided total.
   const openInterestAtEnd = longOpenInterestAtEnd;
 
-  return { longOpenInterestAtEnd, shortOpenInterestAtEnd, openInterestAtEnd };
+  return {
+    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
+    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
+    openInterestAtEnd,
+  };
 };
 
 const adapter: SimpleAdapter = {

--- a/open-interest/phoenix-trade-oi.ts
+++ b/open-interest/phoenix-trade-oi.ts
@@ -15,7 +15,8 @@ async function fetch(options: FetchOptions) {
         .for(markets)
         .process(async (market) => {
             const marketData = await fetchURLAutoHandleRateLimit(`${PHOENIX_TRADE_API_URL}/market/${market}`);
-            openInterestAtEnd.addUSDValue(Number(marketData.market.openInterest.ui) * Number(marketData.market.markPrice.price));
+            // Phoenix docs: "Each contract consists of one long and one short position", so openInterest is long+short
+            openInterestAtEnd.addUSDValue(Number(marketData.market.openInterest.ui) * Number(marketData.market.markPrice.price) / 2);
             await sleep(1000);
         });
 

--- a/open-interest/reya-dex-oi.ts
+++ b/open-interest/reya-dex-oi.ts
@@ -48,7 +48,8 @@ const fetch = async (options: FetchOptions) => {
   const shortOpenInterestAtEnd = oneSidedOpenInterest;
 
   return {
-    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    // one-sided convention: don't sum long + short into the headline number
+    openInterestAtEnd: oneSidedOpenInterest,
     longOpenInterestAtEnd,
     shortOpenInterestAtEnd,
   };

--- a/open-interest/reya-dex-oi.ts
+++ b/open-interest/reya-dex-oi.ts
@@ -44,16 +44,8 @@ const fetch = async (options: FetchOptions) => {
     return sum + oi * price;
   }, 0);
 
-  // each contract contributes one long leg and one short leg to the one-sided total
-  const longOpenInterestAtEnd = oneSidedOpenInterest / 2;
-  const shortOpenInterestAtEnd = oneSidedOpenInterest / 2;
-
-  return {
-    // one-sided convention: don't sum long + short into the headline number
-    openInterestAtEnd: oneSidedOpenInterest,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
-  };
+  // Matched book, so no long/short split is reported: it would be this number twice.
+  return { openInterestAtEnd: oneSidedOpenInterest };
 };
 
 const adapter: SimpleAdapter = {

--- a/open-interest/reya-dex-oi.ts
+++ b/open-interest/reya-dex-oi.ts
@@ -44,8 +44,9 @@ const fetch = async (options: FetchOptions) => {
     return sum + oi * price;
   }, 0);
 
-  const longOpenInterestAtEnd = oneSidedOpenInterest;
-  const shortOpenInterestAtEnd = oneSidedOpenInterest;
+  // each contract contributes one long leg and one short leg to the one-sided total
+  const longOpenInterestAtEnd = oneSidedOpenInterest / 2;
+  const shortOpenInterestAtEnd = oneSidedOpenInterest / 2;
 
   return {
     // one-sided convention: don't sum long + short into the headline number

--- a/open-interest/risex-perps-oi.ts
+++ b/open-interest/risex-perps-oi.ts
@@ -28,10 +28,11 @@ const fetch = async (options: FetchOptions) => {
     }),
   ]);
 
+  // getOpenInterest returns long+short summed, halve it for the one-sided convention
   const openInterestAtEnd = openInterests.reduce((total: number, openInterest: any, i: number) => {
     const baseOpenInterest = Number(openInterest) / WAD;
     const markPrice = Number(markPrices[i]) / WAD;
-    return total + baseOpenInterest * markPrice;
+    return total + (baseOpenInterest * markPrice) / 2;
   }, 0);
 
   return { openInterestAtEnd };

--- a/open-interest/sparkdex-perps-oi.ts
+++ b/open-interest/sparkdex-perps-oi.ts
@@ -14,7 +14,8 @@ const fetch = async (options: FetchOptions) => {
   if (!item) throw new Error(`No SparkDEX OI data for ${options.endTimestamp}`);
 
   return {
-    openInterestAtEnd: item.openInterest,
+    // openInterest is long + short; pool venue with no single-sided field, so average them
+    openInterestAtEnd: item.openInterest / 2,
     longOpenInterestAtEnd: item.longOpenInterest,
     shortOpenInterestAtEnd: item.shortOpenInterest,
   };

--- a/open-interest/sparkdex-perps-oi.ts
+++ b/open-interest/sparkdex-perps-oi.ts
@@ -16,8 +16,8 @@ const fetch = async (options: FetchOptions) => {
   return {
     // openInterest is long + short; pool venue with no single-sided field, so average them
     openInterestAtEnd: item.openInterest / 2,
-    longOpenInterestAtEnd: item.longOpenInterest,
-    shortOpenInterestAtEnd: item.shortOpenInterest,
+    longOpenInterestAtEnd: item.longOpenInterest / 2,
+    shortOpenInterestAtEnd: item.shortOpenInterest / 2,
   };
 };
 

--- a/open-interest/standx.ts
+++ b/open-interest/standx.ts
@@ -34,7 +34,9 @@ const fetch = async (_options: FetchOptions) => {
     }, { openInterestAtEnd: 0 });
 
     return {
-        openInterestAtEnd,
+        // open_interest_notional is double-sided (measured: 43 windows at exactly 2x fill size,
+        // 12/12 lags, on BNB-USD), so halve it for the one-sided convention
+        openInterestAtEnd: openInterestAtEnd / 2,
     };
 };
 

--- a/open-interest/stormtrade-oi.ts
+++ b/open-interest/stormtrade-oi.ts
@@ -17,7 +17,8 @@ const fetch = async (_options: FetchOptions) => {
   }
 
   return {
-    openInterestAtEnd: longOpenInterestAtEnd + shortOpenInterestAtEnd,
+    // pool venue with no single-sided field: average the two sides instead of summing them
+    openInterestAtEnd: (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2,
     longOpenInterestAtEnd,
     shortOpenInterestAtEnd,
   };

--- a/open-interest/stormtrade-oi.ts
+++ b/open-interest/stormtrade-oi.ts
@@ -19,8 +19,8 @@ const fetch = async (_options: FetchOptions) => {
   return {
     // pool venue with no single-sided field: average the two sides instead of summing them
     openInterestAtEnd: (longOpenInterestAtEnd + shortOpenInterestAtEnd) / 2,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
+    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
+    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
   };
 };
 

--- a/open-interest/synthetix-v4.ts
+++ b/open-interest/synthetix-v4.ts
@@ -23,7 +23,8 @@ const fetch = async (options: any) => {
     if (!price || !price.markPrice || !longOpenInterest || !shortOpenInterest) {
       throw new Error(`Missing Synthetix mark price or open interest for ${symbol}`);
     }
-    openInterestAtEnd.addUSDValue(Number(price.markPrice) * (Number(longOpenInterest) + Number(shortOpenInterest)));
+    // long == short exactly on every market, so summing the two sides double-counts
+    openInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest));
     longOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest));
     shortOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(shortOpenInterest));
   });

--- a/open-interest/synthetix-v4.ts
+++ b/open-interest/synthetix-v4.ts
@@ -12,9 +12,9 @@ const post = async (params: any) => {
 };
 
 const fetch = async (options: any) => {
+  // long == short exactly on every market, so one side is the one-sided total and a
+  // long/short split would report it twice.
   const openInterestAtEnd = options.createBalances();
-  const longOpenInterestAtEnd = options.createBalances();
-  const shortOpenInterestAtEnd = options.createBalances();
   const marketPrices = await post({ action: "getMarketPrices" });
   const openInterest = await post({ action: "getOpenInterest" });
 
@@ -23,18 +23,10 @@ const fetch = async (options: any) => {
     if (!price || !price.markPrice || !longOpenInterest || !shortOpenInterest) {
       throw new Error(`Missing Synthetix mark price or open interest for ${symbol}`);
     }
-    // long == short exactly on every market, so summing the two sides double-counts
     openInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest));
-    // halved: each leg's contribution to the one-sided total above
-    longOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest) / 2);
-    shortOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(shortOpenInterest) / 2);
   });
 
-  return {
-    openInterestAtEnd,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
-  };
+  return { openInterestAtEnd };
 };
 
 const adapter = {

--- a/open-interest/synthetix-v4.ts
+++ b/open-interest/synthetix-v4.ts
@@ -25,8 +25,9 @@ const fetch = async (options: any) => {
     }
     // long == short exactly on every market, so summing the two sides double-counts
     openInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest));
-    longOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest));
-    shortOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(shortOpenInterest));
+    // halved: each leg's contribution to the one-sided total above
+    longOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(longOpenInterest) / 2);
+    shortOpenInterestAtEnd.addUSDValue(Number(price.markPrice) * Number(shortOpenInterest) / 2);
   });
 
   return {

--- a/open-interest/zo-perps-oi.ts
+++ b/open-interest/zo-perps-oi.ts
@@ -22,7 +22,8 @@ const fetch = async (options: FetchOptions) => {
   }
 
   return {
-    openInterestAtEnd,
+    // totalOpenInterest is long + short; pool venue with no single-sided field, so average them
+    openInterestAtEnd: openInterestAtEnd / 2,
     longOpenInterestAtEnd,
     shortOpenInterestAtEnd,
   };

--- a/open-interest/zo-perps-oi.ts
+++ b/open-interest/zo-perps-oi.ts
@@ -24,8 +24,8 @@ const fetch = async (options: FetchOptions) => {
   return {
     // totalOpenInterest is long + short; pool venue with no single-sided field, so average them
     openInterestAtEnd: openInterestAtEnd / 2,
-    longOpenInterestAtEnd,
-    shortOpenInterestAtEnd,
+    longOpenInterestAtEnd: longOpenInterestAtEnd / 2,
+    shortOpenInterestAtEnd: shortOpenInterestAtEnd / 2,
   };
 };
 


### PR DESCRIPTION
DO NOT MERGE YET. Needs a call on the pool-venue convention first, and the history migration in DefiLlama/defillama-server#12712 has to run immediately before this merges.

Checking that migration's plans against the stored data turned up three bugs in this PR, now fixed: `fulcrom` was quartering rather than halving, because its headline is derived from the side variables and the division landed twice; and `leverup` and `synthetix-v4` were reporting one side on the assumption that long equals short, which stored history disproves (the two legs run 37% and 3.6% apart at the median), so both now report the average like the other pool venues. `perpl` and `dango` were checked the same way and their sides are identical on every stored row, so they stay as they are.

Open interest is inconsistent across perp adapters: some read a venue field that already counts both legs of a contract, some sum long and short themselves, and four multiply an already one-sided field by 2. Roughly half the perp coverage sits at 2x the rest. Conventions come from `orderbook-watch/exchanges/unit-specs.ts`, which records a per-venue `oi_multiplier` with the measurement behind it.

**Dropped a bogus `* 2`** (field was already one-sided): `lighter-v2`, `lighter-rh-oi` (28 windows at exactly 1x fill size), `derive-options`, `lyra-v2` (`statistics.open_interest` is one-sided, `get_ticker` is the 2x map), `hotstuff-oi`, `bulk-trade`.

**Halved a double-sided venue field:** `hyperliquid` (2.00x CMC, 16 windows at 2x), `apollox` = Aster (docs: "calculated both ways"), `extended`, `nado`, `ondo`, `risex`, `phoenix`, `standx` (43 windows at 2x), `arcus` (CoinGecko carries 2.013x), `pacifica`, `gum`, `variational` (headline is gross both-legs, exactly 2.00000x the summed per-listing sides).

**Stopped reporting long plus short:** `reya`, `perpl`, `leverup`, `synthetix-v4`, `dango` where long equals short exactly. The pool venues where it does not (`gmx`, `avantis`, `ostium`, `gains`, `jupiter-perpetual`, `drift`, `flashtrade`, `drake`, `zo`, `sparkdex`, `bounce-tech`, `stormtrade`, `gmtrade`, `hertzflow`, `kiloex`, `mux`, `fulcrom`, `moonlander`, `wavex`) now report the average of the two sides, since none has a single-sided field to read.

**Long/short breakdown:** only reported where the two sides are independent trader exposure, which is the pool venues. On a matched book, or where an LP or vault takes the other side of every position, long equals short by construction, so the split is this number twice and invites being summed back into a doubled total. Dropped from `bulk-trade`, `reya-dex-oi`, `perpl`, `synthetix-v4`, `dango-oi` and `leverup-oi`, with headline open interest unchanged on all six. Where the split is kept, it is on the same scale as the total: `longOpenInterestAtEnd` and `shortOpenInterestAtEnd` are each leg's contribution to the one-sided figure, so long plus short equals `openInterestAtEnd` on every adapter that reports them. Leaving them on the old scale would have made the breakdown sum to 2x the total it belongs to. This also caught `leverup-oi`, where only the pre-V2 path had been corrected and the V2 branch that runs today still returned the contract's `totalUsd`.

Sample of the before and after against the one-sided figures tracked in orderbook-watch:

| venue | was | now | reference |
| --- | --- | --- | --- |
| hyperliquid | $14.67B | $7.33B | $7.61B |
| aster | $2.54B | $1.27B | $1.27B |
| lighter | $1.15B | $579M | $576M |
| variational | $1.76B | $839M | see note |
| extended | $181M | $93.5M | $92.6M |
| pacifica | $97.5M | $48.9M | $48.7M |
| ondo | $84.8M | $43.1M | $42.4M |
| nado | $79.7M | $39.8M | $41.6M |
| standx | $61.5M | $30.8M | $30.8M |
| gmx | $59.2M | $29.2M | n/a |
| risex | $59.1M | $29.6M | $30.7M |
| phoenix | $23.1M | $11.7M | $11.6M |
| arcus | $17.2M | $8.57M | $8.6M |
| avantis | $14.2M | $7.10M | n/a |

Unchanged because they measured one-sided already: grvt, vest, katana, dydx, hibachi, edgex, sunperp. Left alone: `paradex`, whose 0.5 in the spec was never measured (the run was skipped on stale markets), and `01`, whose feed lags rather than doubles.

On `variational` this PR disagrees with `unit-specs.ts`, which files it with the pool venues at `oi_multiplier: 0.5` and would publish half again ($420M). Variational is RFQ: the dealer is the counterparty, so per-listing long and short are both user exposure facing that dealer, not the two legs of one contract. 51 of its 550 markets carry longs against a short of exactly 0, which a two-leg field pair cannot do, so their sum already counts each position once. The spec row wants updating to match, or this one changed back.

Two things to settle before this ships:


1. The pool-venue rule (average the sides) is a convention choice, not a measurement. `ostium` is the sharpest case: it had a deliberate `max(long, short) * 2` with its own rationale about off-chain vault hedging, and this replaces it.
2. Every changed adapter needs a refill from its start date. Without one the charts show a step, not a correction.

Not in this PR: the matching volume fix for `dexs/sunperp` (SunX klines are buy plus sell doubled, roughly $229M/day against a one-sided $114M).




