### PR TITLE
Add Route daily aggregator volume and swap fees on Robinhood Chain

### DIFF
--- a/aggregators/route.ts
+++ b/aggregators/route.ts
@@ -1,0 +1,29 @@
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { addToken, engines, swapEvents, volumeSide } from '../helpers/aggregators/route';
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  for (const eventAbi of swapEvents) {
+    const logs = await options.getLogs({ targets: engines, eventAbi });
+    for (const log of logs) {
+      // Wrappers emit the final swap as well as their inner engine. Count only the outer one.
+      // The tiered collector is NOT in engines: it emits Settled, so its engine swap counts once.
+      if (engines.includes(log.sender.toLowerCase())) continue;
+      const [token, amount] = volumeSide(log);
+      addToken(dailyVolume, token, amount, 'Routed Swaps');
+    }
+  }
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: '2026-09-05',
+  methodology: { Volume: 'One side of successful swaps through current and historical Route settlement contracts, excluding nested engine events; includes contract-level integrations and treasury trades, not quotes or underlying pool hops.' },
+  breakdownMethodology: { Volume: { 'Routed Swaps': 'USDG, otherwise ETH/WETH when present, otherwise the input token, valued by DefiLlama; no fixed dollar peg or current-price cumulative estimate.' } },
+};
+export default adapter;

--- a/fees/route.ts
+++ b/fees/route.ts
@@ -1,0 +1,40 @@
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { addToken, collector, engines, feePaid, settled } from '../helpers/aggregators/route';
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const oldFees = await options.getLogs({ targets: engines, eventAbi: feePaid });
+  const currentFees = await options.getLogs({ target: collector, eventAbi: settled });
+  for (const log of oldFees) {
+    addToken(dailyFees, log.token, log.feeAmount.toString(), 'Swap Fees');
+    addToken(dailyRevenue, log.token, log.feeAmount.toString(), 'Swap Fees To Route');
+  }
+  for (const log of currentFees) {
+    addToken(dailyFees, log.tokenOut, log.feeAmount.toString(), 'Swap Fees');
+    addToken(dailyRevenue, log.tokenOut, log.feeAmount.toString(), 'Swap Fees To Route');
+  }
+  // Revenue belongs to Route; buying protocol-owned LP is not a payment to outside LPs.
+  // Do not add receiver conversions/escrow claims again. The mixed-source worker cannot
+  // attribute realized holder distributions to swap fees alone; omit that metric, not zero.
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue: 0 };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: '2026-09-05',
+  methodology: {
+    Fees: 'Actual Route output-token swap fees from historical FeePaid and current Settled events; excludes pool/provider fees, gas, creator fees and private transfers.',
+    Revenue: 'All collected Route swap fees accrue to Route-controlled recipients; later conversions and allocations are not counted again.',
+    SupplySideRevenue: 'No portion of this aggregator fee is paid to external liquidity providers or referrers; protocol-owned liquidity is a capital allocation.',
+  },
+  breakdownMethodology: {
+    Fees: { 'Swap Fees': 'Actual emitted fee amounts, not an assumed fee rate multiplied by volume; includes historical fees and the September 11, 2026 tiered collector.' },
+    Revenue: { 'Swap Fees To Route': 'Swap fees received by Route treasury or its fee receiver, before subsequent buybacks and protocol-owned liquidity allocations.' },
+  },
+};
+export default adapter;

