### PR TITLE
feat(fees): add DexLab

### DIFF
--- a/fees/dexlab.ts
+++ b/fees/dexlab.ts
@@ -43,6 +43,7 @@ const fetch = async (options: FetchOptions) => {
   return {
     dailyFees,
     dailyRevenue: dailyFees,
+    dailyProtocolRevenue: dailyFees,
   };
 };
 
@@ -62,10 +63,17 @@ const adapter: SimpleAdapter = {
   },
   methodology: {
     Fees: 'Flat SOL fees paid by users to create a token, manage a token, create an OpenBook market and bulk send tokens on DexLab, received by the DexLab fee wallet on Solana.',
-    Revenue: 'All fees are kept by DexLab. There is no supplier side and no token holder share.',
+    Revenue: 'All fees (SOL paid by users to create a token, manage a token, create an OpenBook market and bulk send tokens on DexLab) are kept by DexLab. There is no supplier side and no token holder share.',
+    ProtocolRevenue: 'All fees (SOL paid by users to create a token, manage a token, create an OpenBook market and bulk send tokens on DexLab) are kept by DexLab. There is no supplier side and no token holder share.',
   },
   breakdownMethodology: {
     Fees: {
+      [METRIC.PROTOCOL_FEES]: 'All flat SOL fees received by the DexLab fee wallet on Solana, retained entirely by the protocol.',
+    },
+    Revenue: {
+      [METRIC.PROTOCOL_FEES]: 'All flat SOL fees received by the DexLab fee wallet on Solana, retained entirely by the protocol.',
+    },
+    ProtocolRevenue: {
       [METRIC.PROTOCOL_FEES]: 'All flat SOL fees received by the DexLab fee wallet on Solana, retained entirely by the protocol.',
     },
   },

--- a/fees/dexlab.ts
+++ b/fees/dexlab.ts
@@ -1,0 +1,74 @@
+import { Dependencies, FetchOptions, SimpleAdapter } from "../adapters/types";
+import { CHAIN } from "../helpers/chains";
+import { getSolanaReceived } from "../helpers/token";
+import { METRIC } from "../helpers/metrics";
+
+// Every DexLab platform fee settles in SOL to this one address. It is the fee
+// destination held by the Minting Lab token factory program's config account
+// (program EeHfbcv8g1qE4wdWF3gWNrzYia3jYJngR44Fuijd5CiJ, PDA seed
+// "mintinglab:config-account"), and the same address receives the token
+// management, OpenBook market creation and Multisender fees.
+const FEE_WALLET = 'AvpdLZGKjghJgdpctNgXT1L7bXKq2ifKiGYBGjeVugWC';
+
+// SOL that DexLab sends to its own fee wallet is not user revenue, and there is
+// no shape to it on chain that tells it apart from a user paying a fee. Both of
+// these are DexLab wallets, found by reading every inflow to the fee wallet and
+// looking at the ones larger than a single action can produce. The largest fee
+// one action can charge is the Multisender batch cap of 0.3 SOL, so anything
+// materially above that did not come from a user.
+//
+//   2TUHrApH...  the program deploy payer. Returned rent when a retired program
+//                was closed on 2026-06-15: 3.7171 and 2.9786 SOL.
+//   CH4uMXS8...  a treasury wallet. Sent 0.8733 SOL back on 2026-05-21, the same
+//                day the fee wallet was swept into it.
+//
+// Against a run rate near 4 SOL a week, leaving these in would publish two days
+// that look like large spikes and are not revenue at all. blacklists filters
+// from_address, which is what these are; blacklist_signers is the separate
+// option for signers.
+const INTERNAL_SENDERS = [
+  '2TUHrApHJ18EaSbzNWPdP9Kmbum5smLXuvy5MCwCAssx',
+  'CH4uMXS8EcTDARNSjz6pdHMz5tggSzGio6H1v53s7zzd',
+];
+
+const fetch = async (options: FetchOptions) => {
+  const dailyFees = options.createBalances();
+  const fees = await getSolanaReceived({
+    options,
+    target: FEE_WALLET,
+    blacklists: INTERNAL_SENDERS,
+  });
+  dailyFees.addBalances(fees, METRIC.PROTOCOL_FEES);
+
+  return {
+    dailyFees,
+    dailyRevenue: dailyFees,
+  };
+};
+
+const adapter: SimpleAdapter = {
+  version: 2,
+  pullHourly: true,
+  dependencies: [Dependencies.ALLIUM],
+  adapter: {
+    [CHAIN.SOLANA]: {
+      fetch,
+      // The wallet's oldest signature, 5oqJv62p6wt9VgWNsHfssB75EiuZJC4DNcRViQ
+      // CfBAv8iCNGDvHNmsPw1vBdK5bsaUkpF7eLkardk3AGHXqGeN9A, received exactly
+      // 0.15 SOL at 2024-11-12 01:03 UTC and is a token creation fee, so this
+      // start date is measured rather than estimated.
+      start: '2024-11-12',
+    },
+  },
+  methodology: {
+    Fees: 'Flat SOL fees paid by users to create a token, manage a token, create an OpenBook market and bulk send tokens on DexLab, received by the DexLab fee wallet on Solana.',
+    Revenue: 'All fees are kept by DexLab. There is no supplier side and no token holder share.',
+  },
+  breakdownMethodology: {
+    Fees: {
+      [METRIC.PROTOCOL_FEES]: 'All flat SOL fees received by the DexLab fee wallet on Solana, retained entirely by the protocol.',
+    },
+  },
+};
+
+export default adapter;


