### PR TITLE
[feat] Accrued - add volume and fees adapters

### DIFF
--- a/dexs/accrued.ts
+++ b/dexs/accrued.ts
@@ -1,0 +1,84 @@
+/**
+ * DeFiLlama dimension-adapters — Accrued DEX aggregator volume (Robinhood Chain).
+ *
+ * Copy to: dimension-adapters/dexs/accrued.ts
+ * Register in dexs/index.ts exports.
+ *
+ * Category: DEX Aggregator (routes Uniswap liquidity; Accrued does not own pools).
+ */
+import type { SimpleAdapter, FetchOptions, FetchResult } from "../../adapters/types";
+
+const ACCRUED_SWAP_ROUTER = "0xc78e883f87675e75334df4d341f6fcb0915ebf19";
+const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+const USDT = "0xE246BC49b0598d7Cd9f0eAD48B885034f1254380";
+const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
+
+/** Router deploy block on Robinhood mainnet — update if redeployed. */
+const START_BLOCK = 59334164;
+
+const ACCRUED_SWAP_ABI =
+  "event AccruedSwap(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address recipient)";
+
+function stableUsdAmount(token: string, amount: bigint): number | null {
+  const t = token.toLowerCase();
+  if (t === USDG.toLowerCase() || t === USDT.toLowerCase()) {
+    return Number(amount) / 1e6;
+  }
+  return null;
+}
+
+async function fetchAccruedVolume(options: FetchOptions): Promise<FetchResult> {
+  const logs = await options.getLogs({
+    target: ACCRUED_SWAP_ROUTER,
+    eventAbi: ACCRUED_SWAP_ABI,
+    fromBlock: START_BLOCK,
+  });
+
+  let dailyVolume = 0;
+
+  for (const log of logs) {
+    const tokenIn = String(log.tokenIn).toLowerCase();
+    const tokenOut = String(log.tokenOut).toLowerCase();
+    const amountIn = BigInt(log.amountIn);
+    const amountOut = BigInt(log.amountOut);
+
+    const inStable = stableUsdAmount(tokenIn, amountIn);
+    const outStable = stableUsdAmount(tokenOut, amountOut);
+
+    if (inStable != null) {
+      dailyVolume += inStable;
+      continue;
+    }
+    if (outStable != null) {
+      dailyVolume += outStable;
+      continue;
+    }
+
+    // WETH / majors: use DeFiLlama price helper when available
+    if (tokenIn.toLowerCase() === WETH.toLowerCase()) {
+      const ethPrice = await options.getUSDValue?.(WETH, amountIn);
+      if (ethPrice != null) dailyVolume += ethPrice;
+    }
+  }
+
+  return { dailyVolume };
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    robinhood: {
+      start: START_BLOCK,
+      fetch: fetchAccruedVolume,
+      runAtCurrTime: true,
+    },
+  },
+  methodology: {
+    Volume:
+      "Trading volume generated through Accrued on Robinhood Chain. Only swaps " +
+      "emitting AccruedSwap from AccruedSwapRouter are included. One event per user trade; " +
+      "internal Uniswap hops are not double-counted. USD uses stablecoin leg or token price oracles.",
+  },
+};
+
+export default adapter;

--- a/dexs/accrued.ts
+++ b/dexs/accrued.ts
@@ -2,39 +2,55 @@
  * DeFiLlama dimension-adapters — Accrued DEX aggregator volume (Robinhood Chain).
  *
  * Copy to: dimension-adapters/dexs/accrued.ts
- * Register in dexs/index.ts exports.
  *
  * Category: DEX Aggregator (routes Uniswap liquidity; Accrued does not own pools).
  */