--- a/helpers/aggregators/route.ts
+++ b/helpers/aggregators/route.ts
@@ -1,0 +1,42 @@
+import { FetchOptions } from '../../adapters/types';
+import ADDRESSES from '../coreAssets.json';
+
+// Historical settlement registry: https://github.com/routerh/route/blob/main/lib/route/activity.ts
+// Keep old emitters for backfills. They are not current approval recommendations.
+export const engines = [
+  '0xfb866d8cd2796efd920a7a062814aeb88b1d2bcb',
+  '0xb1a65445695b79d042caaa86b5aa1e3b5f38ac03',
+  '0xd8f7171886f8476ece2e51cffe8c4c637815a815',
+  '0x872d8bd2d903f83377c873d3234fb762a4fd4703',
+  '0xde02d8438a92084eddff012c0a4673a0832da21d',
+  '0x485e249b82587531165ef2fe97a768813964ebd3',
+  '0x201a935146e1283f35bb54b8fe7a4c584265b7e8',
+  '0x418d76ffa3026fe9e8b067cc39251cca8fcba3f5',
+  '0x22c1bba36ba220964d029eb4b1ef7c6ed167e32e',
+  '0x70656a2b4a401def17c55687c19c536c0fad4db1',
+  '0x9990a63ef329ab407956b4fe5a812aba0d81e20c',
+];
+// Exact source: https://repo.sourcify.dev/4663/0xBFADcf357545cb185420eAD0fDE1008A289c0154
+export const collector = '0xbfadcf357545cb185420ead0fde1008a289c0154';
+export const settled = 'event Settled(address indexed sender,address indexed recipient,address indexed tokenOut,uint256 grossAmountOut,uint256 feeBps,uint256 feeAmount,uint256 amountOut)';
+export const swapEvents = [
+  'event Swapped(address indexed sender,address indexed recipient,address indexed tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut)',
+  'event Swapped(address indexed sender,address indexed recipient,address indexed tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut,bytes32 routeHash)',
+  'event Swapped(address indexed sender,address indexed recipient,address indexed tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut,address intermediate,address firstAdapter,uint24 firstFee,address secondAdapter,uint24 secondFee)',
+];
+export const feePaid = 'event FeePaid(address indexed sender,address indexed recipient,address indexed token,uint256 grossAmountOut,uint256 feeAmount)';
+
+export function addToken(balance: ReturnType<FetchOptions['createBalances']>, token: string, amount: string, label: string) {
+  if (token.toLowerCase() === ADDRESSES.null) balance.addGasToken(amount, label);
+  else balance.add(token, amount, label);
+}
+
+// Count a single, preferentially priceable side. Never price long-tail tokens at $1.
+export function volumeSide(log: any): [string, string] {
+  const preferred = [ADDRESSES.robinhood.USDG, ADDRESSES.null, ADDRESSES.robinhood.WETH].map(x => x.toLowerCase());
+  for (const token of preferred) {
+    if (log.tokenIn.toLowerCase() === token) return [log.tokenIn, log.amountIn.toString()];
+    if (log.tokenOut.toLowerCase() === token) return [log.tokenOut, log.amountOut.toString()];
+  }
+  return [log.tokenIn, log.amountIn.toString()];
+}


### PR DESCRIPTION
# Add Route aggregator volume and swap fees on Robinhood Chain

## Listing

- Name: Route
- Website: https://www.route.fun
- Twitter: https://x.com/routedotfun
- Documentation: https://docs.route.fun
- Category: DEX Aggregator
- Chain: Robinhood (4663; existing `robinhood` SDK chain)
- GitHub: https://github.com/routerh/route
- Treasury Safe: `0x3b9C7bC09FF64F554480f30Ad40286cFc09d2F80`
- Audit: no completed independent audit claimed. Sourcify source matching is not an audit.
- Logo: https://raw.githubusercontent.com/routerh/dimension-adapters/refs/heads/codex/route-listing-assets/route-logo.png (owner-supplied square PNG, hosted on a separate branch; not added to the adapter diff).
- CoinGecko/CoinMarketCap token IDs: not confirmed; do not invent.
- Token address/ticker: `0x4a72b9702f991b790788f8afa9e7112541f4e8f8` / ROUTE on Robinhood Chain. Owner supplied; live ERC20 reads confirmed name `Route`, symbol `ROUTE`, decimals `18`.
- TVL: not requested; these are dimensions adapters, not a custody/TVL listing.
- Oracle metadata: adapter uses DefiLlama token pricing, not a project-supplied USD total. Product-wide oracle fields require separate release-scoped confirmation.

## Implementation

Three files: `aggregators/route.ts`, `fees/route.ts`, and shared `helpers/aggregators/route.ts`. Custom settlement events do not match a DEX factory. Both adapters are version 2, hourly-compatible, start September 5, 2026, and use only targeted onchain logs.

Volume counts one side per successful outer Route swap. USDG is preferred, then ETH/WETH, otherwise the input asset; raw token units go to DefiLlama pricing. No hardcoded USD peg. Historical nested executor events are excluded. The September 11 collector emits `Settled`, not `Swapped`: its engine event is counted once. Underlying pool-hop events and collector `Settled` are not added as additional volume. This is contract-level routed volume, including actual treasury/bot integrations and early mainnet test swaps, not website-user-only volume.

Fees use the actual `feeAmount` from historical `FeePaid` and current `Settled`, denominated in the fee token. They accrue to Route-controlled recipients. Pool fees, gas, private-transfer fees, provider commissions and token-creator fees are outside this swap-product metric. No receiver conversion, escrow credit, claim, donation or treasury transfer is added a second time. There is no external LP/referrer share of the collected aggregator fee; protocol-owned liquidity purchases are capital allocations, not external supply-side payouts.

## Source evidence

