### PR TITLE
basestonk: start on the launch day (2026-08-16), the biggest day was being dropped

### DIFF
--- a/fees/basestonk.ts
+++ b/fees/basestonk.ts
@@ -42,10 +42,9 @@ type ChainConfig = {
 
 const chainConfig: Record<string, ChainConfig> = {
   [CHAIN.BASE]: {
-    // first launch (BSTONK itself), block 50069724, 2026-08-17 01:06 UTC
-    // first launch (BSTONK itself) at 2026-08-16 22:50 UTC, block 50065628;
-    // the launch day carried $5.3M of volume and $52.6k of fees, and a start
-    // of 08-17 dropped every hour of it
+    // first launch (BSTONK itself) at 2026-08-16 22:50 UTC, block 50065628.
+    // The launch day carried $5.3M of volume and $52.6k of fees; a start of
+    // 08-17 dropped every hour of it.
     start: "2026-08-16",
     // https://basescan.org/address/0x498581fF718922c3f8e6A244956aF099B2652b2b
     poolManager: "0x498581ff718922c3f8e6a244956af099b2652b2b",

--- a/fees/basestonk.ts
+++ b/fees/basestonk.ts
@@ -43,7 +43,10 @@ type ChainConfig = {
 const chainConfig: Record<string, ChainConfig> = {
   [CHAIN.BASE]: {
     // first launch (BSTONK itself), block 50069724, 2026-08-17 01:06 UTC
-    start: "2026-08-17",
+    // first launch (BSTONK itself) at 2026-08-16 22:50 UTC, block 50065628;
+    // the launch day carried $5.3M of volume and $52.6k of fees, and a start
+    // of 08-17 dropped every hour of it
+    start: "2026-08-16",
     // https://basescan.org/address/0x498581fF718922c3f8e6A244956aF099B2652b2b
     poolManager: "0x498581ff718922c3f8e6a244956af099b2652b2b",
     knownPairs: [


### PR DESCRIPTION
Follow-up to #9295: the adapter's `start` was one day late.

BaseStonk's first launch was at 2026-08-16 22:50 UTC, and the launch day, 2026-08-17, is the biggest day in its history: $5.66M of volume and $57.5k of fees (verified: `pnpm test fees basestonk 2026-08-18`, which runs the 08-17 UTC window, gives exactly that). With `start: "2026-08-17"` the backfill began on the 18th and dropped every hour of it, which is why the page currently reads $27.9M cumulative volume / $431.9k fees against the protocol's own $32.8M / $470.5k. Every other day matches to within a few percent.

One-line change, `start` to `2026-08-16`. Would appreciate a backfill of both the fees and dexs dimensions for 2026-08-17 once merged.

Website: https://basestonk.io - Twitter: https://x.com/BaseStonk
