### PR TITLE
[feat] Route - add daily aggregator volume and swap-fee revenue on Robinhood

### DIFF
--- a/adapters/utils/runAdapter.ts
+++ b/adapters/utils/runAdapter.ts
@@ -465,7 +465,8 @@ async function _runAdapter({
   }
 
   async function setChainValidStart(chain: string) {
-    const cleanPreviousDayTimestamp = cleanCurrentDayTimestamp - ONE_DAY_IN_SECONDS
+    // Hourly backfills must admit the first hour, not wait until a full day has elapsed.
+    const cleanPreviousDayTimestamp = cleanCurrentDayTimestamp - WINDOW_SECONDS
     let _start = adapterObject![chain]?.start ?? 0
     // Use root-level deadFrom if set, otherwise use chain-specific deadFrom
     let _end = module.deadFrom ?? adapterObject![chain]?.deadFrom ?? 32503593600

--- a/aggregators/route.ts
+++ b/aggregators/route.ts
@@ -1,0 +1,29 @@
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { addToken, engines, swapEvents, volumeSide } from '../helpers/aggregators/route';
+
+const fetch = async (options: FetchOptions) => {
+  const dailyVolume = options.createBalances();
+  for (const eventAbi of swapEvents) {
+    const logs = await options.getLogs({ targets: engines, eventAbi });
+    for (const log of logs) {
+      // Wrappers emit the final swap as well as their inner engine. Count only the outer one.
+      // The tiered collector is NOT in engines: it emits Settled, so its engine swap counts once.
+      if (engines.includes(log.sender.toLowerCase())) continue;
+      const [token, amount] = volumeSide(log);
+      addToken(dailyVolume, token, amount, 'Routed Swaps');
+    }
+  }
+  return { dailyVolume };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: '2026-09-05',
+  methodology: { Volume: 'One side of successful swaps through current and historical Route settlement contracts, excluding nested engine events; includes contract-level integrations and treasury trades, not quotes or underlying pool hops.' },
+  breakdownMethodology: { Volume: { 'Routed Swaps': 'USDG, otherwise ETH/WETH when present, otherwise the input token, valued by DefiLlama; no fixed dollar peg or current-price cumulative estimate.' } },
+};
+export default adapter;

--- a/fees/route.ts
+++ b/fees/route.ts
@@ -1,0 +1,40 @@
+import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { CHAIN } from '../helpers/chains';
+import { addToken, collector, engines, feePaid, settled } from '../helpers/aggregators/route';
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const oldFees = await options.getLogs({ targets: engines, eventAbi: feePaid });
+  const currentFees = await options.getLogs({ target: collector, eventAbi: settled });
+  for (const log of oldFees) {
+    addToken(dailyFees, log.token, log.feeAmount.toString(), 'Swap Fees');
+    addToken(dailyRevenue, log.token, log.feeAmount.toString(), 'Swap Fees To Route');
+  }
+  for (const log of currentFees) {
+    addToken(dailyFees, log.tokenOut, log.feeAmount.toString(), 'Swap Fees');
+    addToken(dailyRevenue, log.tokenOut, log.feeAmount.toString(), 'Swap Fees To Route');
+  }
+  // Revenue belongs to Route; buying protocol-owned LP is not a payment to outside LPs.
+  // Do not add receiver conversions/escrow claims again. The mixed-source worker cannot
+  // attribute realized holder distributions to swap fees alone; omit that metric, not zero.
+  return { dailyFees, dailyRevenue, dailySupplySideRevenue: 0 };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  chains: [CHAIN.ROBINHOOD],
+  fetch,
+  start: '2026-09-05',
+  methodology: {
+    Fees: 'Actual Route output-token swap fees from historical FeePaid and current Settled events; excludes pool/provider fees, gas, creator fees and private transfers.',
+    Revenue: 'All collected Route swap fees accrue to Route-controlled recipients; later conversions and allocations are not counted again.',
+    SupplySideRevenue: 'No portion of this aggregator fee is paid to external liquidity providers or referrers; protocol-owned liquidity is a capital allocation.',
+  },
+  breakdownMethodology: {
+    Fees: { 'Swap Fees': 'Actual emitted fee amounts, not an assumed fee rate multiplied by volume; includes historical fees and the September 11, 2026 tiered collector.' },
+    Revenue: { 'Swap Fees To Route': 'Swap fees received by Route treasury or its fee receiver, before subsequent buybacks and protocol-owned liquidity allocations.' },
+  },
+};
+export default adapter;

--- a/fees/route.ts
+++ b/fees/route.ts
@@ -1,6 +1,18 @@
 import { FetchOptions, SimpleAdapter } from '../adapters/types';
+import { Interface } from 'ethers';
 import { CHAIN } from '../helpers/chains';
 import { addToken, collector, engines, feePaid, settled } from '../helpers/aggregators/route';
+
+// Verified manager binds this escrow and ROUTE pool hook in escrow()/poolKey():
+// https://repo.sourcify.dev/4663/0xDa5790345FD25878e5186EBd98823814188AcfBE
+const creatorEscrow = '0xd3afeb2a57f70ef218aa82451c51b2fb0416ac9e';
+const creatorManager = '0xda5790345fd25878e5186ebd98823814188acfbe';
+const creatorHook = '0xe5e702641ea86f4ae6cc3cdaed2b886f976be044';
+// https://robinhoodchain.blockscout.com/tx/0x00a45c5d3843cd51e9e9b2bd825f915a285afb6b889e04c43266b2fc3c1642aa
+const creatorManagerDeploymentBlock = 59844471;
+const credited = 'event Credited(address indexed recipient,address indexed depositor,uint256 amount)';
+// Filter the shared escrow at the RPC/indexer as well as validating decoded args.
+const creatorTopics = new Interface([credited]).encodeFilterTopics('Credited', [creatorManager, creatorHook]) as string[];
 
 const fetch = async (options: FetchOptions) => {
   const dailyFees = options.createBalances();
@@ -18,7 +30,18 @@ const fetch = async (options: FetchOptions) => {
   // Revenue belongs to Route; buying protocol-owned LP is not a payment to outside LPs.
   // Do not add receiver conversions/escrow claims again. The mixed-source worker cannot
   // attribute realized holder distributions to swap fees alone; omit that metric, not zero.
-  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue.clone(), dailySupplySideRevenue: 0 };
+  // Creator income is external income, not an additional aggregator surcharge.
+  // Only the current manager's history is verified; omit earlier unknown income.
+  let dailyOtherIncome;
+  if (await options.getToBlock() >= creatorManagerDeploymentBlock) {
+    dailyOtherIncome = options.createBalances();
+    const credits = await options.getLogs({ target: creatorEscrow, eventAbi: credited, topics: creatorTopics });
+    for (const log of credits) {
+      if (log.recipient.toLowerCase() !== creatorManager || log.depositor.toLowerCase() !== creatorHook) continue;
+      dailyOtherIncome.addGasToken(log.amount.toString(), 'ROUTE Creator Income');
+    }
+  }
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue.clone(), dailySupplySideRevenue: 0, dailyOtherIncome };
 };
 
 const adapter: SimpleAdapter = {
@@ -32,11 +55,13 @@ const adapter: SimpleAdapter = {
     Revenue: 'All collected Route swap fees accrue to Route-controlled recipients; later conversions and allocations are not counted again.',
     ProtocolRevenue: 'Swap fees retained by Route at collection, before subsequent capital allocations; excludes unverified holder distributions.',
     SupplySideRevenue: 'No portion of this aggregator fee is paid to external liquidity providers or referrers; protocol-owned liquidity is a capital allocation.',
+    OtherIncome: 'Native ETH creator income credited by the ROUTE pool hook to the current Route manager, from its deployment at block 59844471; earlier recipient history is not covered. Excludes swap-fee receiver deposits, donations, migrations and subsequent claims.',
   },
   breakdownMethodology: {
     Fees: { 'Swap Fees': 'Actual emitted fee amounts, not an assumed fee rate multiplied by volume; includes historical fees and the September 11, 2026 tiered collector.' },
     Revenue: { 'Swap Fees To Route': 'Swap fees received by Route treasury or its fee receiver, before subsequent buybacks and protocol-owned liquidity allocations.' },
     ProtocolRevenue: { 'Swap Fees To Route': 'Route-retained swap fees at collection; subsequent conversions and escrow claims are not additional revenue.' },
+    OtherIncome: { 'ROUTE Creator Income': 'Actual escrow credits from the verified ROUTE creator hook to the current Route manager; counted at credit, not again on claim, conversion or allocation. Separate from aggregator fees and revenue.' },
   },
 };
 export default adapter;

