### PR TITLE
fluid: skip the solana leg when the juplend view has no rows, instead of booking zero

### DIFF
--- a/fees/fluid/index.ts
+++ b/fees/fluid/index.ts
@@ -27,6 +27,16 @@ const fetch: FetchV2 = async (options: FetchOptions) => {
   }
 }
 
+const DUNE_SOLANA_INDEXING_DELAY_MS = 10 * 60 * 60 * 1000;
+
+const SKIP_SOLANA_LEG = {
+  dailyFees: undefined,
+  dailyRevenue: undefined,
+  dailyProtocolRevenue: undefined,
+  dailyHoldersRevenue: undefined,
+  dailySupplySideRevenue: undefined,
+};
+
 // Revenu share from Jupiter Lend
 const fetchSolana: FetchV2 = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -49,7 +59,15 @@ const fetchSolana: FetchV2 = async (options: FetchOptions) => {
     group by 1
     order by day desc
   `
+  if (options.toTimestamp * 1000 > Date.now() - DUNE_SOLANA_INDEXING_DELAY_MS) {
+    return SKIP_SOLANA_LEG;
+  }
+
   const data: any[] = await queryDuneSql(options, sql);
+  if (!data || data.length === 0) {
+    return SKIP_SOLANA_LEG;
+  }
+
   const jupiterRevenue = data.reduce((sum, row) => sum + (row.daily_revenue_usd || 0), 0);
   dailyFees.addUSDValue(jupiterRevenue * 0.5, FLUID_METRICS.RevenueShareFromJupLend);
   


### PR DESCRIPTION
Fixes #9370. Sibling of #9347 / #9348, same Dune view, the other adapter that reads it.

`fetchSolana` had no empty-rows check, so when the JupLend materialized view returns nothing for the window, `[].reduce(..., 0)` books **$0** as the day's revenue share. 09-07 and 09-08 both published zero while Fluid's five EVM chains published full days.

`assertDuneSolanaIndexed` is not usable here; it throws, and its docstring says why that matters:

> Only safe on single-chain adapters: `runAdapter` drops every chain's record when one chain throws.

Fluid has six chains, so a throw would blank $108k/day of healthy legs to fix a $1.3k/day one. This returns the metrics as `undefined` instead; `runAdapter` deletes undefined values before aggregating, so the leg contributes nothing and the day stays refillable rather than being stored as a zero. The same guard covers the mid-refresh case that produced the partial in #9347.

## verification

With the wait constant temporarily widened so the guard fires on a settled day:

```
chain     | Daily fees | Daily revenue | Daily supply side revenue
ethereum  | 71.20 k    | 7.50 k        | 63.69 k
arbitrum  | 20.26 k    | 2.16 k        | 18.10 k
base      | 2.12 k     | 212.00        | 1.91 k
polygon   | 152.00     | 15.00         | 136.00
plasma    | 15.18 k    | 1.46 k        | 13.72 k
solana    |            |               |
Aggregate | 108.91 k   | 11.34 k       | 97.56 k
```

Solana is blank rather than zero, the other five chains are unaffected, and the aggregate matches what production published for 2026-09-08 ($108,906) to the dollar.

With the real 10-hour constant restored, a settled day goes on to the Dune call exactly as before:

```
$ npx ts-node cli/testAdapter.ts fees fluid 2026-09-09
Error: DUNE_API_KEYS environment variable is not set
```

`npx tsc --noEmit` is clean.

What I could not check: I have no Dune key, so the empty-rows branch is verified by reading rather than by executing the query. The 10-hour threshold is inherited from `helpers/duneSolanaDex.ts` rather than measured against this view, same caveat as #9348.