### PR DESCRIPTION
Website: https://www.dexlab.space
Twitter: https://x.com/Dexlab_official

DexLab is a Solana token creation and management app. It charges flat SOL fees per action, and every one of them settles to a single address, so this is a single-address daily inflow sum in the shape of `fees/fluxbeam.ts`. No TVL adapter is included; the pools hold about $148k and the fees are the meaningful measurement.

### Pre-answering the usual review questions

**Is a zero-fee day correct for this protocol?** Yes. Fees are charged per user action, not continuously, and a quiet day genuinely produces no fee. The run rate is roughly 4 SOL per week, so a single zero day is normal and a zero week would be unusual.

**Did the fee rate ever change, and when?** Token creation has been 0.15 SOL throughout. The Multisender changed on 2026-09-07, from a flat 0.05 SOL per recipient to the first 20 recipients free, then 0.001 SOL each, capped at 0.3 SOL per batch. It is a small share of the total: roughly 92 percent of fees are token creation. No refill is needed, since the adapter sums what actually arrived rather than reconstructing it from a rate.

**Why might the numbers differ from a chart we publish?** They should not. We publish no revenue dashboard of our own, which is part of why this adapter is being submitted.

**Is this related to an existing listing or an open PR?** No. DexLab is not on DefiLlama today, and a code search of this repository for "dexlab" returns nothing.

**Does the fee-to-volume ratio make sense?** There is no volume dimension here. These are flat per-action fees, not a share of traded value.

### The two blacklisted senders

`getSolanaReceived` sums everything arriving at the address, and some of what arrives is DexLab moving its own SOL. Nothing on chain distinguishes that from a user paying a fee, so I read every inflow to the fee wallet and kept the ones larger than any single action can charge. The largest possible single fee is the 0.3 SOL Multisender batch cap, so anything materially above it is not revenue:

| Date | Amount | Sender | What it was |
| --- | --- | --- | --- |
| 2026-06-15 | 3.7171 and 2.9786 SOL | `2TUHrApH...` | Program deploy payer returning rent when a retired program was closed |
| 2026-05-21 | 0.8733 SOL | `CH4uMXS8...` | Treasury wallet returning SOL on the day the fee wallet was swept into it |

Against a run rate near 4 SOL a week, leaving these in would publish two days that look like large spikes and are not revenue.

### Start date

Measured rather than estimated. The fee wallet's oldest signature, `5oqJv62p6wt9VgWNsHfssB75EiuZJC4DNcRViQCfBAv8iCNGDvHNmsPw1vBdK5bsaUkpF7eLkardk3AGHXqGeN9A`, received exactly 0.150000 SOL at 2024-11-12 01:03 UTC, which is one token creation fee.

### Known gap, declared

Swap fees are not included. The DexLab swap program pays the owner share of each pool's trade fee to a separate address in LP tokens, and that revenue is effectively zero. It is left out rather than misreported.

### Verification

`pnpm run ts-check` and `pnpm run ts-check-cli` both pass, and `git diff --check` is clean. `pnpm test fees dexlab` reaches the Allium query and stops at "Allium API Key is required", which is expected without a key. No `package.json` or lockfile changes.

---

##### Name (to be shown on DefiLlama):
DexLab

##### Twitter Link:
https://x.com/Dexlab_official

##### List of audit links if any:
none

##### Website Link:
https://www.dexlab.space

##### Logo (High resolution, will be shown with rounded borders):
https://raw.githubusercontent.com/dexlab-protocol/assets/master/dexlab/dexlab_symbol_512.png

##### Current TVL:
About $148,000 across DexLab AMM pools

##### Treasury Addresses (if the protocol has treasury)
AvpdLZGKjghJgdpctNgXT1L7bXKq2ifKiGYBGjeVugWC

##### Chain:
Solana

##### Coingecko ID:
dexlab-3

##### Coinmarketcap ID:
dexlab

##### Short Description (to be shown on DefiLlama):
Solana token creation and management. Mint SPL and Token-2022 tokens, manage authorities, snapshot holders, airdrop and open pools. Live since 2021.

##### Token address and ticker if any:
XLnpFRQ3rSWupCRjuQfx74mgVoT3ezVJKE1CogRZxhH (XLAB)

##### Category:
Launchpad

##### Oracle Provider(s):
none

##### Implementation Details:
No oracle. Flat SOL fees settle to one treasury address on Solana; daily inflows to that address, minus transfers from DexLab's own wallets, are the fees.

##### Documentation/Proof:
https://docs.dexlab.space/products/minting-lab/factory-fee

##### forkedFrom:
none

##### methodology:
Fees are the flat SOL amounts users pay to create a token, manage a token, create an OpenBook market and bulk send tokens, received by the DexLab fee wallet on Solana. All of it is kept by DexLab, so revenue equals fees. There is no supplier side and no token holder share.

##### Github org/user:
https://github.com/dexlab-protocol

##### Does this project have a referral program?
Yes. A referrer receives 20 percent of the creation fee paid through their link, settled on chain to a referral PDA rather than to the fee wallet, so referred amounts never appear in this adapter.