### PR TITLE
Fix HASHCATS fees adapter: deployment guard and hookDue block

### DIFF
--- a/fees/hashcats/index.ts
+++ b/fees/hashcats/index.ts
@@ -70,7 +70,7 @@ const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
 // The block the collection's code first appears in, found by bisecting
 // eth_getCode. Below it every call to either contract reverts, so the exact
 // height matters: it is the lowest block a state read may target.
-const DEPLOY_BLOCK = 60412470;
+const DEPLOY_TIMESTAMP = 1789145587;
 
 const BPS = 10000n;
 
@@ -130,7 +130,7 @@ const fetch = async (options: FetchOptions) => {
   // missing data: the protocol was not deployed yet. The adapter starts on the
   // day of deployment, so on that first day most hourly windows end below this
   // block and every read below would revert.
-  if ((await options.getToBlock()) < DEPLOY_BLOCK) return result;
+  if (options.toTimestamp < DEPLOY_TIMESTAMP) return result;
 
   // Read at the END of the window, not the start: the first day's window opens
   // hours before the collection is deployed, and reading there would revert.
@@ -161,7 +161,7 @@ const fetch = async (options: FetchOptions) => {
   // which makes the difference zero no matter what happened.
   const windowStart = await options.getFromBlock();
   const [dueBefore, dueAfter] = await Promise.all([
-    windowStart > DEPLOY_BLOCK
+    options.fromTimestamp > DEPLOY_TIMESTAMP
       ? new ChainApi({ chain: options.chain, block: windowStart - 1 }).call({
           abi: "uint256:hookDue",
           target: COLLECTION,

--- a/fees/hashcats/index.ts
+++ b/fees/hashcats/index.ts
@@ -58,6 +58,7 @@
 // The hook's own buybacks pay no trading fee: Uniswap does not invoke hooks on
 // swaps the hook itself sends, so they cannot inflate this adapter.
 
+import { ChainApi } from "@defillama/sdk";
 import { Adapter, FetchOptions } from "../../adapters/types";
 import { CHAIN } from "../../helpers/chains";
 import { METRIC } from "../../helpers/metrics";
@@ -65,6 +66,11 @@ import { METRIC } from "../../helpers/metrics";
 const COLLECTION = "0xca75df55cc9c476db27a7375d1fc8e794cf80721";
 const HOOK = "0xca757986e932bc55776492cca0b413e9b3d02acc";
 const WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73";
+
+// The block the collection's code first appears in, found by bisecting
+// eth_getCode. Below it every call to either contract reverts, so the exact
+// height matters: it is the lowest block a state read may target.
+const DEPLOY_BLOCK = 60412470;
 
 const BPS = 10000n;
 
@@ -119,6 +125,13 @@ const fetch = async (options: FetchOptions) => {
     dailyProtocolRevenue,
   };
 
+  // A window that ends before the collection exists has nothing in it, and the
+  // contracts cannot be called at that height either. This is a real zero, not
+  // missing data: the protocol was not deployed yet. The adapter starts on the
+  // day of deployment, so on that first day most hourly windows end below this
+  // block and every read below would revert.
+  if ((await options.getToBlock()) < DEPLOY_BLOCK) return result;
+
   // Read at the END of the window, not the start: the first day's window opens
   // hours before the collection is deployed, and reading there would revert.
   // The three price constants are immutable, so the height cannot change them;
@@ -137,18 +150,23 @@ const fetch = async (options: FetchOptions) => {
   // mints - and the rent, being the remainder, straight into nonsense. Taking
   // the change in hookDue puts every mint's cut back in its own window.
   //
-  // The two readings have to bracket exactly the blocks whose logs a re counted.
+  // The two readings have to bracket exactly the blocks whose logs are counted.
   // getLogs includes the window's first block, while fromApi reads the state
   // after that block has already run, so the opening reading is taken one block
   // earlier - otherwise a deferral in that first block would be missing from the
   // difference while its mint was counted, and the rent would absorb the error.
+  //
+  // It needs its own ChainApi: a per-call block is ignored, so asking options.api
+  // for an earlier height silently returns the value at the end of the window,
+  // which makes the difference zero no matter what happened.
   const windowStart = await options.getFromBlock();
   const [dueBefore, dueAfter] = await Promise.all([
-    options.api.call({
-      abi: "uint256:hookDue",
-      target: COLLECTION,
-      block: windowStart - 1,
-    }),
+    windowStart > DEPLOY_BLOCK
+      ? new ChainApi({ chain: options.chain, block: windowStart - 1 }).call({
+          abi: "uint256:hookDue",
+          target: COLLECTION,
+        })
+      : Promise.resolve(0),
     options.toApi.call({ abi: "uint256:hookDue", target: COLLECTION }),
   ]);
 


### PR DESCRIPTION
Follow-up to #9418. Thanks for taking the adapters in — two edits to `fees/hashcats` changed behaviour, and both are easy to miss.

**1. The deployment guard is gone, and the first day throws.**

The collection's code first appears in block `60412470` (16:53:07 UTC on 11 Sep); the adapter starts at 00:00 that day. `pullHourly` therefore runs about seventeen windows whose *end* block is below the deployment, and the first read — `EPOCH0` through `toApi` — reverts on every one of them. Measured directly: `EPOCH0` at 60412469 fails, at 60412470 returns 8.

Driving the adapter over the 09:00–10:00 UTC window of 11 Sep:

```
master:     Failed to call: uint256:PRICE_EPOCH0 target: 0xca75df55... on chain: [robinhood]
with fix:   ok, blocks 60134166..60169514, dailyFees = {}
```

An empty result is the truth for that hour, and the comment above the reads still describes the protection, so this looks like it was dropped by accident rather than on purpose.

**2. `options.api.call({ block })` does not read at that block.**

`ChainApi.call` ignores a per-call `block` and uses the height the ChainApi itself carries. `options.api` is the window's *end*, so `dueBefore` was being read at the same height as `dueAfter`: the difference is zero regardless of what happened, and the deferral handling it exists for is dead. Checked on a value that differs between two heights:

```
queue() at block 60500000        =   629536459000000121
queue() at block 61000000        = 22793039821082763523
api(block=61000000).call({ block: 60500000 }) = 22793039821082763523
```

Restored to a `ChainApi` pinned to `windowStart - 1`, the way `fees/3f.ts` does it.

Nothing is wrong numerically today — `hookDue` has been zero since deployment, so the two paths agree on every window that currently exists. The point is the first day, and the fact that a deferral would silently vanish.

Also fixed a typo I left in a comment ("logs a re counted").

Unchanged: `active-users`, and the Allium rewrite of `new-users` — I checked that one over and it is right (topic0 matches `keccak(Mined(uint256,address,uint256,uint256,bytes32,uint256,uint256,uint256))`, `SUBSTR(topic2, 27)` lands on the address, and the first-seen window is half-open on both sides).

**Testing.** `npm run test fees hashcats <date>` over the last 24 h: fees 778.35k, revenue 417.49k, supply side 360.86k, holders 292.25k, protocol 125.25k — both identities hold. The completed day of 11 Sep: 16.36k / 8.28k / 8.09k, likewise. Types clean.