### PR TITLE
Add Valhalla liquidity-management fees adapter

### DIFF
--- a/fees/valhalla.ts
+++ b/fees/valhalla.ts
@@ -5,32 +5,36 @@
  * Meteora DLMM positions.  It does not custody position liquidity, so this is
  * a fees/revenue adapter, not a TVL adapter.
  *
- * Each attributable fee is a native-SOL system transfer to the Valhalla
- * treasury, appended to the same successful transaction that invokes either
- * Meteora DLMM or DAMM v2.  Joining receipts to those transactions prevents
- * unrelated receipts to the treasury (for example voluntary developer tips)
- * from being reported as protocol fees.
+ * Each attributable fee is a native-SOL system transfer appended after the
+ * Meteora workflow in a successful position transaction.  The adapter matches
+ * that transfer by instruction order, rather than treating every transfer to
+ * the treasury in a Meteora transaction as a fee.
  *
  * The application charges a percentage of LP fees at claim/close and a small
  * opening fee.  Rates vary by user discount, referrals and a fee cap, so gross
  * fees cannot be safely inferred from a fixed commission rate.  This adapter
- * therefore reports only the net fee receipts retained by Valhalla.  Referral
- * payments are made directly from a user wallet and are deliberately excluded:
- * they do not reach the protocol treasury.
+ * therefore reports the actual transfers: treasury receipts as protocol
+ * revenue and the immediately following referral payout as supply-side
+ * revenue.  No internal user, referral, or application data is queried.
  */
 import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
 import { CHAIN } from "../helpers/chains";
 import ADDRESSES from "../helpers/coreAssets.json";
 import { queryAllium } from "../helpers/allium";
 
+// https://solscan.io/account/BGP8a4yW8THuUZaq2TxVPU6KjHXi7G4McRyz333uuqNr
 const TREASURY = "BGP8a4yW8THuUZaq2TxVPU6KjHXi7G4McRyz333uuqNr";
+// https://solscan.io/account/LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo
 const METEORA_DLMM = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
+// https://solscan.io/account/cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG
 const METEORA_DAMM_V2 = "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG";
 
 const LABEL = "Meteora Liquidity-Management Fees";
 
 const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
   const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
   const timeRange =
     "block_timestamp >= TO_TIMESTAMP_NTZ(" +
     options.startTimestamp +
