### PR TITLE
[fix] sunperp: report one-sided volume

### DIFF
--- a/dexs/sunperp/index.ts
+++ b/dexs/sunperp/index.ts
@@ -29,7 +29,8 @@ const fetch = async (options: FetchOptions) => {
     });
 
   return {
-    dailyVolume: results.reduce((sum, volume) => sum + volume, 0),
+    // SunX klines report buy+sell turnover (HTX-clone convention), halve for the one-sided volume
+    dailyVolume: results.reduce((sum, volume) => sum + volume, 0) / 2,
   };
 };
 


### PR DESCRIPTION
`/sapi/v1/market/history/kline` on SunPerp is the HTX API surface, where `trade_turnover` sums both the buy and the sell leg of every fill. We were adding it up as-is, so SunPerp's daily volume was reported at 2x. Halved to match the one-sided convention used everywhere else.

Needs a derivatives volume refill for sunperp (Tron) from 2025-09-10, the adapter start.