--- a/fees/route.ts
+++ b/fees/route.ts
@@ -18,7 +18,7 @@ const fetch = async (options: FetchOptions) => {
   // Revenue belongs to Route; buying protocol-owned LP is not a payment to outside LPs.
   // Do not add receiver conversions/escrow claims again. The mixed-source worker cannot
   // attribute realized holder distributions to swap fees alone; omit that metric, not zero.
-  return { dailyFees, dailyRevenue, dailySupplySideRevenue: 0 };
+  return { dailyFees, dailyRevenue, dailyProtocolRevenue: dailyRevenue.clone(), dailySupplySideRevenue: 0 };
 };
 
 const adapter: SimpleAdapter = {
@@ -30,11 +30,13 @@ const adapter: SimpleAdapter = {
   methodology: {
     Fees: 'Actual Route output-token swap fees from historical FeePaid and current Settled events; excludes pool/provider fees, gas, creator fees and private transfers.',
     Revenue: 'All collected Route swap fees accrue to Route-controlled recipients; later conversions and allocations are not counted again.',
+    ProtocolRevenue: 'Swap fees retained by Route at collection, before subsequent capital allocations; excludes unverified holder distributions.',
     SupplySideRevenue: 'No portion of this aggregator fee is paid to external liquidity providers or referrers; protocol-owned liquidity is a capital allocation.',
   },
   breakdownMethodology: {
     Fees: { 'Swap Fees': 'Actual emitted fee amounts, not an assumed fee rate multiplied by volume; includes historical fees and the September 11, 2026 tiered collector.' },
     Revenue: { 'Swap Fees To Route': 'Swap fees received by Route treasury or its fee receiver, before subsequent buybacks and protocol-owned liquidity allocations.' },
+    ProtocolRevenue: { 'Swap Fees To Route': 'Route-retained swap fees at collection; subsequent conversions and escrow claims are not additional revenue.' },
   },
 };
 export default adapter;

--- a/helpers/aggregators/route.ts
+++ b/helpers/aggregators/route.ts
@@ -32,7 +32,14 @@ export function addToken(balance: ReturnType<FetchOptions['createBalances']>, to
 }
 
 // Count a single, preferentially priceable side. Never price long-tail tokens at $1.
-export function volumeSide(log: any): [string, string] {
+type SwapLog = {
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: { toString(): string };
+  amountOut: { toString(): string };
+};
+
+export function volumeSide(log: SwapLog): [string, string] {
   const preferred = [ADDRESSES.robinhood.USDG, ADDRESSES.null, ADDRESSES.robinhood.WETH].map(x => x.toLowerCase());
   for (const token of preferred) {
     if (log.tokenIn.toLowerCase() === token) return [log.tokenIn, log.amountIn.toString()];

--- a/helpers/aggregators/route.ts
+++ b/helpers/aggregators/route.ts
@@ -1,0 +1,42 @@
+import { FetchOptions } from '../../adapters/types';
+import ADDRESSES from '../coreAssets.json';
+
+// Historical settlement registry: https://github.com/routerh/route/blob/main/lib/route/activity.ts
+// Keep old emitters for backfills. They are not current approval recommendations.
+export const engines = [
+  '0xfb866d8cd2796efd920a7a062814aeb88b1d2bcb',
+  '0xb1a65445695b79d042caaa86b5aa1e3b5f38ac03',
+  '0xd8f7171886f8476ece2e51cffe8c4c637815a815',
+  '0x872d8bd2d903f83377c873d3234fb762a4fd4703',
+  '0xde02d8438a92084eddff012c0a4673a0832da21d',
+  '0x485e249b82587531165ef2fe97a768813964ebd3',
+  '0x201a935146e1283f35bb54b8fe7a4c584265b7e8',
+  '0x418d76ffa3026fe9e8b067cc39251cca8fcba3f5',
+  '0x22c1bba36ba220964d029eb4b1ef7c6ed167e32e',
+  '0x70656a2b4a401def17c55687c19c536c0fad4db1',
+  '0x9990a63ef329ab407956b4fe5a812aba0d81e20c',
+];
+// Exact source: https://repo.sourcify.dev/4663/0xBFADcf357545cb185420eAD0fDE1008A289c0154
+export const collector = '0xbfadcf357545cb185420ead0fde1008a289c0154';
+export const settled = 'event Settled(address indexed sender,address indexed recipient,address indexed tokenOut,uint256 grossAmountOut,uint256 feeBps,uint256 feeAmount,uint256 amountOut)';
+export const swapEvents = [
+  'event Swapped(address indexed sender,address indexed recipient,address indexed tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut)',
+  'event Swapped(address indexed sender,address indexed recipient,address indexed tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut,bytes32 routeHash)',
+  'event Swapped(address indexed sender,address indexed recipient,address indexed tokenIn,address tokenOut,uint256 amountIn,uint256 amountOut,address intermediate,address firstAdapter,uint24 firstFee,address secondAdapter,uint24 secondFee)',
+];
+export const feePaid = 'event FeePaid(address indexed sender,address indexed recipient,address indexed token,uint256 grossAmountOut,uint256 feeAmount)';
+
+export function addToken(balance: ReturnType<FetchOptions['createBalances']>, token: string, amount: string, label: string) {
+  if (token.toLowerCase() === ADDRESSES.null) balance.addGasToken(amount, label);
+  else balance.add(token, amount, label);
+}
+
+// Count a single, preferentially priceable side. Never price long-tail tokens at $1.
+export function volumeSide(log: any): [string, string] {
+  const preferred = [ADDRESSES.robinhood.USDG, ADDRESSES.null, ADDRESSES.robinhood.WETH].map(x => x.toLowerCase());
+  for (const token of preferred) {
+    if (log.tokenIn.toLowerCase() === token) return [log.tokenIn, log.amountIn.toString()];
+    if (log.tokenOut.toLowerCase() === token) return [log.tokenOut, log.amountOut.toString()];
+  }
+  return [log.tokenIn, log.amountIn.toString()];
+}

--- a/tests/route-fees.test.ts
+++ b/tests/route-fees.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import adapter from '../fees/route';
+import { FetchOptions } from '../adapters/types';
+import { feePaid, settled } from '../helpers/aggregators/route';
+
+class Balance {
+  values: Record<string, bigint> = {};
+  add(token: string, amount: string, label: string) {
+    const key = `${token.toLowerCase()}:${label}`;
+    this.values[key] = (this.values[key] ?? 0n) + BigInt(amount);
+  }
+  addGasToken(amount: string, label: string) { this.add('native', amount, label); }
+  clone() { const copy = new Balance(); copy.values = { ...this.values }; return copy; }
+}
+
+const manager = '0xda5790345fd25878e5186ebd98823814188acfbe';
+const hook = '0xe5e702641ea86f4ae6cc3cdaed2b886f976be044';
+const receiver = '0xcceb9655af6877d5c8c2919902c356bed71fa1fc';
+const other = '0x0000000000000000000000000000000000000001';
+const native = '0x0000000000000000000000000000000000000000';
+
+function options(toBlock = 60425312, credits: any[] = []) {
+  return {
+    createBalances: () => new Balance(),
+    getToBlock: async () => toBlock,
+    getLogs: async ({ eventAbi, target }: any) => {
+      if (eventAbi === feePaid) return [{ token: native, feeAmount: 19n }];
+      if (eventAbi === settled) return [{ tokenOut: other, feeAmount: 31n }];
+      assert.equal(target, '0xd3afeb2a57f70ef218aa82451c51b2fb0416ac9e');
+      assert.equal(eventAbi, 'event Credited(address indexed recipient,address indexed depositor,uint256 amount)');
+      return credits;
+    },
+  } as unknown as FetchOptions;
+}
+
+test('creator income requires both hook and recipient; swap fees remain separate', async () => {
+  const result: any = await adapter.fetch!(options(60425312, [
+    { recipient: manager.toUpperCase(), depositor: hook.toUpperCase(), amount: 1234567890123456789n },
+    { recipient: manager, depositor: hook, amount: 1n },
+    { recipient: manager, depositor: receiver, amount: 100n },
+    { recipient: manager, depositor: other, amount: 200n },
+    { recipient: other, depositor: hook, amount: 300n },
+  ]));
+  assert.deepEqual(result.dailyOtherIncome.values, { 'native:ROUTE Creator Income': 1234567890123456790n });
+  assert.deepEqual(result.dailyFees.values, { 'native:Swap Fees': 19n, [`${other}:Swap Fees`]: 31n });
+  assert.deepEqual(result.dailyRevenue.values, { 'native:Swap Fees To Route': 19n, [`${other}:Swap Fees To Route`]: 31n });
+  assert.deepEqual(result.dailyProtocolRevenue.values, result.dailyRevenue.values);
+  assert.notEqual(result.dailyProtocolRevenue, result.dailyRevenue);
+  assert.equal(result.dailyHoldersRevenue, undefined);
+});
+
+test('unmapped earlier history is omitted; known empty current window is zero', async () => {
+  assert.equal((await adapter.fetch!(options(59844470))).dailyOtherIncome, undefined);
+  const result: any = await adapter.fetch!(options(59844471));
+  assert.deepEqual(result.dailyOtherIncome.values, {});
+});
+
+test('creator RPC failure propagates instead of reporting zero', async () => {
+  const opts = options();
+  const original = opts.getLogs;
+  opts.getLogs = async params => {
+    if (params.eventAbi !== feePaid && params.eventAbi !== settled) throw new Error('creator RPC failed');
+    return original(params);
+  };
+  await assert.rejects(() => adapter.fetch!(opts), /creator RPC failed/);
+});

--- a/tests/runAdapter-start.test.ts
+++ b/tests/runAdapter-start.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import runAdapter from '../adapters/utils/runAdapter';
+import { SimpleAdapter } from '../adapters/types';
+
+const start = Date.parse('2026-09-05T00:00:00Z') / 1000;
+
+async function fetchedWindows(version: number, windowSize: number, ends: number[]) {
+  const windows: number[][] = [];
+  const module: SimpleAdapter = {
+    version, pullHourly: version === 2, chains: ['off_chain'], start: '2026-09-05',
+    fetch: async options => {
+      windows.push([options.startTimestamp, options.endTimestamp]);
+      return { dailyVolume: 1 };
+    },
+  };
+  for (const endTimestamp of ends)
+    await runAdapter({ module, endTimestamp, runWindowInSeconds: windowSize });
+  return windows;
+}
+
+test('all 24 hours of the first day run; pre-start hour does not', async () => {
+  const windows = await fetchedWindows(2, 3600, Array.from({ length: 25 }, (_, i) => start + i * 3600));
+  assert.equal(windows.length, 24);
+  assert.equal(windows[0][1], start + 3600);
+  assert.equal(windows[23][1], start + 24 * 3600);
+});
+
+test('daily v1 and v2 keep their original first-day boundary', async () => {
+  for (const version of [1, 2]) {
+    const windows = await fetchedWindows(version, 86400, [start, start + 86400]);
+    assert.equal(windows.length, 1);
+    assert.equal(windows[0][1], start + 86400);
+  }
+});


### PR DESCRIPTION
# Add Route aggregator volume and swap fees on Robinhood Chain

**Route swap fees are active as of September 11, 2026.** This adapter tracks actual daily collected swap fees and revenue, not zero-fee current settlement. `dailySupplySideRevenue: 0` means no share of Route's aggregator fee is paid to external suppliers; it does not mean users pay zero Route fees. Historical fee-free periods are retained accurately.

Supersedes closed PR #9398, resubmitted from the owner's requested GitHub account, micahalp. Please review this PR rather than the closed submission.

## Listing

- Name: Route
- Website: https://www.route.fun
- Twitter: https://x.com/routedotfun
- Documentation: https://docs.route.fun
- Category: DEX Aggregator
- Chain: Robinhood (4663; existing `robinhood` SDK chain)
- GitHub: https://github.com/routerh/route
- Treasury Safe: `0x3b9C7bC09FF64F554480f30Ad40286cFc09d2F80`
- Audit: no completed independent audit claimed. Sourcify source matching is not an audit.
- Logo: https://raw.githubusercontent.com/micahalp/dimension-adapters/refs/heads/codex/route-listing-assets/route-logo.png (owner-supplied square PNG, hosted on a separate branch; not added to the adapter diff).
- CoinGecko/CoinMarketCap token IDs: not confirmed; do not invent.
- Token address/ticker: `0x4a72b9702f991b790788f8afa9e7112541f4e8f8` / ROUTE on Robinhood Chain. Owner supplied; live ERC20 reads confirmed name `Route`, symbol `ROUTE`, decimals `18`.
- TVL: not requested; these are dimensions adapters, not a custody/TVL listing.
- Oracle metadata: adapter uses DefiLlama token pricing, not a project-supplied USD total. Product-wide oracle fields require separate release-scoped confirmation.

## Implementation

### Implemented additional coverage: ROUTE token creator income

The code now exports ROUTE token creator income as `dailyOtherIncome`, with a `ROUTE Creator Income` breakdown. This is a distinct, verified ETH flow, not additional aggregator swap fees. `dailyFees`, `dailyRevenue` and `dailyProtocolRevenue` remain swap-product metrics. Please review the proposed other-income classification and dashboard presentation; no frontend support or listing acceptance is assumed.

- Source: `Credited(address indexed recipient,address indexed depositor,uint256 amount)` on escrow `0xd3AFEB2a57f70eF218Aa82451c51B2fb0416Ac9e`.
- Required recipient filter: Route revenue manager `0xDa5790345FD25878e5186EBd98823814188AcfBE`.
- Required depositor filter: ROUTE pool creator hook `0xe5e702641ea86f4ae6cc3cdaed2b886f976be044`, verified from the manager's `poolKey`.
- Exclude deposits from swap-fee receiver `0xcCeb9655af6877D5c8c2919902c356beD71Fa1Fc`, other depositors, later escrow claims, treasury funding and token conversions. Counting these again would double-count receipts or include non-revenue.
- Read-only reconciliation for blocks 60,272,704 through 60,425,312 (ending September 11, 2026 at 17:14:50 UTC) found **0.742293729245752445 ETH** credited from that hook. This is a bounded sample, not a daily or lifetime total and not a hardcoded adapter value. Swap receiver credits reconciled separately with its `SwapRevenueCredited` events.
- Coverage is the current manager, deployed at block 59,844,471. Before that block, `dailyOtherIncome` is omitted rather than returning zero for unmapped earlier recipients. Historic manager/recipient migrations still need mapping before claiming complete creator-income history. Creator income does not inflate aggregator volume or swap-fee metrics.

Three files: `aggregators/route.ts`, `fees/route.ts`, and shared `helpers/aggregators/route.ts`. Custom settlement events do not match a DEX factory. Both adapters are version 2, hourly-compatible, start September 5, 2026, and use only targeted onchain logs.

Volume counts one side per successful outer Route swap. USDG is preferred, then ETH/WETH, otherwise the input asset; raw token units go to DefiLlama pricing. No hardcoded USD peg. Historical nested executor events are excluded. The September 11 collector emits `Settled`, not `Swapped`: its engine event is counted once. Underlying pool-hop events and collector `Settled` are not added as additional volume. This is contract-level routed volume, including actual treasury/bot integrations and early mainnet test swaps, not website-user-only volume.

Fees use the actual `feeAmount` from historical `FeePaid` and current `Settled`, denominated in the fee token. They accrue to Route-controlled recipients. Pool fees, gas, private-transfer fees, provider commissions and token-creator fees are outside this swap-product metric. No receiver conversion, escrow credit, claim, donation or treasury transfer is added a second time. There is no external LP/referrer share of the collected aggregator fee; protocol-owned liquidity purchases are capital allocations, not external supply-side payouts.

## Source evidence

- Historical registry: https://github.com/routerh/route/blob/main/lib/route/activity.ts
- Historical fee contract: https://github.com/routerh/route/blob/main/contracts/RouteFeeExecutor.sol
- Current collector exact source: https://repo.sourcify.dev/4663/0xBFADcf357545cb185420eAD0fDE1008A289c0154
- Current direct engine: https://repo.sourcify.dev/4663/0x9990A63ef329aB407956B4fE5A812ABA0d81e20C
- Collector deployment: https://robinhoodchain.blockscout.com/tx/0x4ac4a9253168997313d4d15078e3e6d7f691413056ddde27484afd2235460dae
- Historical fee example: https://robinhoodchain.blockscout.com/tx/0x22c286fd56c8e9c7a756b5a4244b5380ea946f50e73eb5c938a98003d723432f
- Current 10-bps fee example: https://robinhoodchain.blockscout.com/tx/0x956604ad09f2c3f2715b4f76eb1536d909307f2e040c57af04cb6584f86563ca

## Reviewer questions / exclusions

1. Zero fees are legitimate during the fee-free period and for individual zero-tier or rounding-to-zero swaps. Fees were 15 bps on early historical wrappers on September 5; the public product subsequently became fee-free. Tiered collection activated September 11. Historical contracts are preserved, so future direct calls to old wrappers would still be measured. Actual events, not date-based estimated rates, determine fees.
2. Current permitted tiers are 0/2/5/10/50 bps. The adapter does not classify token ages or assume everyone pays the same fee. A global fee-to-volume ratio can be lower because older fee-free engines remain callable. Fee/volume token-side pricing can also differ.
3. The website's all-time volume uses current indexed ETH/USDG spot valuation and an older registry; this adapter uses time-windowed raw amounts, DefiLlama pricing, and the new direct engine. Totals need not match. Missing long-tail token prices can reduce priced coverage; no fabricated price fills are used.
4. `dailyProtocolRevenue` reports Route-retained fees at collection using a clone of the revenue balance. **Holder attribution remains a reviewer question:** the worker mixes creator revenue with swap fees. Its 35% buyback, 30% protocol-owned LP, 35% vault policy does not prove source-specific realized distributions. `dailyHoldersRevenue` remains omitted, not zero or estimated at 35%. Later conversions/claims are not added again. No burn claim.
5. No existing adapter or factory entry for route.fun/routedotfun found in upstream `ff5ad6ce1a5e33263ae5f996ab3dcf28b11a5388`. This replaces closed PR #9398; it is not an additional listing. Maintainers should confirm any existing parent listing and add `dimensions: { aggregators: "route", fees: "route" }` in server-side metadata as appropriate.
6. No existing adapter is being modified, so no correction refill is requested. Initial history should include September 5 onward.

## Validation

Using upstream `ff5ad6ce1a5e33263ae5f996ab3dcf28b11a5388` and its frozen pnpm lockfile:

- `pnpm run ts-check`: passed.
- `pnpm run ts-check-cli`: passed.
- `pnpm test aggregators route 2026-09-10`: all 24 September 9 slots completed; approximately $501.10K volume.
- `pnpm test aggregators route 2026-09-07T13:00:00Z`: September 7, 12:00–13:00 UTC, approximately $2.50K volume.
- `pnpm test aggregators route 2026-09-11T14:20:00Z`: September 11, 13:20–14:20 UTC, approximately $401.97K volume across all engines, not only fee-collector swaps.
- `pnpm test fees route 2026-09-11T14:20:00Z`: 13:20–14:20 UTC, $0.113 fees and revenue, zero supply-side payout.
- `pnpm test fees route 2026-09-10T13:00:00Z`: zero fees during the fee-free period.
- Local independent fixtures: nested engine exclusion, collector engine inclusion, major-token side selection, native/ERC20 fee accounting, omitted unknown holder attribution, and RPC error propagation passed.
- Direct SDK invocation on blocks 1–55,500,000 recovered all 10 historical fee events: 1,853 USDG base units and 746,570,430,499 wei. Independent viem logs agreed on count and emitters.
- **First-day runner fixed:** the shared start gate now uses the requested window length rather than a hardcoded day, with adapter start dates unchanged. `pnpm test fees route 2026-09-06` now executes all 24 slots and reports $0.0037 in its fee/revenue breakdown (the two-decimal headline rounds to $0.00). `tests/runAdapter-start.test.ts` verifies all first-day hours run, the preceding hour is excluded, and daily v1/v2 boundaries remain unchanged.
- No dependency manifests, lockfiles, runtime configuration, production deployments or existing adapters changed.

CodeRabbit follow-up: added cloned protocol-revenue balances and matching methodology, typed swap inputs, and corrected the shared hourly start gate with regression tests. Both type checks pass. The fee window retest at 2026-09-11T14:20:00Z reports matching fees/revenue/protocol revenue ($0.0102 on the retest; historical dollar valuations differ from the earlier run). Raw emitted fee amounts are unchanged. This requests daily aggregator volume and swap-fee revenue tracking, not a claim that the listing has already been accepted.

Creator-income regression tests cover both source/recipient filters, case-insensitive addresses, exact wei arithmetic, swap-fee separation, omission before current-manager deployment, empty current windows, and RPC failure propagation. See `tests/route-fees.test.ts`.

Creator-code validation: both TypeScript checks and all three creator-income regression tests pass. The adapter run ending `2026-09-11T14:20:00Z` reports approximately $4.37K `dailyOtherIncome` separately from $0.0103 swap fees/revenue (one-hour test window, not a full day). The September 10 pre-deployment window preserves zero swap fees and omits unknown creator income. Direct RPC and SDK reconciliation both recovered 35 creator receipts totaling exactly 742293729245752445 wei in blocks 60272704–60425312; this separate bounded window is not the one-hour test. Indexed topic filters restrict the shared escrow query to the verified recipient and depositor, with decoded-argument checks retained.