@@ -38,60 +42,90 @@ const fetch = async (options: FetchOptions) => {
     options.endTimestamp +
     ")";
 
-  // program_id on raw instructions includes both top-level calls and CPIs.
-  // The fee transfer itself is a top-level System Program instruction, so it
-  // must be associated by transaction id rather than outer_program_id.
+  // program_id includes top-level calls and CPIs. The fee transfer is a
+  // top-level System Program transfer appended after the Meteora instructions.
   const query =
     "WITH meteora_transactions AS (" +
-    " SELECT DISTINCT txn_id" +
+    " SELECT txn_id, MAX(instruction_index) AS last_meteora_instruction_index" +
     " FROM solana.raw.instructions" +
-    " WHERE program_id IN ('" +
+    " WHERE parent_tx_success = true AND program_id IN ('" +
     METEORA_DLMM +
     "', '" +
     METEORA_DAMM_V2 +
     "') AND " +
     timeRange +
-    ") SELECT COALESCE(SUM(t.raw_amount), 0) AS amount" +
+    " GROUP BY txn_id)," +
+    " treasury_receipts AS (" +
+    " SELECT t.txn_id, t.from_address, t.instruction_index, t.raw_amount" +
     " FROM solana.assets.transfers t" +
     " INNER JOIN meteora_transactions m ON m.txn_id = t.txn_id" +
     " WHERE t.to_address = '" +
     TREASURY +
     "' AND t.mint = '" +
     ADDRESSES.solana.SOL +
-    "' AND " +
+    "' AND t.program_name = 'system' AND t.type = 'transfer'" +
+    " AND t.transfer_type = 'sol_transfer'" +
+    " AND t.instruction_index > m.last_meteora_instruction_index AND " +
     timeRange;
+  const resultQuery =
+    query +
+    "), referral_payouts AS (" +
+    " SELECT r.raw_amount" +
+    " FROM solana.assets.transfers r" +
+    " INNER JOIN treasury_receipts t ON t.txn_id = r.txn_id" +
+    " AND t.from_address = r.from_address" +
+    " AND r.instruction_index = t.instruction_index + 1" +
+    " WHERE r.to_address != '" +
+    TREASURY +
+    "' AND r.mint = '" +
+    ADDRESSES.solana.SOL +
+    "' AND r.program_name = 'system' AND r.type = 'transfer'" +
+    " AND r.transfer_type = 'sol_transfer' AND " +
+    timeRange +
+    ") SELECT COALESCE((SELECT SUM(raw_amount) FROM treasury_receipts), 0) AS treasury_amount," +
+    " COALESCE((SELECT SUM(raw_amount) FROM referral_payouts), 0) AS referral_amount";
 
-  const [result] = await queryAllium(query);
-  dailyRevenue.add(ADDRESSES.solana.SOL, result?.amount ?? 0, LABEL);
+  const [result] = await queryAllium(resultQuery);
+  dailyRevenue.add(ADDRESSES.solana.SOL, result?.treasury_amount ?? 0, LABEL);
+  dailySupplySideRevenue.add(
+    ADDRESSES.solana.SOL,
+    result?.referral_amount ?? 0,
+    "Referral Payouts",
+  );
+  dailyFees.addBalances(dailyRevenue);
+  dailyFees.addBalances(dailySupplySideRevenue);
 
   return {
-    // Fees are restricted to fees the protocol actually receives.  This avoids
-    // overstating the metric by treating direct referral payouts as treasury
-    // revenue, or by back-calculating through variable discounts and fee caps.
-    dailyFees: dailyRevenue,
+    dailyFees,
     dailyRevenue,
     dailyProtocolRevenue: dailyRevenue,
+    dailySupplySideRevenue,
   };
 };
 
 const methodology = {
   Fees:
-    "Net native-SOL liquidity-management fees received by Valhalla's treasury in successful Meteora DLMM or DAMM v2 position transactions. User liquidity is not included as Valhalla TVL.",
+    "Native-SOL liquidity-management fees in successful Meteora DLMM or DAMM v2 position transactions: the Valhalla treasury receipt plus an immediately following direct referral payout from the same user. User liquidity is not included as Valhalla TVL.",
   Revenue:
-    "The verified fee receipts retained by the Valhalla treasury. Direct referral payouts are excluded because they never reach the protocol.",
+    "The verified fee receipts retained by the Valhalla treasury.",
   ProtocolRevenue:
     "The verified native-SOL liquidity-management fee receipts to the Valhalla treasury.",
+  SupplySideRevenue:
+    "Direct referral payouts immediately following a matching treasury receipt; these are included in fees but not protocol revenue.",
 };
 
 const breakdownMethodology = {
   Fees: {
-    [LABEL]: "Native-SOL Valhalla fee transfers to the treasury, counted only when the transaction invokes Meteora DLMM or DAMM v2.",
+    [LABEL]: "Native-SOL treasury fee transfers and their immediately following referral payouts, counted only after successful Meteora DLMM or DAMM v2 instructions.",
   },
   Revenue: {
     [LABEL]: "The portion of those attributable liquidity-management fees received by the Valhalla treasury.",
   },
   ProtocolRevenue: {
     [LABEL]: "The portion of those attributable liquidity-management fees received by the Valhalla treasury.",
+  },
+  SupplySideRevenue: {
+    "Referral Payouts": "Direct referral payouts paired with a qualifying Valhalla treasury fee transfer.",
   },
 };
 