- Historical registry: https://github.com/routerh/route/blob/main/lib/route/activity.ts
- Historical fee contract: https://github.com/routerh/route/blob/main/contracts/RouteFeeExecutor.sol
- Current collector exact source: https://repo.sourcify.dev/4663/0xBFADcf357545cb185420eAD0fDE1008A289c0154
- Current direct engine: https://repo.sourcify.dev/4663/0x9990A63ef329aB407956B4fE5A812ABA0d81e20C
- Collector deployment: https://robinhoodchain.blockscout.com/tx/0x4ac4a9253168997313d4d15078e3e6d7f691413056ddde27484afd2235460dae
- Historical fee example: https://robinhoodchain.blockscout.com/tx/0x22c286fd56c8e9c7a756b5a4244b5380ea946f50e73eb5c938a98003d723432f
- Current 10-bps fee example: https://robinhoodchain.blockscout.com/tx/0x956604ad09f2c3f2715b4f76eb1536d909307f2e040c57af04cb6584f86563ca

## Reviewer questions / exclusions

1. Zero fees are legitimate during the fee-free period and for individual zero-tier or rounding-to-zero swaps. Fees were 15 bps on early historical wrappers on September 5; the public product subsequently became fee-free. Tiered collection activated September 11. Historical contracts are preserved, so future direct calls to old wrappers would still be measured. Actual events, not date-based estimated rates, determine fees.
2. Current permitted tiers are 0/2/5/10/50 bps. The adapter does not classify token ages or assume everyone pays the same fee. A global fee-to-volume ratio can be lower because older fee-free engines remain callable. Fee/volume token-side pricing can also differ.
3. The website's all-time volume uses current indexed ETH/USDG spot valuation and an older registry; this adapter uses time-windowed raw amounts, DefiLlama pricing, and the new direct engine. Totals need not match. Missing long-tail token prices can reduce priced coverage; no fabricated price fills are used.
4. **Holder attribution remains a reviewer question:** the revenue worker mixes creator revenue with swap fees. Its policy is 35% buybacks, 30% protocol-owned LP, 35% vault, but that does not prove per-period execution or source-specific buybacks. `dailyHoldersRevenue` and `dailyProtocolRevenue` are omitted, not published as zero and not estimated at 35%/65%. Need agreed source attribution before adding either. No burn claim.
5. No existing adapter or factory entry for route.fun/routedotfun found in upstream `ff5ad6ce1a5e33263ae5f996ab3dcf28b11a5388`. GitHub PR search for `route.fun` returned no results. Maintainers should confirm any existing parent listing and add `dimensions: { aggregators: "route", fees: "route" }` in server-side metadata as appropriate.
6. No existing adapter is being modified, so no correction refill is requested. Initial history should include September 5 onward.

## Validation

Using upstream `ff5ad6ce1a5e33263ae5f996ab3dcf28b11a5388` and its frozen pnpm lockfile:

- `pnpm run ts-check`: passed.
- `pnpm run ts-check-cli`: passed.
- `pnpm test aggregators route 2026-09-10`: all 24 September 9 slots completed; approximately $501.10K volume.
- `pnpm test aggregators route 2026-09-07T13:00:00Z`: September 7, 12:00–13:00 UTC, approximately $2.50K volume.
- `pnpm test aggregators route 2026-09-11T14:20:00Z`: September 11, 13:20–14:20 UTC, approximately $401.97K volume across all engines, not only fee-collector swaps.
- `pnpm test fees route 2026-09-11T14:20:00Z`: 13:20–14:20 UTC, $0.113 fees and revenue, zero supply-side payout.
- `pnpm test fees route 2026-09-10T13:00:00Z`: zero fees during the fee-free period.
- Local independent fixtures: nested engine exclusion, collector engine inclusion, major-token side selection, native/ERC20 fee accounting, omitted unknown holder attribution, and RPC error propagation passed.
- Direct SDK invocation on blocks 1–55,500,000 recovered all 10 historical fee events: 1,853 USDG base units and 746,570,430,499 wei. Independent viem logs agreed on count and emitters.
- **First-day CLI caveat:** `pnpm test fees route 2026-09-06` skipped the first 23 slots and only ran the last slot. `runAdapter.ts` compares start against a timestamp minus a full day during hourly execution. Its resulting zero is NOT evidence of zero historical fees. Maintainers should resolve/confirm first-day backfill behavior; no core runner patch is bundled here.
- No dependency manifests, lockfiles, runtime configuration, production deployments or existing adapters changed.

Please review the holder-attribution treatment and first-day backfill caveat above. This requests daily aggregator volume and swap-fee revenue tracking, not a claim that the listing has already been accepted.

Adapter commit: `a3e588c`.
