### PR TITLE
Add Otomate Tydro vault accrued yield and performance revenue

### DIFF
--- a/dexs/otomate.ts
+++ b/dexs/otomate.ts
@@ -4,7 +4,41 @@ import { CHAIN } from "../helpers/chains";
 const OFFCHAIN_EXCHANGE = "0x8373C3Aa04153aBc0cfD28901c3c971a946994ab";
 const BUILDER_ID_PADDED = "0x" + (900).toString(16).padStart(64, "0");
 
-const fetch = async ({ getLogs }: FetchOptions) => {
+// Otomate Earn wrappers. Deployment blocks are from each proxy's creation transaction:
+// https://explorer.inkonchain.com/address/<vault>
+const VAULTS = [
+  { target: "0x919C57BF59484798Ff2f90018640fd0A08242aC2", block: 39817878 }, // USDT0
+  { target: "0x2baA4C3f66Fa6f0c2d56242BaAE446a4De878B98", block: 40073655 }, // kBTC
+  { target: "0xcc7DcF43b17D8EdC437a6e33a6A325C57eba1ED7", block: 40073901 }, // WETH
+  { target: "0x59046e5a0cbb5b64981b4668a31ab3a5ed0e7dd0", block: 40074036 }, // USDC
+];
+
+// ATokenVault._accrueYield and getClaimableFees:
+// https://explorer.inkonchain.com/address/0xBEDF324cbd1F06b4faa8e20De527FD593Ee0b7c6?tab=contract
+// Pending yield at each boundary reconciles sparse accrual events into period earnings.
+// Deposits/withdrawals update lastVaultBalance; withdrawing previously accrued fees
+// is not revenue again. On-chain fees/events also preserve historical rate changes.
+async function pendingYield(api: FetchOptions["api"], block: number) {
+  const vaults = VAULTS.filter(v => v.block <= block);
+  const result: Record<string, { yield: bigint; fee: bigint }> = {};
+  if (!vaults.length) return result;
+  const aTokens = await api.multiCall({ abi: "address:ATOKEN", calls: vaults });
+  const lastBalances = await api.multiCall({ abi: "uint256:getLastVaultBalance", calls: vaults });
+  const fees = await api.multiCall({ abi: "uint256:getFee", calls: vaults });
+  const balances = await api.multiCall({
+    abi: "erc20:balanceOf",
+    calls: vaults.map((v, i) => ({ target: aTokens[i], params: [v.target] })),
+  });
+  vaults.forEach((vault, i) => {
+    const growth = BigInt(balances[i]) - BigInt(lastBalances[i]);
+    const yieldAmount = growth > 0n ? growth : 0n; // Matches getClaimableFees.
+    result[vault.target.toLowerCase()] = { yield: yieldAmount, fee: yieldAmount * BigInt(fees[i]) / 10n ** 18n };
+  });
+  return result;
+}
+
+const fetch = async (options: FetchOptions) => {
+  const { getLogs, createBalances } = options;
   const logs = await getLogs({
     target: OFFCHAIN_EXCHANGE,
     eventAbi:
@@ -12,27 +46,74 @@ const fetch = async ({ getLogs }: FetchOptions) => {
     topics: [null as any, null as any, BUILDER_ID_PADDED],
   });
 
-  let dailyFees = 0;
+  const dailyFees = createBalances();
+  const dailyRevenue = createBalances();
+  const dailySupplySideRevenue = createBalances();
+  let builderFees = 0;
   let dailyVolume = 0;
-
   for (const log of logs) {
-    const fee = Math.abs(Number(log.feeAmount)) / 1e18;
-    const vol = Math.abs(Number(log.quoteAmount)) / 1e18;
-    dailyFees += fee;
-    dailyVolume += vol;
+    builderFees += Math.abs(Number(log.feeAmount)) / 1e18;
+    dailyVolume += Math.abs(Number(log.quoteAmount)) / 1e18;
+  }
+  dailyFees.addUSDValue(builderFees, "Nado Builder Fees");
+  dailyRevenue.addUSDValue(builderFees, "Nado Builder Fees To Otomate");
+
+  const fromBlock = await options.getFromBlock();
+  const toBlock = await options.getToBlock();
+  const activeVaults = VAULTS.filter(v => v.block <= toBlock);
+  if (activeVaults.length && toBlock > fromBlock) {
+    const before = await pendingYield(options.fromApi, fromBlock);
+    const after = await pendingYield(options.toApi, toBlock);
+    const assets = await options.toApi.multiCall({ abi: "address:asset", calls: activeVaults });
+    const accrued = await getLogs({
+      targets: activeVaults.map(v => v.target),
+      fromBlock: fromBlock + 1,
+      toBlock,
+      eventAbi: "event YieldAccrued(uint256 accruedYield, uint256 newFeesFromYield, uint256 newVaultBalance)",
+      onlyArgs: false,
+    });
+    for (const [i, vault] of activeVaults.entries()) {
+      const key = vault.target.toLowerCase();
+      let yieldAmount = after[key].yield - (before[key]?.yield ?? 0n);
+      let feeAmount = after[key].fee - (before[key]?.fee ?? 0n);
+      for (const log of accrued) {
+        if (log.address.toLowerCase() !== key) continue;
+        yieldAmount += BigInt(log.args.accruedYield);
+        feeAmount += BigInt(log.args.newFeesFromYield);
+      }
+      dailyFees.add(assets[i], yieldAmount, "Tydro Lending Yield");
+      dailyRevenue.add(assets[i], feeAmount, "Tydro Performance Fees To Otomate");
+      dailySupplySideRevenue.add(assets[i], yieldAmount - feeAmount, "Tydro Yield To Depositors");
+    }
   }
 
-  return {
-    dailyFees,
-    dailyRevenue: dailyFees,
-    dailyVolume,
-  };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue.clone(), dailySupplySideRevenue, dailyVolume };
 };
 
 const methodology = {
-  Fees: "Builder fees charged on trades routed through Otomate on Nado (variable rate per trade)",
-  Revenue: "100% of builder fees go to Otomate protocol",
-  Volume: "Notional trading volume routed through Otomate builder code on Nado",
+  Fees: "Nado builder fees plus lending interest earned by Otomate's Tydro vaults, excluding incentive tokens.",
+  Revenue: "Nado builder fees and the Tydro vault performance fees retained by Otomate, using the on-chain fee rate.",
+  ProtocolRevenue: "All Otomate builder and vault performance fees accrue to the protocol.",
+  SupplySideRevenue: "Tydro vault interest earned by depositors after Otomate's performance fee.",
+  Volume: "Notional trading volume routed through Otomate builder code on Nado; vault deposits and withdrawals are excluded.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    "Nado Builder Fees": "Builder fees charged on trades routed through Otomate on Nado.",
+    "Tydro Lending Yield": "Vault lending interest accrued during the period, reconciling accrual events with pending interest at both boundaries.",
+  },
+  Revenue: {
+    "Nado Builder Fees To Otomate": "All builder fees accrue to Otomate.",
+    "Tydro Performance Fees To Otomate": "The vault's on-chain performance fee on lending interest; fee withdrawals are not counted again.",
+  },
+  ProtocolRevenue: {
+    "Nado Builder Fees To Otomate": "All builder fees accrue to Otomate.",
+    "Tydro Performance Fees To Otomate": "Performance fees reserved for the vault owner, Otomate.",
+  },
+  SupplySideRevenue: {
+    "Tydro Yield To Depositors": "Lending interest less the vault's on-chain performance fee.",
+  },
 };
 
 export default {
@@ -42,5 +123,6 @@ export default {
   fetch,
   start: "2025-11-15",
   methodology,
-  doublecounted: true,
+  breakdownMethodology,
+  doublecounted: true, // Underlying trading and lending are already tracked under Nado and Tydro.
 } as Adapter;


### PR DESCRIPTION
The existing Otomate adapter includes only Nado builder fees and volume. Add the interest earned by its four Tydro wrappers to fees, the on-chain performance fee to protocol revenue, and the remaining interest to supply-side revenue. Preserve the existing Nado builder filter, trading-volume calculation, start date and listing slug.

Website: https://otomate.trade
Twitter: https://x.com/otomate_trade
Listing: https://defillama.com/protocol/otomate
Verified accounting source: https://explorer.inkonchain.com/address/0xBEDF324cbd1F06b4faa8e20De527FD593Ee0b7c6?tab=contract

The calculation reconciles `YieldAccrued` events with the difference in uncrystallized yield at the opening and closing blocks. This measures interest during the period even when no deposit/withdrawal occurs. Pending yield is `max(ATOKEN.balanceOf(vault) - getLastVaultBalance(), 0)`; pending performance fees use `getFee()` with the contract's integer rounding. Accrued events provide the historical fee split, so no 20% constant is imposed retroactively. Deposits, withdrawals and fee claims do not become new revenue. The event interval excludes the opening snapshot's block and includes the closing block, so consecutive windows telescope. Undeployed vaults are omitted by verified creation block. No RPC failures are swallowed.

Fees use the yield-protocol convention: all lending interest is gross fees, and only the performance cut is Otomate revenue. INK/Merkl incentives are excluded. Tydro interest overlaps the underlying Tydro lending protocol, alongside the existing Nado overlap. There is no vault deposit/withdrawal volume.

Validation:
- `npm run ts-check` and `npm run ts-check-cli`: passed.
- `INK_RPC=https://rpc-gel.inkonchain.com DEBUG_BREAKDOWN_FEES=true npm test dexs otomate 2026-09-10`: all 24 hourly windows passed for September 9. Nado breakdown: $98.7035 builder fees, matching published $98.70; volume approximately $126.27k, matching published $126,268. Tydro adds approximately $46.77 gross interest, $9.34 protocol revenue and $37.43 depositor interest.
- Historical hourly windows ending `2026-03-01T12:00:00Z`, `2026-03-12T12:00:00Z` and `2026-08-22T12:00:00Z`: passed, covering pre-vault history, initial deployment and an older active period.
- Six focused accounting checks passed: passive accrual, deposit/accrual reconciliation, fee withdrawal exclusion, fee-rate change and adjacent period reconciliation.
- Manifests and lockfiles unchanged.

A zero vault fee window is valid before deployment or with no new interest, including token precision rounding. A no-transaction window can still earn interest. The vault UI displays currently claimable fees, which is a stock rather than period revenue; the adapter does not repeatedly add that stock. Public RPC/oracle prices and DefiLlama prices may differ. CLI headline totals round each hourly result; breakdown rows provide a more useful comparison.

The on-chain rates were 20% on September 10, 2026; the implementation uses actual boundary rates and emitted fees rather than assuming the rate never changed. No complete historical rate-change audit is claimed.

This extends the existing `dexs/otomate.ts` source that already supplies the listing's fees/revenue/volume, not a second fees adapter. The companion TVL proposal adds `projects/otomate/index.js` in DefiLlama-Adapters; it is submitted at https://github.com/DefiLlama/DefiLlama-Adapters/pull/20976. After merge, please retain the existing fees and volume wiring, enable supply-side/protocol-revenue metrics if needed, and link the TVL adapter. Refill new labels/protocol-revenue history from the existing 2025-11-15 start; vault interest begins only at each deployment (earliest 2026-03-12). Enable Allow edits by maintainers.