--- a/fees/valhalla.ts
+++ b/fees/valhalla.ts
@@ -1,0 +1,114 @@
+/**
+ * Valhalla — Meteora liquidity-management fees & revenue.
+ *
+ * Valhalla is a Solana bot that opens, manages, claims and closes user-owned
+ * Meteora DLMM positions.  It does not custody position liquidity, so this is
+ * a fees/revenue adapter, not a TVL adapter.
+ *
+ * Each attributable fee is a native-SOL system transfer to the Valhalla
+ * treasury, appended to the same successful transaction that invokes either
+ * Meteora DLMM or DAMM v2.  Joining receipts to those transactions prevents
+ * unrelated receipts to the treasury (for example voluntary developer tips)
+ * from being reported as protocol fees.
+ *
+ * The application charges a percentage of LP fees at claim/close and a small
+ * opening fee.  Rates vary by user discount, referrals and a fee cap, so gross
+ * fees cannot be safely inferred from a fixed commission rate.  This adapter
+ * therefore reports only the net fee receipts retained by Valhalla.  Referral
+ * payments are made directly from a user wallet and are deliberately excluded:
+ * they do not reach the protocol treasury.
+ */
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import ADDRESSES from "../helpers/coreAssets.json";
+import { queryAllium } from "../helpers/allium";
+
+const TREASURY = "BGP8a4yW8THuUZaq2TxVPU6KjHXi7G4McRyz333uuqNr";
+const METEORA_DLMM = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
+const METEORA_DAMM_V2 = "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG";
+
+const LABEL = "Meteora Liquidity-Management Fees";
+
+const fetch = async (options: FetchOptions) => {
+  const dailyRevenue = options.createBalances();
+  const timeRange =
+    "block_timestamp >= TO_TIMESTAMP_NTZ(" +
+    options.startTimestamp +
+    ") AND block_timestamp < TO_TIMESTAMP_NTZ(" +
+    options.endTimestamp +
+    ")";
+
+  // program_id on raw instructions includes both top-level calls and CPIs.
+  // The fee transfer itself is a top-level System Program instruction, so it
+  // must be associated by transaction id rather than outer_program_id.
+  const query =
+    "WITH meteora_transactions AS (" +
+    " SELECT DISTINCT txn_id" +
+    " FROM solana.raw.instructions" +
+    " WHERE program_id IN ('" +
+    METEORA_DLMM +
+    "', '" +
+    METEORA_DAMM_V2 +
+    "') AND " +
+    timeRange +
+    ") SELECT COALESCE(SUM(t.raw_amount), 0) AS amount" +
+    " FROM solana.assets.transfers t" +
+    " INNER JOIN meteora_transactions m ON m.txn_id = t.txn_id" +
+    " WHERE t.to_address = '" +
+    TREASURY +
+    "' AND t.mint = '" +
+    ADDRESSES.solana.SOL +
+    "' AND " +
+    timeRange;
+
+  const [result] = await queryAllium(query);
+  dailyRevenue.add(ADDRESSES.solana.SOL, result?.amount ?? 0, LABEL);
+
+  return {
+    // Fees are restricted to fees the protocol actually receives.  This avoids
+    // overstating the metric by treating direct referral payouts as treasury
+    // revenue, or by back-calculating through variable discounts and fee caps.
+    dailyFees: dailyRevenue,
+    dailyRevenue,
+    dailyProtocolRevenue: dailyRevenue,
+  };
+};
+
+const methodology = {
+  Fees:
+    "Net native-SOL liquidity-management fees received by Valhalla's treasury in successful Meteora DLMM or DAMM v2 position transactions. User liquidity is not included as Valhalla TVL.",
+  Revenue:
+    "The verified fee receipts retained by the Valhalla treasury. Direct referral payouts are excluded because they never reach the protocol.",
+  ProtocolRevenue:
+    "The verified native-SOL liquidity-management fee receipts to the Valhalla treasury.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [LABEL]: "Native-SOL Valhalla fee transfers to the treasury, counted only when the transaction invokes Meteora DLMM or DAMM v2.",
+  },
+  Revenue: {
+    [LABEL]: "The portion of those attributable liquidity-management fees received by the Valhalla treasury.",
+  },
+  ProtocolRevenue: {
+    [LABEL]: "The portion of those attributable liquidity-management fees received by the Valhalla treasury.",
+  },
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  // Conservative start.  Do not move it earlier without validating the
+  // pre-migration treasury history transaction by transaction.
+  adapter: {
+    [CHAIN.SOLANA]: { start: "2025-08-06" },
+  },
+  dependencies: [Dependencies.ALLIUM],
+  isExpensiveAdapter: true,
+  fetch,
+  methodology,
+  breakdownMethodology,
+  doublecounted: true, // Meteora's underlying swap fees are tracked separately.
+};
+
+export default adapter;

