### PR TITLE
[fix] accountable - read fee crystallization from FeeSharesMinted for v2+ credit strategies

### DIFF
--- a/fees/accountable.ts
+++ b/fees/accountable.ts
@@ -63,10 +63,12 @@ const config: Record<string, { factories: string[], start: string }> = {
 
 // aHYPER Looping Vault (vault 0x23b148d8f389C5821739381f1FF87bB7e1162566) is
 // EOA-deployed rather than created by a registered factory, so enumeration
-// cannot reach it. The TVL adapter carries the same exception.
-const EXTRA_STRATEGIES: Record<string, { address: string, deployedOn: string }[]> = {
-  [CHAIN.MONAD]: [{ address: "0xE19b272b2fe4a54103A41F9B1c65dB3D2F6d886D", deployedOn: "2026-04-28" }],
-};
+// cannot reach it. Excluded from fee tracking: it's a hidden, still-in-testing
+// vault whose configured 10% performanceFee/50% managerSplit is not actually
+// being charged, so booking fees off its share-price growth would overstate
+// protocol revenue. Re-add once fee collection is live for it. The TVL
+// adapter carries the EOA-deployed exception separately and is unaffected.
+const EXTRA_STRATEGIES: Record<string, { address: string, deployedOn: string }[]> = {};
 
 const abis = {
   getStrategiesCount: "function getStrategiesCount() view returns (uint256)",

--- a/fees/accountable.ts
+++ b/fees/accountable.ts
@@ -82,15 +82,19 @@ const abis = {
   totalSupply: "function totalSupply() view returns (uint256)",
   convertToAssets: "function convertToAssets(uint256) view returns (uint256)",
   performanceFee: "function performanceFee(address) view returns (uint256)",
-  managementFee: "function managementFee(address) view returns (uint256)",
   managerSplit: "function managerSplit(address,bool) view returns (uint256)",
   managerSplitLegacy: "function managerSplit(address) view returns (uint256)",
+  // Absent on v1.0 strategies (no version() at all) — a failed read is treated
+  // as "legacy", same convention as managementFee/managerSplit below.
+  version: "function version() view returns (uint256)",
+  treasury: "function treasury() view returns (address)",
   delinquencyStartTime:
     "function delinquencyStartTime() view returns (uint256)",
   penaltiesEnabled: "function penaltiesEnabled() view returns (bool)",
   loan: "function loan() view returns ((uint256 minDeposit,uint256 minRedeem,uint256 maxCapacity,uint256 minCapacity,uint256 reserveThreshold,uint256 outstandingPrincipal,uint256 outstandingInterest,uint256 drawableFunds,uint256 interestRate,uint256 lateInterestPenalty,uint256 claimableInterest,uint256 interestInterval,uint256 startTime,uint256 termsSetTime,uint256 termsUpdateTime,uint256 duration,uint256 depositPeriod,uint256 acceptGracePeriod,uint256 withdrawalPeriod,uint256 lateInterestGracePeriod))",
   feeSharesMinted:
     "event FeeSharesMinted(address indexed recipient, uint256 shares)",
+  upgraded: "event Upgraded(address indexed implementation)",
 };
 
 // `scaleFactor()` on the credit strategies is an accrual index scaled by 1e36,
@@ -350,10 +354,100 @@ const fetch = async (options: FetchOptions) => {
       permitFailure: true,
     });
     const perfFees = await fmCall(abis.performanceFee);
-    const mgmtFees = await fmCall(abis.managementFee);
     const perfSplits = await fmCall(abis.managerSplit, true);
-    const mgmtSplits = await fmCall(abis.managerSplit, false);
     const legacySplits = await fmCall(abis.managerSplitLegacy);
+    const treasuries = await toApi.multiCall({
+      abi: abis.treasury,
+      calls: active.map((a) => feeManagers[a.i]),
+      permitFailure: true,
+    });
+
+    // version() gates the fee-delivery mechanism, mirroring backend_new's
+    // ManagerFeeService._SHARE_FEE_MIN_VERSION: a v2+ strategy never leaves a
+    // fee balance in the FeeManager — performanceFee()/managementFee() are
+    // just rates — every crystallization mints vault shares straight to the
+    // recipient (FeeSharesMinted), so it has to be read from that event
+    // rather than estimated off accrued interest. Confirmed on monad
+    // 2026-09-09: aHYPER's FeeManager switched that day from a
+    // performanceFee-only config to management-fee-only, and its strategy
+    // minted FeeSharesMinted for the very first time in the SAME transaction —
+    // a one-off catch-up of months of previously-accrued, not-yet-crystallized
+    // performance fee (~$570k) that a notional formula would never see, and
+    // would keep missing on every ordinary day after (management fee is never
+    // realized as a FeeManager balance on these contracts). A failed read is
+    // treated as "legacy" (v1.0), the same convention as the managementFee/
+    // managerSplit absences below.
+    const versions = await toApi.multiCall({
+      abi: abis.version,
+      calls: active.map((a) => strategies[a.i]),
+      permitFailure: true,
+    });
+    const shareFee = active.map((_, k) => Number(versions[k] || 0) >= 2);
+
+    const shareFeeTargets = active
+      .filter((_, k) => shareFee[k])
+      .map((a) => strategies[a.i]);
+    const mintLogs = shareFeeTargets.length
+      ? await options.getLogs({
+          targets: shareFeeTargets,
+          eventAbi: abis.feeSharesMinted,
+          entireLog: true,
+          parseLog: true,
+        })
+      : [];
+    // A contract upgrade (UUPS `Upgraded`) can bundle, in the SAME transaction,
+    // a one-off mint that migrates value already accrued and reported under
+    // the OLD fee model — not fresh income earned today. Confirmed on monad
+    // 2026-09-08: aHYPER's Upgraded + Initialized(v3) + Initialized(v4) +
+    // FeeStructureSet + both FeeSharesMinted events (400,699.82 to the manager,
+    // 133,566.61 to treasury) all fired in one execTransaction. That value was
+    // already recognized day by day under the prior performanceFee formula
+    // (see the legacy path below); booking it again here on the settlement day
+    // would double-count it. Excluded by transaction hash, not by date, so an
+    // ordinary same-day mint that happens to land after the upgrade still
+    // counts normally.
+    const upgradeTxs = shareFeeTargets.length
+      ? await options.getLogs({
+          targets: shareFeeTargets,
+          eventAbi: abis.upgraded,
+          entireLog: true,
+        })
+      : [];
+    const migrationTxHashes = new Set(
+      (upgradeTxs || []).map(
+        (log) => `${log.address.toLowerCase()}:${log.transactionHash.toLowerCase()}`,
+      ),
+    );
+
+    // Grouped by (strategy, recipient): the recipient is the ground truth for
+    // manager-vs-protocol attribution. A split ratio read at the end of the
+    // window is not — aHYPER's very first mint paid out under the OLD split,
+    // in the same transaction that changed the split to the new one.
+    const mintedByRecipient: Record<string, Record<string, bigint>> = {};
+    for (const log of mintLogs || []) {
+      const strategyKey = log.address.toLowerCase();
+      if (migrationTxHashes.has(`${strategyKey}:${log.transactionHash.toLowerCase()}`))
+        continue;
+      const recipientKey = (log.args.recipient as string).toLowerCase();
+      mintedByRecipient[strategyKey] ??= {};
+      mintedByRecipient[strategyKey][recipientKey] =
+        (mintedByRecipient[strategyKey][recipientKey] || 0n) +
+        BigInt(log.args.shares);
+    }
+
+    const mintedTotals = active.map((a) => {
+      const byRecipient = mintedByRecipient[strategies[a.i].toLowerCase()];
+      if (!byRecipient) return 0n;
+      return Object.values(byRecipient).reduce((sum, s) => sum + s, 0n);
+    });
+    const mintedValues = await toApi.multiCall({
+      abi: abis.convertToAssets,
+      calls: active.map((a, k) => ({
+        target: vaults[a.i],
+        params: [mintedTotals[k].toString()],
+      })),
+      permitFailure: true,
+    });
 
     active.forEach((a, k) => {
       const token = assets[k];
@@ -362,11 +456,42 @@ const fetch = async (options: FetchOptions) => {
           `Accountable: could not read the asset of ${strategies[a.i]} on ${options.chain}`,
         );
 
-      // The performance fee and the manager split are what separate protocol
-      // revenue from the manager's cut, so a failed read of either must not
-      // pass as a zero rate. The nulls that are expected: `managementFee` is
-      // absent from the first-generation FeeManagers, and of the two
-      // `managerSplit` overloads only one exists on any given generation.
+      if (shareFee[k]) {
+        const totalShares = mintedTotals[k];
+        if (totalShares === 0n) {
+          // Nothing crystallized this window — a real zero, not a gap to estimate.
+          book(token, a.interest, 0n, 0n, METRIC.BORROW_INTEREST);
+          return;
+        }
+        if (mintedValues[k] === null)
+          throw new Error(
+            `Accountable: could not convert minted fee shares to assets for ${strategies[a.i]} on ${options.chain}`,
+          );
+        const treasury = (treasuries[k] || "").toLowerCase();
+        if (!treasury)
+          throw new Error(
+            `Accountable: could not read the treasury of feeManager ${feeManagers[a.i]} on ${options.chain}, refusing to attribute a real fee mint for ${strategies[a.i]}`,
+          );
+        const byRecipient =
+          mintedByRecipient[strategies[a.i].toLowerCase()] || {};
+        let protocolShares = 0n;
+        for (const [recipient, shares] of Object.entries(byRecipient)) {
+          if (recipient === treasury) protocolShares += shares;
+        }
+        const mintedValue = big(mintedValues[k]);
+        const protocol = (mintedValue * protocolShares) / totalShares;
+        const manager = mintedValue - protocol;
+        // Gross stays the window's own interest, full stop — a mint can
+        // crystallize months of prior accrual in one shot (the aHYPER
+        // catch-up above), and `book()`'s depositors leg is what absorbs that:
+        // it can go negative on such a day rather than being floored at zero.
+        // `allowNegativeValue` is set for exactly this.
+        book(token, a.interest, manager, protocol, METRIC.BORROW_INTEREST);
+        return;
+      }
+
+      // Legacy (v1.0) path: fee accrues as an estimate against interest and is
+      // claimed later via Collected — unchanged.
       if (perfFees[k] === null)
         throw new Error(
           `Accountable: could not read the performance fee of ${strategies[a.i]} on ${options.chain}`,
@@ -377,30 +502,10 @@ const fetch = async (options: FetchOptions) => {
         );
 
       const perfFee = (a.interest * big(perfFees[k])) / FEE_DENOMINATOR;
-      const mgmtFee =
-        (a.aum * big(mgmtFees[k]) * elapsed) / (YEAR * FEE_DENOMINATOR);
-      const total = perfFee + mgmtFee;
-
-      // Capped at the interest so that fees = supply side + revenue stays exact.
-      // A management fee accrues on AUM, so in a very low interest window it can
-      // exceed the interest earned; the excess is dropped rather than reported.
-      const charged = total > a.interest ? a.interest : total;
-      const perfPart = total === 0n ? 0n : (charged * perfFee) / total;
-      const mgmtPart = charged - perfPart;
-
       const perfSplit = big(perfSplits[k] ?? legacySplits[k]);
-      const mgmtSplit = big(mgmtSplits[k] ?? legacySplits[k]);
-      const manager =
-        (perfPart * perfSplit) / FEE_DENOMINATOR +
-        (mgmtPart * mgmtSplit) / FEE_DENOMINATOR;
+      const manager = (perfFee * perfSplit) / FEE_DENOMINATOR;
 
-      book(
-        token,
-        a.interest,
-        manager,
-        charged - manager,
-        METRIC.BORROW_INTEREST,
-      );
+      book(token, a.interest, manager, perfFee - manager, METRIC.BORROW_INTEREST);
     });
   }
 


### PR DESCRIPTION
## Summary
- v2+ `OPEN_TERM`/`EARLY_EXIT`/`YIELD_STRATEGY_V1_1` strategies never leave a fee balance in the FeeManager — `performanceFee()`/`managementFee()` are just rates, and every crystallization mints vault shares straight to the recipient (`FeeSharesMinted`), same mechanism already used for NAV/looping vaults in this adapter.
- Credit vaults (the ones exposing `scaleFactor()`) were still using a notional interest/AUM-based estimate for this, which (a) never picked up a management-fee-only config (`performanceFee=0`) as revenue at all, and (b) capped any crystallization at that day's own accrued interest, silently dropping real value when a mint settles a longer backlog in one shot.
- Fix: gate by `version()` (mirrors `backend_new`'s `ManagerFeeService._SHARE_FEE_MIN_VERSION`); for `>=2`, sum `FeeSharesMinted` for the window, convert to assets via `convertToAssets`, and attribute manager vs protocol by matching the mint's recipient against the FeeManager's own `treasury()` — not a split ratio, which can change in the same transaction as the mint.
- Mints that share a transaction with an `Upgraded` event on the same contract are excluded (keyed by tx hash, not date) — see below for why.
- Legacy (v1.0) strategies are untouched: `managementFee()` has always read `null` there, so the removed notional management-fee term was already always zero for them.

## Why the `Upgraded` exclusion

On monad, aHYPER's FeeManager switched from a performanceFee-only config to management-fee-only on 2026-09-08, bundled in a Safe multisig `execTransaction` that also upgraded the strategy's own implementation (`Upgraded` + `Initialized` v3/v4 in the same tx). That transaction minted a one-off 400,699.82 / 133,566.61 share settlement — months of previously-accrued, not-yet-crystallized performance fee that was already being recognized day-by-day under the prior notional formula. Booking it again as fresh revenue on the settlement day would double-count it. Excluding by transaction hash (not by date) means an ordinary mint that happens to land later the same day still counts normally.

## Test plan
- [x] `npm run ts-check` clean.
- [x] `npm test fees accountable` clean on monad and ethereum, before and after the aHYPER switch date.
- [x] Cross-checked the computed manager/protocol split against raw `FeeSharesMinted` logs and the Safe transaction's decoded events (recipient-by-recipient) — matches to within rounding.
- [x] Confirmed the pre-switch day correctly falls back to the legacy path (real `version()` was <2 before the upgrade tx bumped it), reproducing the prior ~20% performance-fee split with no regression.
- [x] Confirmed other `version()>=2` credit vaults on monad (e.g. Valos) that already mint fee shares are picked up by the same generic path, with stable day-over-day numbers unrelated to the aHYPER migration.
- [ ] Other chains (arbitrum, robinhood, citrea) not individually re-verified beyond `ts-check`; the change is chain-agnostic and gated purely by on-chain `version()`.
