### PR TITLE
Add HASHCATS fees, active-users and new-users adapters

### DIFF
--- a/active-users/hashcats.ts
+++ b/active-users/hashcats.ts
@@ -61,7 +61,8 @@ const adapter: SimpleAdapter = {
   version: 1,
   fetch,
   chains: [CHAIN.ROBINHOOD],
-  // Deployment block of the collection, 60412000: the first cat is mined in it.
+  // The collection's code appears in block 60412470, and the first cat is mined
+  // a few minutes later in block 60415844.
   start: "2026-09-11",
   methodology:
     "Counts unique addresses that interacted with the HASHCATS collection directly - mining a cat (Mined), claiming accrued rent (RentClaimed) or burning a cat for $HASH (CatBurned) - and the transactions those actions occurred in. Rent is usually claimed for several cats at once, so transactions are fewer than events. Swaps of $HASH are excluded: they arrive through routers, so the address on a swap is the router rather than the trader.",

--- a/active-users/hashcats.ts
+++ b/active-users/hashcats.ts
@@ -1,0 +1,70 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// HASHCATS — a proof-of-work NFT collection on Robinhood Chain (chainId 4663).
+//
+// Everything a user can do to the protocol happens on the collection contract
+// and each action carries the address that performed it:
+//
+//   Mined       - a miner submitted a valid hash and paid for the cat.
+//   RentClaimed - a cat owner withdrew the rent their cats have accrued.
+//   CatBurned   - an owner destroyed a cat in exchange for $HASH.
+//
+// Trading $HASH is deliberately not counted. Swaps reach the pool through
+// routers, so the address on the swap is the router rather than the trader, and
+// interactions that go through a middleman contract do not count as direct
+// interactions with the protocol.
+const COLLECTION = "0xca75df55cc9c476db27a7375d1fc8e794cf80721";
+
+const activityEvents = [
+  {
+    userField: "miner",
+    eventAbi:
+      "event Mined(uint256 indexed tokenId, address indexed miner, uint256 seed, uint256 work, bytes32 anchor, uint256 target, uint256 nonce, uint256 unique)",
+  },
+  {
+    userField: "to",
+    eventAbi: "event RentClaimed(uint256 indexed tokenId, address indexed to, uint256 amount, uint256 cursor)",
+  },
+  {
+    userField: "by",
+    eventAbi: "event CatBurned(uint256 indexed tokenId, address indexed by, uint256 tokens, uint256 rent)",
+  },
+] as const;
+
+const fetch = async (options: FetchOptions) => {
+  const logsByEvent = await Promise.all(
+    activityEvents.map(({ eventAbi }) =>
+      options.getLogs({ targets: [COLLECTION], eventAbi, onlyArgs: false })
+    )
+  );
+
+  const users = new Set<string>();
+  const transactions = new Set<string>();
+
+  logsByEvent.forEach((logs, eventIndex) => {
+    const { userField } = activityEvents[eventIndex];
+    logs.forEach((log: any) => {
+      const user = log.args?.[userField];
+      if (typeof user === "string") users.add(user.toLowerCase());
+      if (typeof log.transactionHash === "string") transactions.add(log.transactionHash.toLowerCase());
+    });
+  });
+
+  return {
+    dailyActiveUsers: users.size,
+    dailyTransactionsCount: transactions.size,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  // Deployment block of the collection, 60412000: the first cat is mined in it.
+  start: "2026-09-11",
+  methodology:
+    "Counts unique addresses that interacted with the HASHCATS collection directly - mining a cat (Mined), claiming accrued rent (RentClaimed) or burning a cat for $HASH (CatBurned) - and the transactions those actions occurred in. Rent is usually claimed for several cats at once, so transactions are fewer than events. Swaps of $HASH are excluded: they arrive through routers, so the address on a swap is the router rather than the trader.",
+};
+
+export default adapter;

--- a/fees/hashcats/index.ts
+++ b/fees/hashcats/index.ts
@@ -1,0 +1,276 @@
+// HASHCATS — fees & revenue adapter.
+//
+// HASHCATS is a proof-of-work NFT collection on Robinhood Chain (chainId 4663).
+// A cat is minted only when a miner submits a hash below the collection's target,
+// and the entry price is derived rather than chosen: it is the number of cats
+// created so far times a fixed step, so it rises with every mint.
+//
+//   Collection: 0xca75df55cc9c476db27a7375d1fc8e794cf80721
+//   Hook:       0xca757986e932bc55776492cca0b413e9b3d02acc
+//   $HASH:      0xca75082b85bb7bec8325d513f615b16bda260020
+//
+// Money enters the protocol from three places. Two of them are always ether;
+// royalties arrive as ether or as WETH, depending on how the sale settled:
+//
+// 1. Mints. The price of a cat is split on the spot by the collection: a fixed
+//    share per past cat accrues as rent to the cats still alive, and the rest is
+//    forwarded to the hook. Burned cats have no claim, so their share of the rent
+//    is forwarded to the hook as well. The whole price is a fee paid by the
+//    miner: there is no third-party seller, no allowlist and no team allocation,
+//    and every wei of it stays inside the protocol.
+//
+// 2. The trading fee on the $HASH pool, taken by the hook in beforeSwap or
+//    afterSwap depending on which side of the pair the trader specified. The pool
+//    itself has a zero fee, so this is entirely the protocol's. The rate decays
+//    from a high opening value to its target over the first ten minutes of
+//    trading (a launch defense that arms once), which is why it is read from the
+//    FeeTaken events rather than computed from a rate.
+//
+// 3. Secondary-market royalties. The collection names the hook as the ERC-2981
+//    recipient, so marketplace royalties arrive at the hook directly - as ether
+//    through its receive(), or as WETH when the sale settled in WETH.
+//
+// Everything the hook receives is split by devBps: the developer's share accrues
+// for withdrawal, and the remainder joins the buyback queue, which is spent
+// buying $HASH back and burning it. The split is applied to revenue here rather
+// than read from the DevAccrued events, because royalties that arrive as WETH
+// pass through the split later, when they are unwrapped - so the events lag the
+// income by an unpredictable amount while the rate itself never does.
+//
+// Classification:
+//
+//   dailyFees               everything paid by users: mint prices, trading fees
+//                           and royalties.
+//   dailySupplySideRevenue  rent to living cats. Cat holders are suppliers, not
+//                           governance-token holders: the cat is the asset that
+//                           earns, and the payment is a cost of revenue.
+//   dailyRevenue            fees minus rent.
+//   dailyHoldersRevenue     the queue's share of revenue, spent buying $HASH back
+//                           and burning it. Measured at the fee source, which is
+//                           where the split happens, not at the moment a buyback
+//                           executes.
+//   dailyProtocolRevenue    the developer's share of revenue.
+//
+// Not counted: $HASH handed out when a cat is burned. The holder destroys an
+// asset that was earning rent and receives another asset in exchange, so it is a
+// conversion rather than an incentive, and no fee is paid by anyone.
+//
+// The hook's own buybacks pay no trading fee: Uniswap does not invoke hooks on
+// swaps the hook itself sends, so they cannot inflate this adapter.
+
+import { Adapter, FetchOptions } from "../../adapters/types";
+import { CHAIN } from "../../helpers/chains";
+import { METRIC } from "../../helpers/metrics";
+
+const COLLECTION = "0xca75df55cc9c476db27a7375d1fc8e794cf80721";
+const HOOK = "0xca757986e932bc55776492cca0b413e9b3d02acc";
+const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
+
+// Deployment block of the collection: the first cat is mined in it, and before
+// it neither contract can be called.
+const DEPLOY_BLOCK = 60412000;
+
+const BPS = 10000n;
+
+// Rent is paid to cat holders, who are suppliers here rather than holders of a
+// governance token - the METRIC list has no label for it, so it carries its own.
+const RENT = "Rent to Cat Holders";
+
+const MINED =
+  "event Mined(uint256 indexed tokenId, address indexed miner, uint256 seed, uint256 work, bytes32 anchor, uint256 target, uint256 nonce, uint256 unique)";
+const FUNDED = "event Funded(address indexed from, uint256 amount, uint256 queue)";
+const FEE_TAKEN = "event FeeTaken(bool buying, uint256 amount)";
+const TRANSFER = "event Transfer(address indexed from, address indexed to, uint256 value)";
+// keccak256("Transfer(address,address,uint256)"), with the hook padded to a topic:
+// royalties that settled in WETH are filtered to this recipient at the node.
+const TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+const HOOK_TOPIC = `0x000000000000000000000000${HOOK.slice(2)}`;
+
+// Cats created before epoch k begins: EPOCH0 * 2^k - EPOCH0. The price of a cat
+// is that count times PRICE_STEP, which is why the price doubles every epoch.
+const createdBefore = (k: bigint, epoch0: bigint) => epoch0 * (2n ** k - 1n);
+
+// Price of a given cat, the same derivation the collection performs on-chain.
+// The constants come from the contract rather than from this file, so a
+// redeployment with different economics cannot silently produce wrong numbers.
+const priceOf = (tokenId: bigint, epoch0: bigint, priceEpoch0: bigint, priceStep: bigint) => {
+  let k = 0n;
+  // The bound is a guard, not a limit: epochs double, so 255 of them cover any
+  // token id that fits in a uint256. Without it a zero epoch size - which the
+  // contract cannot produce, but a wrong read could - would spin forever.
+  while (k < 255n && createdBefore(k + 1n, epoch0) < tokenId) k++;
+  // Epoch zero is sold at a flat price and pays no rent: there are no past cats
+  // to pay, so the whole price goes to the hook.
+  if (k === 0n) return priceEpoch0;
+  return createdBefore(k, epoch0) * priceStep;
+};
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const dailyRevenue = options.createBalances();
+  const dailySupplySideRevenue = options.createBalances();
+  const dailyHoldersRevenue = options.createBalances();
+  const dailyProtocolRevenue = options.createBalances();
+
+  // The same object is returned either way: empty when the protocol did not
+  // exist yet, filled in once the window has something in it.
+  const result = {
+    dailyFees,
+    dailyUserFees: dailyFees,
+    dailyRevenue,
+    dailySupplySideRevenue,
+    dailyHoldersRevenue,
+    dailyProtocolRevenue,
+  };
+
+  // A window that ends before the collection exists has nothing in it, and the
+  // contracts cannot be called at that height either. This is a real zero, not
+  // missing data: the protocol was not deployed yet.
+  if ((await options.getToBlock()) < DEPLOY_BLOCK) return result;
+
+  // Read at the END of the window, not the start: the first day's window opens
+  // hours before the collection is deployed, and reading there would revert.
+  // The three price constants are immutable, so the height cannot change them;
+  // devBps and the owner are read at the same point for consistency.
+  const [epoch0, priceEpoch0, priceStep, devBps, hookOwner] = await Promise.all([
+    options.toApi.call({ abi: "uint256:EPOCH0", target: COLLECTION }),
+    options.toApi.call({ abi: "uint256:PRICE_EPOCH0", target: COLLECTION }),
+    options.toApi.call({ abi: "uint256:PRICE_STEP", target: COLLECTION }),
+    options.toApi.call({ abi: "uint16:devBps", target: HOOK }),
+    options.toApi.call({ abi: "address:owner", target: HOOK }),
+  ]);
+
+  // The collection forwards the hook's cut with a capped gas stipend. If that
+  // transfer ever fails the amount is held in hookDue and sent with a later
+  // mint, which would otherwise push a window's receipts out of step with its
+  // mints - and the rent, being the remainder, straight into nonsense. Taking
+  // the change in hookDue puts every mint's cut back in its own window.
+  const windowStart = await options.getFromBlock();
+  const [dueBefore, dueAfter] = await Promise.all([
+    windowStart >= DEPLOY_BLOCK
+      ? options.fromApi.call({ abi: "uint256:hookDue", target: COLLECTION })
+      : Promise.resolve(0),
+    options.toApi.call({ abi: "uint256:hookDue", target: COLLECTION }),
+  ]);
+
+  const [mined, funded, feeTaken, wethIn] = await Promise.all([
+    options.getLogs({ target: COLLECTION, eventAbi: MINED }),
+    options.getLogs({ target: HOOK, eventAbi: FUNDED }),
+    options.getLogs({ target: HOOK, eventAbi: FEE_TAKEN }),
+    options.getLogs({ target: WETH, eventAbi: TRANSFER, topics: [TRANSFER_TOPIC, null, HOOK_TOPIC] as any }),
+  ]);
+
+  // 1. What miners paid, derived per cat from the price curve.
+  const epochSize = BigInt(epoch0);
+  const flatPrice = BigInt(priceEpoch0);
+  const step = BigInt(priceStep);
+  let mintGross = 0n;
+  for (const log of mined) {
+    mintGross += priceOf(BigInt(log.tokenId), epochSize, flatPrice, step);
+  }
+
+  // 2. The hook's cut of those mints, taken straight from its own receipts.
+  //    The rent is the remainder, so it never has to be reconstructed from the
+  //    rent accumulator - which moves in fractions and would not reconcile.
+  const owner = String(hookOwner).toLowerCase();
+  let hookFromMints = 0n;
+  let royaltiesEth = 0n;
+  for (const log of funded) {
+    const from = String(log.from).toLowerCase();
+    const amount = BigInt(log.amount);
+    if (from === COLLECTION) {
+      hookFromMints += amount;
+    } else if (from === WETH.toLowerCase() || from === owner || from === HOOK) {
+      // Not income. WETH unwrapping is royalty money already counted when it
+      // arrived, and addLiquidity returns the owner's own unspent deposit to the
+      // queue through this very same event.
+      continue;
+    } else {
+      royaltiesEth += amount;
+    }
+  }
+  const hookAccrued = hookFromMints + BigInt(dueAfter) - BigInt(dueBefore);
+  const rent = mintGross - hookAccrued;
+
+  // 3. Trading fee, and royalties that settled in WETH.
+  let tradingFees = 0n;
+  for (const log of feeTaken) tradingFees += BigInt(log.amount);
+
+  let royaltiesWeth = 0n;
+  for (const log of wethIn) royaltiesWeth += BigInt(log.value);
+
+  dailyFees.addGasToken(mintGross, METRIC.MINT_REDEEM_FEES);
+  dailyFees.addGasToken(tradingFees, METRIC.SWAP_FEES);
+  dailyFees.addGasToken(royaltiesEth, METRIC.CREATOR_FEES);
+  dailyFees.add(WETH, royaltiesWeth, METRIC.CREATOR_FEES);
+
+  dailySupplySideRevenue.addGasToken(rent, RENT);
+
+  // Revenue is what is left once the suppliers are paid, split by the hook's
+  // rate. Each currency is split on its own so the two sides always reconcile.
+  const splitToDev = (amount: bigint) => (amount * BigInt(devBps)) / BPS;
+
+  const revenueEth = hookAccrued + tradingFees + royaltiesEth;
+  const devEth = splitToDev(revenueEth);
+  const devWeth = splitToDev(royaltiesWeth);
+
+  dailyRevenue.addGasToken(revenueEth - devEth, METRIC.TOKEN_BUY_BACK);
+  dailyRevenue.addGasToken(devEth, METRIC.PROTOCOL_FEES);
+  dailyRevenue.add(WETH, royaltiesWeth - devWeth, METRIC.TOKEN_BUY_BACK);
+  dailyRevenue.add(WETH, devWeth, METRIC.PROTOCOL_FEES);
+
+  dailyHoldersRevenue.addGasToken(revenueEth - devEth, METRIC.TOKEN_BUY_BACK);
+  dailyHoldersRevenue.add(WETH, royaltiesWeth - devWeth, METRIC.TOKEN_BUY_BACK);
+
+  dailyProtocolRevenue.addGasToken(devEth, METRIC.PROTOCOL_FEES);
+  dailyProtocolRevenue.add(WETH, devWeth, METRIC.PROTOCOL_FEES);
+
+  return result;
+};
+
+const methodology = {
+  Fees: "Everything users pay the protocol: the price of every cat minted, the trading fee the hook takes on the $HASH pool, and the secondary-market royalty the collection routes to the hook. The mint price is derived per cat from the contract's own curve - the number of cats created so far times PRICE_STEP - rather than read from a transaction value, so a mint sent with excess ether cannot inflate it.",
+  UserFees: "Same as Fees. Every one of the three flows is paid by a user: the miner pays the entry price, the trader pays the swap fee, and the secondary-market buyer pays the royalty.",
+  Revenue: "Fees minus the rent paid out to living cats.",
+  SupplySideRevenue: "Rent paid to the cats already alive. Every mint splits its price between the cats that came before it and the hook; cat holders are suppliers whose asset earns, not holders of a governance token, so their cut is a cost of revenue. Measured as the mint price minus the hook's cut, which is exact and needs no reconstruction from the rent accumulator. The hook's cut is what it was owed in the window rather than what it was sent: a transfer that fails its gas stipend is held in the collection's hookDue and forwarded later, so the change in that balance is added back.",
+  HoldersRevenue: "The share of revenue that joins the hook's buyback queue and is spent buying $HASH back on the pool and burning it. Measured at the fee source - the moment the hook receives and splits the money - rather than when a buyback executes, since the queue is drained gradually under a per-block cap.",
+  ProtocolRevenue: "The developer's share of revenue, at the hook's devBps rate, read from the chain rather than hardcoded.",
+};
+
+const breakdownMethodology = {
+  Fees: {
+    [METRIC.MINT_REDEEM_FEES]: "The price paid for every cat mined in the window, derived per cat from the contract's price curve.",
+    [METRIC.SWAP_FEES]: "The trading fee the hook takes on $HASH swaps. The pool's own fee is zero, so this is the whole of it. The rate decays from its opening value to its target over the first ten minutes of trading, so the amounts are read from FeeTaken rather than computed.",
+    [METRIC.CREATOR_FEES]: "Secondary-market royalties, which the collection routes to the hook as the ERC-2981 recipient - in ether, or in WETH when the sale settled in WETH.",
+  },
+  UserFees: {
+    [METRIC.MINT_REDEEM_FEES]: "The price paid for every cat mined in the window.",
+    [METRIC.SWAP_FEES]: "The trading fee paid by swappers on the $HASH pool.",
+    [METRIC.CREATOR_FEES]: "Royalties paid by secondary-market buyers.",
+  },
+  Revenue: {
+    [METRIC.TOKEN_BUY_BACK]: "The part of revenue that joins the buyback queue.",
+    [METRIC.PROTOCOL_FEES]: "The developer's share of revenue, at the hook's devBps rate.",
+  },
+  SupplySideRevenue: {
+    [RENT]: "Rent accrued to the cats alive at the time of each mint, paid out of that mint's price.",
+  },
+  HoldersRevenue: {
+    [METRIC.TOKEN_BUY_BACK]: "Ether queued for buying $HASH back on the pool and burning it.",
+  },
+  ProtocolRevenue: {
+    [METRIC.PROTOCOL_FEES]: "The developer's share of everything the hook receives.",
+  },
+};
+
+const adapter: Adapter = {
+  version: 2,
+  pullHourly: true,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-09-11",
+  methodology,
+  breakdownMethodology,
+};
+
+export default adapter;

--- a/fees/hashcats/index.ts
+++ b/fees/hashcats/index.ts
@@ -58,6 +58,7 @@
 // The hook's own buybacks pay no trading fee: Uniswap does not invoke hooks on
 // swaps the hook itself sends, so they cannot inflate this adapter.
 
+import { ChainApi } from "@defillama/sdk";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
@@ -66,9 +67,10 @@ const COLLECTION = "0xca75df55cc9c476db27a7375d1fc8e794cf80721";
 const HOOK = "0xca757986e932bc55776492cca0b413e9b3d02acc";
 const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
 
-// Deployment block of the collection: the first cat is mined in it, and before
-// it neither contract can be called.
-const DEPLOY_BLOCK = 60412000;
+// The block the collection's code first appears in. Before it neither contract
+// can be called at all, so the exact height matters: it is the lowest block a
+// state read may target.
+const DEPLOY_BLOCK = 60412470;
 
 const BPS = 10000n;
 
@@ -145,10 +147,19 @@ const fetch = async (options: FetchOptions) => {
   // mint, which would otherwise push a window's receipts out of step with its
   // mints - and the rent, being the remainder, straight into nonsense. Taking
   // the change in hookDue puts every mint's cut back in its own window.
+  //
+  // The two readings have to bracket exactly the blocks whose logs are counted.
+  // getLogs includes the window's first block, while fromApi reads the state
+  // after that block has already run, so the opening reading is taken one block
+  // earlier - otherwise a deferral in that first block would be missing from the
+  // difference while its mint was counted, and the rent would absorb the error.
   const windowStart = await options.getFromBlock();
   const [dueBefore, dueAfter] = await Promise.all([
-    windowStart >= DEPLOY_BLOCK
-      ? options.fromApi.call({ abi: "uint256:hookDue", target: COLLECTION })
+    windowStart > DEPLOY_BLOCK
+      ? new ChainApi({ chain: options.chain, block: windowStart - 1 }).call({
+          abi: "uint256:hookDue",
+          target: COLLECTION,
+        })
       : Promise.resolve(0),
     options.toApi.call({ abi: "uint256:hookDue", target: COLLECTION }),
   ]);

--- a/new-users/hashcats.ts
+++ b/new-users/hashcats.ts
@@ -1,0 +1,64 @@
+import { FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+
+// HASHCATS — first-time miners on Robinhood Chain (chainId 4663).
+//
+// Mining is the only way into this protocol: a cat cannot be bought from the
+// collection, only mined, and everything else a user can do - claiming rent,
+// burning a cat - requires owning one first. So an address mining its first cat
+// is an address arriving at the protocol for the first time.
+//
+// There is no "first time" flag on-chain, so the window's miners are compared
+// against every miner seen before it. One event type is scanned, which keeps the
+// history cheap to walk even as it grows.
+const COLLECTION = "0xca75df55cc9c476db27a7375d1fc8e794cf80721";
+
+// Deployment block of the collection: the first cat is mined in it, so there is
+// nothing to scan before it.
+const FROM_BLOCK = 60412000;
+
+const MINED =
+  "event Mined(uint256 indexed tokenId, address indexed miner, uint256 seed, uint256 work, bytes32 anchor, uint256 target, uint256 nonce, uint256 unique)";
+
+const fetch = async (options: FetchOptions) => {
+  const windowStart = await options.getFromBlock();
+
+  const [inWindow, before] = await Promise.all([
+    options.getLogs({ target: COLLECTION, eventAbi: MINED }),
+    // Everything from deployment up to the moment this window opens. When the
+    // window is the protocol's first, the range is empty and every miner in it
+    // is new. skipCache keeps this full-history read out of the window cache,
+    // which is keyed by contract and would otherwise be overwritten by it.
+    windowStart > FROM_BLOCK
+      ? options.getLogs({
+          target: COLLECTION,
+          eventAbi: MINED,
+          fromBlock: FROM_BLOCK,
+          toBlock: windowStart - 1,
+          skipCache: true,
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const seen = new Set<string>();
+  for (const log of before as any[]) seen.add(String(log.miner).toLowerCase());
+
+  const fresh = new Set<string>();
+  for (const log of inWindow as any[]) {
+    const miner = String(log.miner).toLowerCase();
+    if (!seen.has(miner)) fresh.add(miner);
+  }
+
+  return { dailyNewUsers: fresh.size };
+};
+
+const adapter: SimpleAdapter = {
+  version: 1,
+  fetch,
+  chains: [CHAIN.ROBINHOOD],
+  start: "2026-09-11",
+  methodology:
+    "Counts addresses that mined their first HASHCATS cat during the day. Mining is the only entry point into the protocol - cats cannot be bought from the collection, and claiming rent or burning a cat both require owning one - so a first-time miner is a first-time user. Each window's miners are compared against every miner recorded since the collection was deployed.",
+};
+
+export default adapter;

--- a/new-users/hashcats.ts
+++ b/new-users/hashcats.ts
@@ -13,9 +13,10 @@ import { CHAIN } from "../helpers/chains";
 // history cheap to walk even as it grows.
 const COLLECTION = "0xca75df55cc9c476db27a7375d1fc8e794cf80721";
 
-// Deployment block of the collection: the first cat is mined in it, so there is
-// nothing to scan before it.
-const FROM_BLOCK = 60412000;
+// The block the collection's code appears in. Nothing it emits can predate it,
+// so the history walk starts here. The first cat is mined a few minutes later,
+// in block 60415844.
+const FROM_BLOCK = 60412470;
 
 const MINED =
   "event Mined(uint256 indexed tokenId, address indexed miner, uint256 seed, uint256 work, bytes32 anchor, uint256 target, uint256 nonce, uint256 unique)";


### PR DESCRIPTION
Adds fees, active-users and new-users adapters for HASHCATS, a proof-of-work NFT collection on Robinhood Chain. The TVL adapter is submitted separately in DefiLlama/DefiLlama-Adapters.

**Where the money comes from**

1. **Mints.** A cat is minted only when a miner submits a hash below the collection's target. The price is derived from the contract's own curve — the number of cats created so far times `PRICE_STEP` — and is split on the spot between rent to the cats already alive and the hook. The whole price is a fee: there is no third-party seller, no allowlist and no team allocation, and every wei stays inside the protocol. The price is derived per cat rather than read from the transaction value, so a mint sent with excess ether cannot inflate it.

2. **Trading fee** on the $HASH pool, taken by the hook. The pool's own fee is zero, so this is entirely the protocol's. The rate decays from a high opening value to its target over the first ten minutes of trading — a launch defense that arms once — which is why amounts are read from `FeeTaken` rather than computed from a rate.

3. **Secondary-market royalties.** The collection names the hook as the ERC-2981 recipient, so royalties arrive there directly, as ether or as WETH depending on how the sale settled.

**Classification**

| Field | What it is |
|---|---|
| `dailyFees` | Mint prices + trading fees + royalties |
| `dailySupplySideRevenue` | Rent to living cats. Cat holders are suppliers whose asset earns, not governance-token holders, so their cut is a cost of revenue |
| `dailyRevenue` | Fees minus rent |
| `dailyHoldersRevenue` | The queue's share of revenue, spent buying $HASH back and burning it — measured at the fee source, where the split happens |
| `dailyProtocolRevenue` | The developer's share, at the hook's `devBps` rate read from the chain |

**Not counted:** $HASH handed out when a cat is burned. The holder destroys an asset that was earning rent and receives another in exchange — a conversion, not an incentive, and nobody pays a fee.

**Not submitted:** a volume adapter. The $HASH pool is a Uniswap V4 pool and `dexs/uniswap-v4.ts` already covers that PoolManager, so reporting the volume here would double it at the aggregate — the same reasoning `dexs/hookos.ts` gives for its own pool on this chain. The fee the hook skims is a different matter and is reported above, since no Uniswap adapter sees it.

**Two details worth flagging**

- The hook's own buybacks pay no trading fee: Uniswap does not invoke hooks on swaps the hook itself sends, so they cannot inflate the fee figures.
- The collection forwards the hook's cut with a capped gas stipend. If that transfer ever fails, the amount is held in `hookDue` and sent with a later mint. The adapter takes the change in `hookDue` across the window, so a deferral cannot push a window's receipts out of step with its mints — and the rent, which is the remainder, cannot go negative because of it. No deferral has occurred so far.

**Testing.** Run with `npm run test fees hashcats <date>`, `npm run test active-users hashcats <date>` and `npm run test new-users hashcats <date>`, and cross-checked against an independent read of the same logs. On the engine's own block boundaries the match is exact: active addresses 705 vs 705, transactions 2,352 vs 2,352, first-time miners 624 vs 624. Both identities hold — `fees − supplySide = revenue` and `holders + protocol = revenue`. A window that ends before the deployment block returns zero rather than reverting, which matters here because the first day's window opens hours before the collection existed.

**Server-side wiring:** `dimensions: { fees: "hashcats" }` in defillama-server, as a follow-up after merge.

---

##### Name (to be shown on DefiLlama):
HASHCATS

##### Twitter Link:
https://x.com/hashcats_rh

##### List of audit links if any:
None

##### Website Link:
https://hashcats.fun

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/hashcats-dot-fun/branding/HEAD/logo/hashcats-mark-1000.png

##### Current TVL:
~$260,000 (TVL adapter submitted separately)

##### Treasury Addresses (if the protocol has treasury)
None

##### Chain:
Robinhood Chain

##### Coingecko ID (so your TVL can appear on Coingecko, leave empty if not listed): (https://api.coingecko.com/api/v3/coins/list)

##### Coinmarketcap ID (so your TVL can appear on Coinmarketcap, leave empty if not listed): (https://api.coinmarketcap.com/data-api/v3/map/all?listing_status=active,inactive,untracked&start=1&limit=10000)

##### Short Description (to be shown on DefiLlama):
A fully on-chain proof-of-work NFT collection on Robinhood Chain. A cat exists only when someone's machine finds a hash below the target — no allowlist, no auction, no team allocation. Every mint pays rent to all the cats already alive, and 70% of what the protocol earns buys back and burns $HASH.

##### Token address and ticker if any:
$HASH — 0xca75082b85bb7bec8325d513f615b16bda260020 (Robinhood Chain)

##### Category (full list at https://defillama.com/categories) *Please choose only one:
Gamified Mining

##### Oracle Provider(s): Specify the oracle(s) used (e.g., Chainlink, Band, API3, TWAP, etc.):
None — the protocol uses no price oracle.

##### Implementation Details: Briefly describe how the oracle is integrated into your project:
Not applicable.

##### Documentation/Proof: Provide links to documentation or any other resources that verify the oracle's usage:
Not applicable. Protocol documentation: https://hashcats.fun/docs

##### forkedFrom (Does your project originate from another project):
No

##### methodology (what is being counted as tvl, how is tvl being calculated):
Covered by the `methodology` and `breakdownMethodology` objects in the adapter, and summarised in the table above.

##### Github org/user (Optional, if your code is open source, we can track activity):

##### Does this project have a referral program?
No