--- a/fees/valhalla.ts
+++ b/fees/valhalla.ts
@@ -30,6 +30,7 @@ const METEORA_DLMM = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
 const METEORA_DAMM_V2 = "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG";
 
 const LABEL = "Meteora Liquidity-Management Fees";
+const REFERRAL_LABEL = "Referral Payouts";
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -90,7 +91,7 @@ const fetch = async (options: FetchOptions) => {
   dailySupplySideRevenue.add(
     ADDRESSES.solana.SOL,
     result?.referral_amount ?? 0,
-    "Referral Payouts",
+    REFERRAL_LABEL,
   );
   dailyFees.addBalances(dailyRevenue);
   dailyFees.addBalances(dailySupplySideRevenue);
@@ -116,7 +117,8 @@ const methodology = {
 
 const breakdownMethodology = {
   Fees: {
-    [LABEL]: "Native-SOL treasury fee transfers and their immediately following referral payouts, counted only after successful Meteora DLMM or DAMM v2 instructions.",
+    [LABEL]: "Native-SOL treasury fee transfers counted only after successful Meteora DLMM or DAMM v2 instructions.",
+    [REFERRAL_LABEL]: "Referral payouts paired with a qualifying Valhalla treasury fee transfer.",
   },
   Revenue: {
     [LABEL]: "The portion of those attributable liquidity-management fees received by the Valhalla treasury.",
@@ -125,7 +127,7 @@ const breakdownMethodology = {
     [LABEL]: "The portion of those attributable liquidity-management fees received by the Valhalla treasury.",
   },
   SupplySideRevenue: {
-    "Referral Payouts": "Direct referral payouts paired with a qualifying Valhalla treasury fee transfer.",
+    [REFERRAL_LABEL]: "Direct referral payouts paired with a qualifying Valhalla treasury fee transfer.",
   },
 };
 


### PR DESCRIPTION
## Summary

- Adds Valhalla's Solana fees/revenue adapter for Meteora liquidity-management transactions.
- Counts only successful transactions and only top-level native-SOL system transfers to the public treasury that occur after the final Meteora instruction.
- Counts a directly following referral payout from the same sender as supply-side revenue, while the treasury receipt remains protocol revenue. Valhalla does not custody user liquidity, so this is not a TVL adapter.

## Validation

- pnpm exec tsc --noEmit --pretty false
- pnpm test fees valhalla 2026-08-21 solana reaches the adapter locally; execution stops as expected locally without the repository-provided Allium credential.

## Listing details

- Name: Valhalla
- Website: https://valhalla-bot.app/
- X/Twitter: https://x.com/SOL_Decoder
- Chain: Solana
- Category: Liquidity manager
- Treasury: BGP8a4yW8THuUZaq2TxVPU6KjHXi7G4McRyz333uuqNr
- Start date: 2025-08-06

## Methodology and review notes

- The adapter derives values solely from public on-chain transfers and program invocations. It does not use or expose non-public application data.
- It uses actual transfer amounts, so variable discounts, referral splits, and fee caps do not require a fixed-rate assumption.
- Zero-volume and fee-to-volume validation are not applicable because this PR reports fees/revenue only; it does not report volume or TVL.
- The dashboard will show Solana fees, revenue, protocol revenue, and supply-side referral payouts.
- Backfill is limited to the public on-chain history from the listed start date.