### PR TITLE
Add ref_market fees (Base)

### DIFF
--- a/fees/ref-market.ts
+++ b/fees/ref-market.ts
@@ -1,8 +1,6 @@
 import { FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
-
-// Base USDC, the only asset the escrow settles in.
-const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+import ADDRESSES from '../helpers/coreAssets.json'
 
 // Every ReferralEscrow deployment on Base mainnet that has settled or can still settle a claim.
 const ESCROWS = [
@@ -15,25 +13,47 @@ const ESCROWS = [
 const ClaimSettled =
   "event ClaimSettled(uint256 indexed claimId, uint256 indexed offerId, address indexed referee, address referrer, uint8 outcome, uint256 rewardPaid, uint256 feePaid, uint256 arbitrationPaid, uint256 refereeStakeReturned, uint256 referrerStakeReturned)";
 
+const REFERRAL_PAYOUT_FEES = "Referral Payout Fees";
+const REFERRAL_PAYOUT_FEES_TO_TREASURY = "Referral Payout Fees To Treasury";
+
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
   const logs = await options.getLogs({ targets: ESCROWS, eventAbi: ClaimSettled });
-  logs.forEach((log: any) => dailyFees.add(USDC, log.feePaid));
-  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+  logs.forEach((log: any) => dailyFees.add(ADDRESSES.base.USDC, log.feePaid, REFERRAL_PAYOUT_FEES));
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees.clone(1, REFERRAL_PAYOUT_FEES_TO_TREASURY),
+    dailyProtocolRevenue: dailyFees.clone(1, REFERRAL_PAYOUT_FEES_TO_TREASURY),
+  };
 };
 
 const methodology = {
   Fees: "The protocol fee on every referral bounty that pays out: 10% of the reward, paid by the referrer.",
-  Revenue: "All protocol fees go to the ref_market treasury.",
-  ProtocolRevenue: "All protocol fees go to the ref_market treasury.",
+  Revenue: "All protocol fees (10% of referral rewards) go to the ref_market treasury.",
+  ProtocolRevenue: "All protocol fees (10% of referral rewards) go to the ref_market treasury.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [REFERRAL_PAYOUT_FEES]:
+      "10% protocol fee on every referral bounty that pays out, charged to the referrer.",
+  },
+  Revenue: {
+    [REFERRAL_PAYOUT_FEES_TO_TREASURY]: "All referral payout fees go to the ref_market treasury.",
+  },
+  ProtocolRevenue: {
+    [REFERRAL_PAYOUT_FEES_TO_TREASURY]: "All referral payout fees go to the ref_market treasury.",
+  },
 };
 
 const adapter: SimpleAdapter = {
   version: 2,
+  pullHourly: true,
   fetch,
   chains: [CHAIN.BASE],
   start: "2026-09-08",
   methodology,
+  breakdownMethodology,
 };
 
 export default adapter;

--- a/fees/ref-market.ts
+++ b/fees/ref-market.ts
@@ -1,0 +1,39 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// Base USDC, the only asset the escrow settles in.
+const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913";
+
+// Every ReferralEscrow deployment on Base mainnet that has settled or can still settle a claim.
+const ESCROWS = [
+  "0xa9f96c74230810205023c3E3AFEe33d3151e5Ee8", // first mainnet escrow, archived
+  "0xA4bFddBc6Bb8F589a92A4d4595c6902e95eb9a38", // live
+];
+
+// Emitted once per settled claim. feePaid is the protocol fee on a slot that paid out:
+// 10% of the reward, charged to the referrer, and zero on a claim that did not pay.
+const ClaimSettled =
+  "event ClaimSettled(uint256 indexed claimId, uint256 indexed offerId, address indexed referee, address referrer, uint8 outcome, uint256 rewardPaid, uint256 feePaid, uint256 arbitrationPaid, uint256 refereeStakeReturned, uint256 referrerStakeReturned)";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const logs = await options.getLogs({ targets: ESCROWS, eventAbi: ClaimSettled });
+  logs.forEach((log: any) => dailyFees.add(USDC, log.feePaid));
+  return { dailyFees, dailyRevenue: dailyFees, dailyProtocolRevenue: dailyFees };
+};
+
+const methodology = {
+  Fees: "The protocol fee on every referral bounty that pays out: 10% of the reward, paid by the referrer.",
+  Revenue: "All protocol fees go to the ref_market treasury.",
+  ProtocolRevenue: "All protocol fees go to the ref_market treasury.",
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  fetch,
+  chains: [CHAIN.BASE],
+  start: "2026-09-08",
+  methodology,
+};
+
+export default adapter;


### PR DESCRIPTION
https://defillama.com/protocol/ref-market

Adds a fees adapter for ref_market, a marketplace for referral bounties on Base. TVL adapter: DefiLlama/DefiLlama-Adapters#20987.

**What is counted.** Referrers post bounties with a USDC reward per signup, escrowed up front with a 10% protocol fee. When a referee's claim pays out, the escrow emits `ClaimSettled` with `feePaid`, and the fee goes to the ref_market treasury. The adapter sums `feePaid` across every mainnet ReferralEscrow deployment.

- **Fees**: the protocol fee on every bounty that pays out, 10% of the reward, paid by the referrer.
- **Revenue / ProtocolRevenue**: the same amount; all of it goes to the treasury (Safe `0x25EE18cBCe05Bd7Ef42A53154058796D4e425b00`).

Rewards paid to referees and dispute stakes are not fees and are not counted.

**Test.** `pnpm test fees ref-market <ts>` over the 24 hours ending 2026-09-10 22:24 UTC: daily fees 0.50, revenue 0.50, protocol revenue 0.50. That window holds the first paid claim (5 USDC reward, 0.50 USDC fee, tx `0x77bdf3d38608a769790e6688d54525c69e66faf1d5abe13e4c773df1fd246440`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167erCUMTdcUWCBwDcXswNT
