### PR TITLE
Mark Glyph Exchange V2/V4 volume and fees as deadFrom

### DIFF
--- a/dexs/glyph-exchange/index.ts
+++ b/dexs/glyph-exchange/index.ts
@@ -43,6 +43,7 @@ const classic = Object.keys(endpointsClassic).reduce(
     [chain]: {
       fetch,
       start: '2024-03-19',
+      deadFrom: '2026-09-11',
     },
   }),
   {}
@@ -50,6 +51,7 @@ const classic = Object.keys(endpointsClassic).reduce(
 
 export default {
   version: 2,
+  deadFrom: '2026-09-11',
   adapter: classic,
   methodology: {
     Fees: "GlyphExchange charges a flat 0.3% fee",

--- a/factory/uniSubgraph.ts
+++ b/factory/uniSubgraph.ts
@@ -96,6 +96,7 @@ const configs: Record<string, SubgraphConfig> = {
       SupplySideRevenue: 85,
     },
     start: "2024-03-19",
+    deadFrom: "2026-09-11",
   },
   // "retro": {
   //   graphUrls: {


### PR DESCRIPTION
Companion to https://github.com/DefiLlama/DefiLlama-Adapters/pull/20991

The Glyph team no longer maintains the Core-era DEX. We are not asking to delete the listings or erase historical data.

Please stop updating volume and fees from 2026-09-11 and keep the existing charts.

- V2: dexs/glyph-exchange
- V4: glyph-exchange-v4
- Added deadFrom: 2026-09-11