### PR TITLE
[fix] duck-chain - mark dead, both mainnet RPCs are down since 07-14

### DIFF
--- a/fees/duck-chain.ts
+++ b/fees/duck-chain.ts
@@ -83,6 +83,8 @@ const adapter: Adapter = {
   adapter: {
     [CHAIN.DUCKCHAIN]: {
       fetch,
+      // SDK marks DuckChain dead; both mainnet RPCs are down, with last nonzero fees on 2026-07-13.
+      deadFrom: '2026-07-14',
     },
   },
   protocolType: ProtocolType.CHAIN,


### PR DESCRIPTION
## What

`fees/duck-chain.ts` computes DuckChain's daily gas fees by calling `eth_getBlockReceipts` against DuckChain's own RPC for every block in the day's range. Both of DuckChain's registered mainnet RPC endpoints are currently down:

```
$ curl -X POST https://rpc.duckchain.io ...        -> HTTP 521 (Cloudflare: origin down)
$ curl -X POST https://rpc-hk.duckchain.io ...      -> HTTP 502
```

(these are the only two endpoints chainid.network's registry lists for chain id 5545; no other public RPC aggregator - publicnode, drpc, 1rpc - carries DuckChain at all)

`@defillama/sdk`'s own `chainUtils.getDeadChains()` already lists `'duckchain'` as dead:

```
$ node -e "console.log(require('@defillama/sdk').chainUtils.getDeadChains().includes('duckchain'))"
true
```

and DuckChain's chain TVL on `api.llama.fi/v2/chains` is `0`.

## Why the chart shows exact zeros instead of a gap

`fetchRpcTotalFees` fetches all blocks for the day via `PromisePool`; per-block RPC failures land in an `errors` array (never thrown), and the function unconditionally sums whatever landed in `results` - which is `0n` when every block fails. It logs the failure count but never refuses to publish. That's why `api.llama.fi/summary/fees/duck-chain`'s daily chart shows real, small nonzero fees (~$0.16-$0.58/day) through **2026-07-13**, then an *exact*, unbroken `0` every single day since (60+ days as of today) - not a gap, an explicit zero every run.

`fees/duck-chain.ts` hasn't been touched since 2026-05-06 (#6577), so the cliff on 07-14 is the chain going dark, not a code regression introduced around that date.

## Fix

Adds `deadFrom: '2026-07-14'` (the day after the last real nonzero day) to the DuckChain chain config, matching this repo's own convention for a confirmed-dead chain/leg (see the merged synapse dfk-leg fix). Reversible: if DuckChain's RPC comes back, drop the field and the adapter resumes on its own - the fetch logic itself is left untouched.

Not marking this via `factory/deadAdapters.json` migration since this repo also keeps inline `deadFrom` on live per-chain configs for exactly this shape (checked: no existing `duck-chain`/`duckchain` entry in `deadAdapters.json`, so this isn't redundant with anything already there).

## Note for reviewers

`fetchRpcTotalFees`'s silent-zero-on-total-failure shape (log-but-never-throw on an all-failed `PromisePool` batch) is a separate, more general bug in the same file - worth a follow-up if this repo wants defensive throw-on-high-failure-rate handling for chains that *aren't* confirmed dead. Keeping this PR to the single-purpose `deadFrom` marking rather than bundling that in.

## Verification

```
$ npx tsc --project tsconfig.json --noEmit
(clean, exit 0)

$ npx ts-node --transpile-only cli/testAdapter.ts fees duck-chain.ts
🦙 Running DUCK-CHAIN.TS adapter 🦙
---------------------------------------------------
🦙 DUCK-CHAIN.TS is dead (deadFrom 2026-07-14); skipping run.
```

Implemented via `codex exec -m gpt-6-astra`, reviewed by a second-opinion pass (Claude, Fable) against the full diff and live evidence before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