-import type { SimpleAdapter, FetchOptions, FetchResult } from "../../adapters/types";
+import type { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
 
+/** AccruedSwapRouter — https://robinhoodchain.blockscout.com/address/0xc78e883f87675e75334df4d341f6fcb0915ebf19 */
 const ACCRUED_SWAP_ROUTER = "0xc78e883f87675e75334df4d341f6fcb0915ebf19";
+/** Robinhood Chain USDG — 6 decimals — https://docs.robinhood.com/chain/contracts/ */
 const USDG = "0x5fc5360D0400a0Fd4f2af552ADD042D716F1d168";
+/** Robinhood Chain USDT — 6 decimals */
 const USDT = "0xE246BC49b0598d7Cd9f0eAD48B885034f1254380";
+/** Robinhood Chain WETH — 18 decimals */
 const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
 
-/** Router deploy block on Robinhood mainnet — update if redeployed. */
-const START_BLOCK = 59334164;
+/** Router deploy block on Robinhood mainnet (2026-09-10). */
+const ROUTER_START_BLOCK = 59334164;
 
 const ACCRUED_SWAP_ABI =
   "event AccruedSwap(address indexed user, address indexed tokenIn, address indexed tokenOut, uint256 amountIn, uint256 amountOut, address recipient)";
 
-function stableUsdAmount(token: string, amount: bigint): number | null {
+/**
+ * Map stablecoin raw amounts to USD. USDG and USDT use 6 decimals on Robinhood Chain.
+ */
+function addStableUsdVolume(
+  dailyVolume: ReturnType<FetchOptions["createBalances"]>,
+  token: string,
+  amount: bigint,
+): boolean {
   const t = token.toLowerCase();
   if (t === USDG.toLowerCase() || t === USDT.toLowerCase()) {
-    return Number(amount) / 1e6;
+    dailyVolume.add(token, Number(amount) / 1e6);
+    return true;
   }
-  return null;
+  return false;
 }
 
-async function fetchAccruedVolume(options: FetchOptions): Promise<FetchResult> {
+/**
+ * Sum AccruedSwap event notionals for the adapter window.
+ * Prefers the stablecoin leg; otherwise prices tokenIn via DeFiLlama balances.
+ */
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  const dailyVolume = options.createBalances();
+
   const logs = await options.getLogs({
     target: ACCRUED_SWAP_ROUTER,
     eventAbi: ACCRUED_SWAP_ABI,
-    fromBlock: START_BLOCK,
+    fromBlock: ROUTER_START_BLOCK,
   });
-
-  let dailyVolume = 0;
 
   for (const log of logs) {
     const tokenIn = String(log.tokenIn).toLowerCase();
@@ -42,42 +58,31 @@ async function fetchAccruedVolume(options: FetchOptions): Promise<FetchResult> {
     const amountIn = BigInt(log.amountIn);
     const amountOut = BigInt(log.amountOut);
 
-    const inStable = stableUsdAmount(tokenIn, amountIn);
-    const outStable = stableUsdAmount(tokenOut, amountOut);
+    if (addStableUsdVolume(dailyVolume, tokenIn, amountIn)) continue;
+    if (addStableUsdVolume(dailyVolume, tokenOut, amountOut)) continue;
 
-    if (inStable != null) {
-      dailyVolume += inStable;
-      continue;
-    }
-    if (outStable != null) {
-      dailyVolume += outStable;
+    if (tokenIn === WETH.toLowerCase()) {
+      dailyVolume.add(WETH, Number(amountIn) / 1e18);
       continue;
     }
 
-    // WETH / majors: use DeFiLlama price helper when available
-    if (tokenIn.toLowerCase() === WETH.toLowerCase()) {
-      const ethPrice = await options.getUSDValue?.(WETH, amountIn);
-      if (ethPrice != null) dailyVolume += ethPrice;
-    }
+    dailyVolume.add(tokenIn, Number(amountIn) / 1e18);
   }
 
   return { dailyVolume };
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  adapter: {
-    robinhood: {
-      start: START_BLOCK,
-      fetch: fetchAccruedVolume,
-      runAtCurrTime: true,
-    },
-  },
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: "2026-09-10",
+  chains: [CHAIN.ROBINHOOD],
   methodology: {
     Volume:
-      "Trading volume generated through Accrued on Robinhood Chain. Only swaps " +
-      "emitting AccruedSwap from AccruedSwapRouter are included. One event per user trade; " +
-      "internal Uniswap hops are not double-counted. USD uses stablecoin leg or token price oracles.",
+      "Trading volume from AccruedSwap events emitted by AccruedSwapRouter on Robinhood Chain. " +
+      "One event per user trade; internal Uniswap hops are not double-counted. " +
+      "USD uses the stablecoin leg when present, otherwise DeFiLlama token pricing.",
   },
 };
 

--- a/fees/accrued.ts
+++ b/fees/accrued.ts
@@ -1,0 +1,33 @@
+/**
+ * DeFiLlama fees adapter — Accrued protocol fees (currently $0).
+ *
+ * Copy to: dimension-adapters/fees/accrued.ts
+ */
+import type { SimpleAdapter, FetchOptions, FetchResult } from "../../adapters/types";
+
+const START_BLOCK = 59334164;
+
+async function fetch(_options: FetchOptions): Promise<FetchResult> {
+  return {
+    dailyFees: 0,
+    dailyRevenue: 0,
+    dailyProtocolRevenue: 0,
+  };
+}
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  adapter: {
+    robinhood: {
+      start: START_BLOCK,
+      fetch,
+    },
+  },
+  methodology: {
+    Fees: "Accrued does not charge an interface fee. Uniswap LP fees are not Accrued protocol revenue.",
+    Revenue: "No protocol revenue until an on-chain fee is added to AccruedSwapRouter.",
+    ProtocolRevenue: "Zero.",
+  },
+};
+
+export default adapter;

--- a/fees/accrued.ts
+++ b/fees/accrued.ts
@@ -3,11 +3,18 @@
  *
  * Copy to: dimension-adapters/fees/accrued.ts
  */
-import type { SimpleAdapter, FetchOptions, FetchResult } from "../../adapters/types";
+import type { FetchOptions, FetchResultV2, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
 
-const START_BLOCK = 59334164;
+/** AccruedSwapRouter deploy date on Robinhood mainnet (block 59334164). */
+const ROUTER_START = "2026-09-10";
 
-async function fetch(_options: FetchOptions): Promise<FetchResult> {
+/**
+ * Accrued charges no interface or protocol fee today.
+ * Returns zero fee metrics until an on-chain fee is added to AccruedSwapRouter.
+ */
+async function fetch(options: FetchOptions): Promise<FetchResultV2> {
+  void options.startOfDay;
   return {
     dailyFees: 0,
     dailyRevenue: 0,
@@ -16,18 +23,17 @@ async function fetch(_options: FetchOptions): Promise<FetchResult> {
 }
 
 const adapter: SimpleAdapter = {
-  version: 1,
-  adapter: {
-    robinhood: {
-      start: START_BLOCK,
-      fetch,
-    },
-  },
+  version: 2,
+  pullHourly: true,
+  fetch,
+  start: ROUTER_START,
+  chains: [CHAIN.ROBINHOOD],
   methodology: {
     Fees: "Accrued does not charge an interface fee. Uniswap LP fees are not Accrued protocol revenue.",
     Revenue: "No protocol revenue until an on-chain fee is added to AccruedSwapRouter.",
     ProtocolRevenue: "Zero.",
   },
+  breakdownMethodology: {},
 };
 
 export default adapter;


### PR DESCRIPTION
## Summary

Adds trading volume tracking for **Accrued** on **Robinhood Chain**.

The adapter tracks only swaps that emit `AccruedSwap` from the deployed **AccruedSwapRouter** (`0xc78e883f87675e75334df4d341f6fcb0915ebf19`). Unrelated Uniswap activity on Robinhood Chain is excluded.

## Category

DEX Aggregator — Accrued routes through Uniswap V3 SwapRouter02 but does not own liquidity.

## Contracts

| Contract | Address |
|----------|---------|
| AccruedSwapRouter | `0xc78e883f87675e75334df4d341f6fcb0915ebf19` |
| SwapRouter02 (downstream) | `0xcaf681a66d020601342297493863e78c959e5cb2` |

## Methodology

- One `AccruedSwap` event = one user trade
- USD: stablecoin leg (USDG/USDT) preferred; WETH via price oracle
- Protocol fees: $0 (fees adapter included for completeness)
- Start block: router deploy block on Robinhood mainnet

## Links

- Website: https://accrued.trade
- Dune dashboard: (add URL after publish)
- Attribution doc: https://github.com/saurabh-sol/Share-fees/blob/main/docs/analytics/swap-attribution.md
