### PR TITLE
reservoir: add pharos

### DIFF
--- a/fees/reservoir-protocol.ts
+++ b/fees/reservoir-protocol.ts
@@ -100,6 +100,7 @@ const adapter: SimpleAdapter = {
     [CHAIN.ARBITRUM]: { start: '2025-05-12' },
     [CHAIN.SEI]: { start: '2025-06-13' },
     [CHAIN.MONAD]: { start: '2026-01-01' },
+    [CHAIN.PHAROS]: { start: '2026-08-06' },
   },
   allowNegativeValue: true,
   doublecounted: true,


### PR DESCRIPTION
Fixes #9367

adds `[CHAIN.PHAROS]: { start: '2026-08-06' }` to `fees/reservoir-protocol`. the chain needs no new code; the existing non-ethereum branch reads the wsrUSD OFT's `totalSupply()` on whatever chain it runs, and that contract holds 6,330,316 wsrUSD on pharos, more than every covered chain except monad.

start is 2026-08-06, the first day the tvl adapter has pharos.

harness:

```
2026-09-05   supply side revenue $1,086
2026-09-06   supply side revenue $1,084
```

plasma is deliberately not added: it holds 3 wsrUSD.
